### PR TITLE
feat(terminal): improve terminal page UX with search, health, and erg…

### DIFF
--- a/radbot/web/api/terminal.py
+++ b/radbot/web/api/terminal.py
@@ -110,7 +110,7 @@ async def terminal_page(request: Request):
 
 @router.get("/workspaces/")
 async def list_workspaces():
-    """List active Claude Code workspaces."""
+    """List active Claude Code workspaces with worker health data."""
     try:
         from radbot.tools.claude_code.db import list_active_workspaces
 
@@ -121,10 +121,88 @@ async def list_workspaces():
                     ws[k] = v.isoformat()
                 elif hasattr(v, "hex"):
                     ws[k] = str(v)
+            # Default health fields
+            ws["worker_status"] = None
+            ws["worker_uptime_seconds"] = None
+            ws["worker_idle_seconds"] = None
+            ws["worker_sessions"] = None
+
+        # Enrich with worker health data if in remote mode
+        if _is_remote_mode():
+            await _enrich_workspaces_with_health(workspaces)
+
         return {"workspaces": workspaces}
     except Exception as e:
         logger.error("Error listing workspaces: %s", e, exc_info=True)
         raise HTTPException(500, f"Error listing workspaces: {e}")
+
+
+async def _enrich_workspaces_with_health(workspaces: list) -> None:
+    """Add worker health info to each workspace dict (best-effort)."""
+    try:
+        from radbot.worker.db import get_workspace_worker
+    except ImportError:
+        return
+
+    async with httpx.AsyncClient(timeout=2) as client:
+        for ws in workspaces:
+            ws_id = str(ws.get("workspace_id", ""))
+            try:
+                worker = get_workspace_worker(ws_id)
+                if not worker:
+                    continue
+                db_status = worker.get("status", "stopped")
+                worker_url = worker.get("worker_url")
+
+                if db_status == "starting":
+                    ws["worker_status"] = "starting"
+                    continue
+
+                if not worker_url or db_status == "stopped":
+                    continue
+
+                # Hit the worker health endpoint
+                resp = await client.get(f"{worker_url}/health")
+                if resp.status_code == 200:
+                    health = resp.json()
+                    ws["worker_status"] = "running"
+                    ws["worker_uptime_seconds"] = health.get("uptime_seconds")
+                    ws["worker_idle_seconds"] = health.get("idle_seconds")
+                    ws["worker_sessions"] = health.get("terminal_sessions")
+                else:
+                    ws["worker_status"] = "unhealthy"
+            except Exception:
+                if ws.get("worker_status") is None:
+                    ws["worker_status"] = "unhealthy"
+
+
+@router.get("/workspaces/{workspace_id}/health")
+async def workspace_health(workspace_id: str):
+    """Get detailed worker health for a single workspace."""
+    try:
+        from radbot.worker.db import get_workspace_worker
+
+        worker = get_workspace_worker(workspace_id)
+        if not worker or not worker.get("worker_url"):
+            return {"worker_status": None}
+
+        if worker.get("status") == "starting":
+            return {"worker_status": "starting"}
+
+        async with httpx.AsyncClient(timeout=2) as client:
+            resp = await client.get(f"{worker['worker_url']}/health")
+            if resp.status_code == 200:
+                health = resp.json()
+                return {
+                    "worker_status": "running",
+                    "worker_uptime_seconds": health.get("uptime_seconds"),
+                    "worker_idle_seconds": health.get("idle_seconds"),
+                    "worker_sessions": health.get("terminal_sessions"),
+                }
+            return {"worker_status": "unhealthy"}
+    except Exception as e:
+        logger.debug("Workspace health check failed: %s", e)
+        return {"worker_status": "unhealthy", "error": str(e)}
 
 
 @router.post("/sessions/")

--- a/radbot/web/frontend/package-lock.json
+++ b/radbot/web/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
@@ -1393,6 +1394,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-unicode11": {

--- a/radbot/web/frontend/package.json
+++ b/radbot/web/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/radbot/web/frontend/src/components/terminal/TerminalEmulator.tsx
+++ b/radbot/web/frontend/src/components/terminal/TerminalEmulator.tsx
@@ -5,32 +5,57 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 import { useTerminalWS } from "@/hooks/use-terminal-ws";
+import type { ConnectionState } from "@/hooks/use-terminal-ws";
 
 interface TerminalEmulatorProps {
   terminalId: string;
   onClosed?: (exitCode: number) => void;
   onSendInputRef?: (fn: (data: string) => void) => void;
+  onConnectionStateChange?: (state: ConnectionState) => void;
 }
 
-export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef }: TerminalEmulatorProps) {
+export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef, onConnectionStateChange }: TerminalEmulatorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const searchAddonRef = useRef<SearchAddon | null>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const [terminal, setTerminal] = useState<Terminal | null>(null);
+  const [searchVisible, setSearchVisible] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [fontSize, setFontSize] = useState(14);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const { sendInput, sendResize } = useTerminalWS({
+  const { sendInput, sendResize, connectionState } = useTerminalWS({
     terminalId,
     terminal,
     onClosed,
   });
 
+  // Notify parent of connection state changes
+  useEffect(() => {
+    onConnectionStateChange?.(connectionState);
+  }, [connectionState, onConnectionStateChange]);
+
   // Expose sendInput to parent
   useEffect(() => {
     onSendInputRef?.(sendInput);
   }, [sendInput, onSendInputRef]);
+
+  // Handle font size changes
+  useEffect(() => {
+    if (terminalRef.current && fitAddonRef.current) {
+      terminalRef.current.options.fontSize = fontSize;
+      try {
+        fitAddonRef.current.fit();
+      } catch {
+        // Ignore fit errors
+      }
+    }
+  }, [fontSize]);
 
   // Create terminal instance
   useEffect(() => {
@@ -41,7 +66,7 @@ export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef 
       cursorBlink: true,
       cursorStyle: "block",
       cursorInactiveStyle: "outline",
-      fontSize: 14,
+      fontSize,
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, monospace",
       theme: {
         background: "#1a1a2e",
@@ -74,9 +99,12 @@ export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef 
 
     const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
+    const searchAddon = new SearchAddon();
 
     term.loadAddon(fitAddon);
     term.loadAddon(webLinksAddon);
+    term.loadAddon(searchAddon);
+    searchAddonRef.current = searchAddon;
 
     // Wait for fonts to load before opening to prevent column miscalculation
     const init = async () => {
@@ -85,7 +113,7 @@ export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef 
 
       term.open(containerRef.current!);
 
-      // GPU-accelerated renderer with fallback chain: WebGL → Canvas → DOM
+      // GPU-accelerated renderer with fallback chain: WebGL -> Canvas -> DOM
       try {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => {
@@ -123,8 +151,64 @@ export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef 
       term.dispose();
       terminalRef.current = null;
       fitAddonRef.current = null;
+      searchAddonRef.current = null;
       setTerminal(null);
     };
+  }, []);
+
+  // Keyboard shortcuts (page-level, not terminal-level)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ctrl+Shift+F: toggle search
+      if (e.ctrlKey && e.shiftKey && e.key === "F") {
+        e.preventDefault();
+        setSearchVisible((v) => {
+          if (!v) {
+            setTimeout(() => searchInputRef.current?.focus(), 50);
+          }
+          return !v;
+        });
+        return;
+      }
+      // Ctrl+= / Ctrl+Shift+=: increase font size
+      if (e.ctrlKey && (e.key === "=" || e.key === "+")) {
+        e.preventDefault();
+        setFontSize((s) => Math.min(s + 1, 24));
+        return;
+      }
+      // Ctrl+-: decrease font size
+      if (e.ctrlKey && e.key === "-") {
+        e.preventDefault();
+        setFontSize((s) => Math.max(s - 1, 10));
+        return;
+      }
+      // Ctrl+0: reset font size
+      if (e.ctrlKey && e.key === "0") {
+        e.preventDefault();
+        setFontSize(14);
+        return;
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Search functionality
+  const handleSearch = useCallback((query: string, direction: "next" | "prev" = "next") => {
+    if (!searchAddonRef.current) return;
+    if (!query) return;
+    if (direction === "next") {
+      searchAddonRef.current.findNext(query, { regex: false, caseSensitive: false });
+    } else {
+      searchAddonRef.current.findPrevious(query, { regex: false, caseSensitive: false });
+    }
+  }, []);
+
+  const closeSearch = useCallback(() => {
+    setSearchVisible(false);
+    setSearchQuery("");
+    searchAddonRef.current?.clearDecorations();
+    terminalRef.current?.focus();
   }, []);
 
   // Debounced ResizeObserver for fit + sendResize (150ms debounce)
@@ -162,11 +246,76 @@ export default function TerminalEmulator({ terminalId, onClosed, onSendInputRef 
   }, []);
 
   return (
-    <div
-      ref={containerRef}
-      className="w-full h-full"
-      onClick={handleClick}
-      style={{ padding: "4px" }}
-    />
+    <div className="relative w-full h-full">
+      {/* Connection state banner */}
+      {(connectionState === "disconnected" || connectionState === "reconnecting") && (
+        <div className="absolute top-0 left-0 right-0 z-20 bg-bg-tertiary/90 border-b border-terminal-amber text-terminal-amber text-xs font-mono text-center py-1.5 transition-opacity">
+          {connectionState === "reconnecting" ? "Reconnecting..." : "Disconnected"}
+        </div>
+      )}
+      {connectionState === "connecting" && (
+        <div className="absolute top-0 left-0 right-0 z-20 bg-bg-tertiary/90 border-b border-accent-blue text-accent-blue text-xs font-mono text-center py-1.5 transition-opacity">
+          Connecting...
+        </div>
+      )}
+
+      {/* Search bar */}
+      {searchVisible && (
+        <div className="absolute top-1 right-1 z-20 flex items-center gap-1 bg-bg-tertiary border border-border rounded px-2 py-1 shadow-lg">
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              if (e.target.value) handleSearch(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                if (e.shiftKey) {
+                  handleSearch(searchQuery, "prev");
+                } else {
+                  handleSearch(searchQuery, "next");
+                }
+              }
+              if (e.key === "Escape") {
+                closeSearch();
+              }
+            }}
+            placeholder="Search..."
+            className="bg-bg-secondary text-txt-primary border-none outline-none font-mono text-xs w-48 px-1 py-0.5"
+            autoFocus
+          />
+          <button
+            onClick={() => handleSearch(searchQuery, "prev")}
+            className="text-txt-secondary hover:text-txt-primary text-xs font-mono px-1"
+            title="Previous (Shift+Enter)"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" /></svg>
+          </button>
+          <button
+            onClick={() => handleSearch(searchQuery, "next")}
+            className="text-txt-secondary hover:text-txt-primary text-xs font-mono px-1"
+            title="Next (Enter)"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <button
+            onClick={closeSearch}
+            className="text-txt-secondary hover:text-txt-primary text-xs font-mono px-1"
+            title="Close (Escape)"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+      )}
+
+      <div
+        ref={containerRef}
+        className="w-full h-full"
+        onClick={handleClick}
+        style={{ padding: "4px" }}
+      />
+    </div>
   );
 }

--- a/radbot/web/frontend/src/components/terminal/WorkspaceSelector.tsx
+++ b/radbot/web/frontend/src/components/terminal/WorkspaceSelector.tsx
@@ -1,8 +1,66 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { cn } from "@/lib/utils";
 import CloneForm from "./CloneForm";
 import type { Workspace } from "@/types/terminal";
+
+// Inline SVG icons
+function GitBranchIcon({ className = "w-3.5 h-3.5" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 3v12M18 9a3 3 0 100-6 3 3 0 000 6zM6 21a3 3 0 100-6 3 3 0 000 6zM18 9a9 9 0 01-9 9" />
+    </svg>
+  );
+}
+
+function TerminalIcon({ className = "w-3.5 h-3.5" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+function SearchIcon({ className = "w-3.5 h-3.5" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+    </svg>
+  );
+}
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const date = new Date(dateStr).getTime();
+  const diff = now - date;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function WorkerStatusBadge({ status }: { status: Workspace["worker_status"] }) {
+  if (!status || status === "stopped") return null;
+  const config = {
+    running: { color: "bg-terminal-green", text: "Running", textColor: "text-terminal-green" },
+    starting: { color: "bg-terminal-amber", text: "Starting", textColor: "text-terminal-amber" },
+    unhealthy: { color: "bg-terminal-red", text: "Unhealthy", textColor: "text-terminal-red" },
+  } as const;
+  const c = config[status as keyof typeof config];
+  if (!c) return null;
+  return (
+    <span className={cn("flex items-center gap-1 text-xs font-mono", c.textColor)}>
+      <span className={cn("w-1.5 h-1.5 rounded-full", c.color)} />
+      {c.text}
+    </span>
+  );
+}
 
 function WorkspaceItem({ ws }: { ws: Workspace }) {
   const sessions = useTerminalStore((s) => s.sessions);
@@ -21,7 +79,7 @@ function WorkspaceItem({ ws }: { ws: Workspace }) {
     return (
       <div className="border border-terminal-red/50 bg-terminal-red/10 p-3">
         <div className="text-terminal-red font-mono text-sm mb-2">
-          Delete workspace "{displayName}"?
+          Delete workspace &ldquo;{displayName}&rdquo;?
         </div>
         <div className="flex gap-2">
           <button
@@ -45,13 +103,20 @@ function WorkspaceItem({ ws }: { ws: Workspace }) {
   }
 
   return (
-    <div className="group border border-border bg-bg-secondary p-3 flex items-center justify-between gap-3">
+    <div className={cn(
+      "group border bg-bg-secondary p-3 flex items-center justify-between gap-3 transition-colors hover:bg-bg-tertiary",
+      isScratch ? "border-l-[3px] border-l-terminal-green border-t-border border-r-border border-b-border" : "border-l-[3px] border-l-accent-blue border-t-border border-r-border border-b-border",
+    )}>
       <div className="min-w-0 flex-1">
         <div className="font-mono text-sm text-txt-primary truncate flex items-center gap-2">
           {isScratch ? (
-            <span className="text-terminal-green">{displayName}</span>
+            <>
+              <TerminalIcon className="w-3.5 h-3.5 text-terminal-green flex-shrink-0" />
+              <span className="text-terminal-green">{displayName}</span>
+            </>
           ) : (
             <>
+              <GitBranchIcon className="w-3.5 h-3.5 text-accent-blue flex-shrink-0" />
               <span className="text-terminal-amber">{ws.owner}</span>
               <span className="text-txt-secondary">/</span>
               <span className="text-accent-blue">{ws.repo}</span>
@@ -62,21 +127,30 @@ function WorkspaceItem({ ws }: { ws: Workspace }) {
           )}
         </div>
         {ws.description && (
-          <div className="text-xs text-txt-secondary font-mono mt-0.5 truncate italic">
+          <div className="text-xs text-txt-secondary font-mono mt-0.5 truncate italic ml-5.5">
             {ws.description}
           </div>
         )}
-        <div className="flex items-center gap-3 mt-1 text-xs text-txt-secondary font-mono">
-          {!isScratch && <span>branch: {ws.branch}</span>}
+        <div className="flex items-center gap-3 mt-1 text-xs text-txt-secondary font-mono ml-5.5">
+          {!isScratch && (
+            <span className="flex items-center gap-1">
+              <GitBranchIcon className="w-3 h-3" />
+              {ws.branch}
+            </span>
+          )}
+          {ws.last_used_at && (
+            <span>{relativeTime(ws.last_used_at)}</span>
+          )}
           {ws.last_session_id && (
             <span className="truncate">
               session: {ws.last_session_id.slice(0, 8)}...
             </span>
           )}
+          <WorkerStatusBadge status={ws.worker_status} />
         </div>
       </div>
 
-      <div className="flex gap-2 flex-shrink-0">
+      <div className="flex gap-2 flex-shrink-0 items-center">
         {activeSession ? (
           <button
             onClick={() =>
@@ -110,10 +184,10 @@ function WorkspaceItem({ ws }: { ws: Workspace }) {
         )}
         <button
           onClick={() => setConfirming(true)}
-          className="px-2 py-1.5 border border-border text-txt-secondary text-xs font-mono hover:text-terminal-red hover:border-terminal-red transition-all cursor-pointer opacity-0 group-hover:opacity-100"
+          className="px-2 py-1.5 border border-border text-txt-secondary text-xs font-mono hover:text-terminal-red hover:border-terminal-red transition-all cursor-pointer opacity-30 group-hover:opacity-100"
           aria-label="Delete workspace"
         >
-          ×
+          &times;
         </button>
       </div>
     </div>
@@ -129,15 +203,32 @@ export default function WorkspaceSelector() {
   const setShowCloneForm = useTerminalStore((s) => s.setShowCloneForm);
   const error = useTerminalStore((s) => s.error);
   const clearError = useTerminalStore((s) => s.clearError);
+  const startHealthPolling = useTerminalStore((s) => s.startHealthPolling);
+  const stopHealthPolling = useTerminalStore((s) => s.stopHealthPolling);
 
   const [showScratchForm, setShowScratchForm] = useState(false);
   const [scratchName, setScratchName] = useState("");
   const [scratchDesc, setScratchDesc] = useState("");
+  const [searchFilter, setSearchFilter] = useState("");
 
   useEffect(() => {
     loadWorkspaces();
     loadSessions();
-  }, [loadWorkspaces, loadSessions]);
+    startHealthPolling();
+    return () => stopHealthPolling();
+  }, [loadWorkspaces, loadSessions, startHealthPolling, stopHealthPolling]);
+
+  const filteredWorkspaces = useMemo(() => {
+    if (!searchFilter) return workspaces;
+    const q = searchFilter.toLowerCase();
+    return workspaces.filter((ws) => {
+      const name = (ws.name || "").toLowerCase();
+      const owner = (ws.owner || "").toLowerCase();
+      const repo = (ws.repo || "").toLowerCase();
+      const desc = (ws.description || "").toLowerCase();
+      return name.includes(q) || owner.includes(q) || repo.includes(q) || desc.includes(q);
+    });
+  }, [workspaces, searchFilter]);
 
   const handleCreateScratch = async () => {
     await createScratchWorkspace(
@@ -168,7 +259,7 @@ export default function WorkspaceSelector() {
                 : "bg-bg-tertiary text-accent-blue border-accent-blue hover:bg-accent-blue hover:text-bg-primary",
             )}
           >
-            {showScratchForm ? "Cancel" : "+ New Session"}
+            {showScratchForm ? "Cancel" : "+ Scratch Workspace"}
           </button>
           <button
             onClick={() => {
@@ -202,13 +293,13 @@ export default function WorkspaceSelector() {
       {showScratchForm && (
         <div className="border border-accent-blue bg-bg-tertiary p-3">
           <div className="text-xs font-mono text-accent-blue uppercase tracking-wider mb-2">
-            New Scratch Session
+            New Scratch Workspace
           </div>
           <input
             type="text"
             value={scratchName}
             onChange={(e) => setScratchName(e.target.value)}
-            placeholder="Session name (optional)..."
+            placeholder="Workspace name (optional)..."
             autoFocus
             className="w-full bg-bg-secondary text-txt-primary border border-border px-2 py-1 font-mono text-sm outline-none focus:border-accent-blue mb-2"
             onKeyDown={(e) => {
@@ -234,16 +325,49 @@ export default function WorkspaceSelector() {
 
       {showCloneForm && <CloneForm />}
 
+      {/* Search filter — shown when >4 workspaces */}
+      {workspaces.length > 4 && (
+        <div className="relative">
+          <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-txt-secondary" />
+          <input
+            type="text"
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
+            placeholder="Filter workspaces..."
+            className="w-full bg-bg-secondary text-txt-primary border border-border pl-7 pr-2 py-1.5 font-mono text-xs outline-none focus:border-accent-blue"
+          />
+        </div>
+      )}
+
       {workspaces.length === 0 ? (
-        <div className="text-center py-12 text-txt-secondary font-mono">
-          <p className="text-sm">No workspaces found.</p>
-          <p className="text-xs mt-2">
-            Clone a repository or create a scratch session to get started.
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <TerminalIcon className="w-10 h-10 text-txt-secondary mb-4 opacity-40" />
+          <p className="text-sm font-mono text-txt-primary mb-1">No workspaces yet</p>
+          <p className="text-xs font-mono text-txt-secondary mb-6 max-w-xs">
+            Create a scratch workspace to start coding, or clone a repository from GitHub.
           </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setShowScratchForm(true)}
+              className="px-4 py-2 border border-accent-blue text-accent-blue text-xs font-mono uppercase tracking-wider hover:bg-accent-blue hover:text-bg-primary transition-all cursor-pointer"
+            >
+              + Scratch Workspace
+            </button>
+            <button
+              onClick={() => setShowCloneForm(true)}
+              className="px-4 py-2 border border-terminal-green text-terminal-green text-xs font-mono uppercase tracking-wider hover:bg-terminal-green hover:text-bg-primary transition-all cursor-pointer"
+            >
+              + Clone Repo
+            </button>
+          </div>
+        </div>
+      ) : filteredWorkspaces.length === 0 ? (
+        <div className="text-center py-8 text-txt-secondary font-mono text-xs">
+          No workspaces match &ldquo;{searchFilter}&rdquo;
         </div>
       ) : (
         <div className="flex flex-col gap-2">
-          {workspaces.map((ws) => (
+          {filteredWorkspaces.map((ws) => (
             <WorkspaceItem key={String(ws.workspace_id)} ws={ws} />
           ))}
         </div>

--- a/radbot/web/frontend/src/hooks/use-stt.ts
+++ b/radbot/web/frontend/src/hooks/use-stt.ts
@@ -5,6 +5,7 @@ type STTState = "idle" | "recording" | "processing";
 
 export function useSTT(onTranscript: (text: string) => void) {
   const [state, setState] = useState<STTState>("idle");
+  const [recordingStartTime, setRecordingStartTime] = useState<number | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
 
@@ -30,6 +31,7 @@ export function useSTT(onTranscript: (text: string) => void) {
       recorder.onstop = async () => {
         // Stop all tracks
         stream.getTracks().forEach((t) => t.stop());
+        setRecordingStartTime(null);
 
         if (chunksRef.current.length === 0) {
           setState("idle");
@@ -54,6 +56,7 @@ export function useSTT(onTranscript: (text: string) => void) {
       mediaRecorderRef.current = recorder;
       recorder.start();
       setState("recording");
+      setRecordingStartTime(Date.now());
     } catch (err) {
       console.error("[STT] Failed to access microphone:", err);
       setState("idle");
@@ -78,5 +81,5 @@ export function useSTT(onTranscript: (text: string) => void) {
     // Don't toggle during processing
   }, [state, start, stop]);
 
-  return { state, start, stop, toggle };
+  return { state, start, stop, toggle, recordingStartTime };
 }

--- a/radbot/web/frontend/src/hooks/use-terminal-ws.ts
+++ b/radbot/web/frontend/src/hooks/use-terminal-ws.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import type { Terminal } from "@xterm/xterm";
 
 /**
@@ -6,21 +6,25 @@ import type { Terminal } from "@xterm/xterm";
  *
  * Each frame is prefixed with a 1-byte type tag:
  *
- * Client → Server:
+ * Client -> Server:
  *   0x01 + raw UTF-8 bytes   (input)
  *   0x02 + uint16BE cols + uint16BE rows  (resize)
  *
- * Server → Client:
+ * Server -> Client:
  *   0x01 + raw PTY bytes     (output)
  *   0x03 + int32BE exit code  (closed)
+ *   0x04                      (end of scrollback replay)
  */
 
 const MSG_DATA = 0x01;
 const MSG_RESIZE = 0x02;
 const MSG_CLOSED = 0x03;
+const MSG_REPLAY_END = 0x04;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+export type ConnectionState = "connecting" | "connected" | "disconnected" | "reconnecting";
 
 interface UseTerminalWSOptions {
   terminalId: string | null;
@@ -37,6 +41,7 @@ export function useTerminalWS({
 }: UseTerminalWSOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const terminalIdRef = useRef(terminalId);
+  const [connectionState, setConnectionState] = useState<ConnectionState>("disconnected");
 
   terminalIdRef.current = terminalId;
 
@@ -70,12 +75,15 @@ export function useTerminalWS({
     const host = window.location.host;
     const url = `${protocol}//${host}/ws/terminal/${terminalId}`;
 
+    setConnectionState("connecting");
+
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
 
     ws.onopen = () => {
       console.log("[Terminal WS] Connected to", terminalId);
+      setConnectionState("connected");
       // Send initial size
       sendResize(terminal.cols, terminal.rows);
       onReady?.();
@@ -96,6 +104,9 @@ export function useTerminalWS({
           const view = new DataView(evt.data);
           const exitCode = buf.length >= 5 ? view.getInt32(1, false) : -1;
           onClosed?.(exitCode);
+        } else if (type === MSG_REPLAY_END) {
+          // Write a visual divider marking end of scrollback replay
+          terminal.write("\x1b[2m\x1b[36m──── reconnected ────\x1b[0m\r\n");
         }
       } else {
         // Fallback: handle text frames (legacy/transition)
@@ -114,10 +125,12 @@ export function useTerminalWS({
 
     ws.onclose = () => {
       console.log("[Terminal WS] Disconnected");
+      setConnectionState("disconnected");
     };
 
     ws.onerror = (err) => {
       console.error("[Terminal WS] Error:", err);
+      setConnectionState("disconnected");
     };
 
     // Wire terminal input to WebSocket
@@ -141,8 +154,9 @@ export function useTerminalWS({
         ws.close();
       }
       wsRef.current = null;
+      setConnectionState("disconnected");
     };
   }, [terminalId, terminal, onClosed, onReady, sendResize]);
 
-  return { sendInput, sendResize };
+  return { sendInput, sendResize, connectionState };
 }

--- a/radbot/web/frontend/src/pages/TerminalPage.tsx
+++ b/radbot/web/frontend/src/pages/TerminalPage.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { useSTT } from "@/hooks/use-stt";
 import TerminalEmulator from "@/components/terminal/TerminalEmulator";
 import WorkspaceSelector from "@/components/terminal/WorkspaceSelector";
+import type { ConnectionState } from "@/hooks/use-terminal-ws";
 
 function StatusIndicator({ ok }: { ok: boolean }) {
   return (
@@ -18,6 +19,38 @@ function StatusIndicator({ ok }: { ok: boolean }) {
   );
 }
 
+function RecordingTimer({ startTime }: { startTime: number }) {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startTime) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startTime]);
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+  return (
+    <span className="text-terminal-red font-mono text-[0.65rem] tabular-nums">
+      {mins}:{secs.toString().padStart(2, "0")}
+    </span>
+  );
+}
+
+function SessionUptime({ createdAt }: { createdAt: number }) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 30000);
+    return () => clearInterval(interval);
+  }, []);
+  const diff = Math.floor((Date.now() - createdAt) / 1000);
+  if (diff < 60) return <span>{diff}s</span>;
+  const mins = Math.floor(diff / 60);
+  if (mins < 60) return <span>{mins}m</span>;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  return <span>{hours}h {remMins}m</span>;
+}
+
 export default function TerminalPage() {
   const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
   const setActiveTerminalId = useTerminalStore((s) => s.setActiveTerminalId);
@@ -28,7 +61,12 @@ export default function TerminalPage() {
   const status = useTerminalStore((s) => s.status);
   const loadStatus = useTerminalStore((s) => s.loadStatus);
   const killTerminal = useTerminalStore((s) => s.killTerminal);
+  const createScratchWorkspace = useTerminalStore((s) => s.createScratchWorkspace);
   const [terminalClosed, setTerminalClosed] = useState(false);
+  const [showKillConfirm, setShowKillConfirm] = useState(false);
+  const [connectionState, setConnectionState] = useState<ConnectionState>("disconnected");
+  const [sessionCreatedAt] = useState<number>(Date.now());
+  const killConfirmTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   // STT: ref to sendInput from TerminalEmulator
   const sendInputRef = useRef<((data: string) => void) | null>(null);
@@ -41,7 +79,7 @@ export default function TerminalPage() {
     sendInputRef.current?.(text);
   }, []);
 
-  const { state: sttState, toggle: sttToggle } = useSTT(handleTranscript);
+  const { state: sttState, toggle: sttToggle, recordingStartTime } = useSTT(handleTranscript);
 
   useEffect(() => {
     loadStatus();
@@ -56,18 +94,105 @@ export default function TerminalPage() {
   const handleBack = useCallback(() => {
     setActiveTerminalId(null);
     setTerminalClosed(false);
+    setShowKillConfirm(false);
   }, [setActiveTerminalId]);
 
-  const handleKill = useCallback(async () => {
+  const handleKillRequest = useCallback(() => {
+    setShowKillConfirm(true);
+    // Auto-dismiss after 5 seconds
+    clearTimeout(killConfirmTimerRef.current);
+    killConfirmTimerRef.current = setTimeout(() => {
+      setShowKillConfirm(false);
+    }, 5000);
+  }, []);
+
+  const handleKillConfirm = useCallback(async () => {
+    clearTimeout(killConfirmTimerRef.current);
+    setShowKillConfirm(false);
     if (activeTerminalId) {
       await killTerminal(activeTerminalId);
       setTerminalClosed(false);
     }
   }, [activeTerminalId, killTerminal]);
 
+  const handleKillCancel = useCallback(() => {
+    clearTimeout(killConfirmTimerRef.current);
+    setShowKillConfirm(false);
+  }, []);
+
+  const handleConnectionStateChange = useCallback((state: ConnectionState) => {
+    setConnectionState(state);
+  }, []);
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => clearTimeout(killConfirmTimerRef.current);
+  }, []);
+
   const activeSession = sessions.find(
     (s) => s.terminal_id === activeTerminalId,
   );
+
+  // Keyboard shortcuts (page-level)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't intercept if terminal has focus (let TerminalEmulator handle its own shortcuts)
+      const target = e.target as HTMLElement;
+      const isTerminalFocused = target.closest(".xterm");
+
+      // Ctrl+Shift+T: new scratch workspace + open terminal
+      if (e.ctrlKey && e.shiftKey && e.key === "T" && !isTerminalFocused) {
+        e.preventDefault();
+        createScratchWorkspace().then(() => {
+          const ws = useTerminalStore.getState().workspaces[0];
+          if (ws) openTerminal(String(ws.workspace_id));
+        });
+        return;
+      }
+      // Ctrl+Shift+W: kill active terminal (with confirmation)
+      if (e.ctrlKey && e.shiftKey && e.key === "W") {
+        e.preventDefault();
+        if (activeTerminalId && !showKillConfirm) {
+          handleKillRequest();
+        }
+        return;
+      }
+      // Ctrl+Shift+[ / ]: switch workspace tabs
+      if (e.ctrlKey && e.shiftKey && (e.key === "[" || e.key === "{")) {
+        e.preventDefault();
+        switchWorkspaceTab(-1);
+        return;
+      }
+      if (e.ctrlKey && e.shiftKey && (e.key === "]" || e.key === "}")) {
+        e.preventDefault();
+        switchWorkspaceTab(1);
+        return;
+      }
+    };
+
+    const switchWorkspaceTab = (direction: number) => {
+      const sorted = [...workspaces].sort(
+        (a, b) => new Date(b.last_used_at).getTime() - new Date(a.last_used_at).getTime()
+      );
+      if (sorted.length === 0) return;
+      const currentIdx = activeSession
+        ? sorted.findIndex((ws) => String(ws.workspace_id) === activeSession.workspace_id)
+        : -1;
+      const nextIdx = (currentIdx + direction + sorted.length) % sorted.length;
+      const nextWs = sorted[nextIdx];
+      const running = sessions.find(
+        (s) => s.workspace_id === String(nextWs.workspace_id) && !s.closed,
+      );
+      if (running) {
+        setActiveTerminalId(running.terminal_id);
+      } else {
+        openTerminal(String(nextWs.workspace_id), nextWs.last_session_id ?? undefined);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [activeTerminalId, activeSession, workspaces, sessions, showKillConfirm, handleKillRequest, createScratchWorkspace, openTerminal, setActiveTerminalId]);
 
   return (
     <div className="flex flex-col h-full bg-bg-primary">
@@ -86,9 +211,15 @@ export default function TerminalPage() {
             Terminal
           </h1>
           {status && <StatusIndicator ok={status.status === "ok"} />}
+          {/* Connection state indicator */}
+          {activeTerminalId && connectionState !== "connected" && connectionState !== "disconnected" && (
+            <span className="text-[0.65rem] font-mono text-terminal-amber">
+              {connectionState === "connecting" ? "connecting..." : "reconnecting..."}
+            </span>
+          )}
         </div>
 
-        {/* Center: workspace tabs — horizontally scrollable */}
+        {/* Center: workspace tabs -- horizontally scrollable */}
         {workspaces.length > 0 && (
           <div
             className="flex-1 min-w-0 overflow-x-auto flex items-center gap-1 scrollbar-hide"
@@ -139,6 +270,13 @@ export default function TerminalPage() {
                   </button>
                 );
               })}
+
+            {/* Session uptime */}
+            {activeTerminalId && (
+              <span className="text-[0.65rem] font-mono text-txt-secondary flex-shrink-0 ml-1">
+                <SessionUptime createdAt={sessionCreatedAt} />
+              </span>
+            )}
           </div>
         )}
 
@@ -146,20 +284,26 @@ export default function TerminalPage() {
         <div className="flex gap-1.5 flex-shrink-0">
           {activeTerminalId && (
             <>
+              {/* MIC button */}
               <button
                 onClick={sttToggle}
                 disabled={sttState === "processing"}
                 className={cn(
                   "px-2 py-1.5 sm:py-0.5 border text-[0.72rem] sm:text-[0.75rem] font-mono uppercase tracking-wider transition-all cursor-pointer",
-                  "flex items-center min-h-[40px] sm:min-h-0",
+                  "flex items-center gap-1 min-h-[40px] sm:min-h-0",
                   sttState === "recording"
-                    ? "bg-bg-tertiary text-terminal-red border-terminal-red animate-pulse"
+                    ? "bg-bg-tertiary text-terminal-red border-terminal-red"
                     : sttState === "processing"
                       ? "bg-bg-tertiary text-terminal-amber border-terminal-amber opacity-70 cursor-not-allowed"
                       : "bg-bg-tertiary text-txt-primary border-border hover:bg-accent-blue hover:text-bg-primary",
                 )}
               >
-                {sttState === "recording" ? "Rec" : sttState === "processing" ? "..." : "Mic"}
+                {sttState === "recording" ? (
+                  <>
+                    <span className="w-2 h-2 rounded-full bg-terminal-red animate-pulse" />
+                    {recordingStartTime && <RecordingTimer startTime={recordingStartTime} />}
+                  </>
+                ) : sttState === "processing" ? "..." : "Mic"}
               </button>
               <button
                 onClick={handleBack}
@@ -171,16 +315,44 @@ export default function TerminalPage() {
               >
                 Back
               </button>
-              <button
-                onClick={handleKill}
-                className={cn(
-                  "px-2 py-1.5 sm:py-0.5 border text-[0.72rem] sm:text-[0.75rem] font-mono uppercase tracking-wider transition-all cursor-pointer",
-                  "flex items-center min-h-[40px] sm:min-h-0",
-                  "bg-bg-tertiary text-terminal-red border-terminal-red hover:bg-terminal-red hover:text-bg-primary",
-                )}
-              >
-                Kill
-              </button>
+
+              {/* Kill button with confirmation */}
+              {showKillConfirm ? (
+                <>
+                  <span className="text-terminal-amber text-[0.7rem] font-mono flex items-center">Kill?</span>
+                  <button
+                    onClick={handleKillConfirm}
+                    className={cn(
+                      "px-2 py-1.5 sm:py-0.5 border text-[0.72rem] sm:text-[0.75rem] font-mono uppercase tracking-wider transition-all cursor-pointer",
+                      "flex items-center min-h-[40px] sm:min-h-0",
+                      "bg-terminal-red text-bg-primary border-terminal-red hover:bg-terminal-red/80",
+                    )}
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={handleKillCancel}
+                    className={cn(
+                      "px-2 py-1.5 sm:py-0.5 border text-[0.72rem] sm:text-[0.75rem] font-mono uppercase tracking-wider transition-all cursor-pointer",
+                      "flex items-center min-h-[40px] sm:min-h-0",
+                      "bg-bg-tertiary text-txt-secondary border-border hover:text-txt-primary",
+                    )}
+                  >
+                    No
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={handleKillRequest}
+                  className={cn(
+                    "px-2 py-1.5 sm:py-0.5 border text-[0.72rem] sm:text-[0.75rem] font-mono uppercase tracking-wider transition-all cursor-pointer",
+                    "flex items-center min-h-[40px] sm:min-h-0",
+                    "bg-bg-tertiary text-terminal-red border-terminal-red hover:bg-terminal-red hover:text-bg-primary",
+                  )}
+                >
+                  Kill
+                </button>
+              )}
             </>
           )}
           <a
@@ -216,6 +388,7 @@ export default function TerminalPage() {
                 terminalId={activeTerminalId}
                 onClosed={handleClosed}
                 onSendInputRef={handleSendInputRef}
+                onConnectionStateChange={handleConnectionStateChange}
               />
             </div>
           </div>

--- a/radbot/web/frontend/src/stores/terminal-store.ts
+++ b/radbot/web/frontend/src/stores/terminal-store.ts
@@ -31,6 +31,11 @@ interface TerminalState {
   updateWorkspace: (workspaceId: string, data: { name?: string; description?: string }) => Promise<void>;
   createScratchWorkspace: (name?: string, description?: string) => Promise<void>;
 
+  // Health polling
+  _healthInterval: ReturnType<typeof setInterval> | null;
+  startHealthPolling: () => void;
+  stopHealthPolling: () => void;
+
   // Error
   error: string | null;
   clearError: () => void;
@@ -43,6 +48,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   status: null,
   showCloneForm: false,
   error: null,
+  _healthInterval: null,
 
   loadWorkspaces: async () => {
     try {
@@ -160,6 +166,24 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       }));
     } catch (e) {
       set({ error: `Failed to create scratch workspace: ${e}` });
+    }
+  },
+
+  startHealthPolling: () => {
+    const existing = get()._healthInterval;
+    if (existing) return;
+    const interval = setInterval(() => {
+      get().loadWorkspaces();
+      get().loadSessions();
+    }, 10000);
+    set({ _healthInterval: interval });
+  },
+
+  stopHealthPolling: () => {
+    const interval = get()._healthInterval;
+    if (interval) {
+      clearInterval(interval);
+      set({ _healthInterval: null });
     }
   },
 

--- a/radbot/web/frontend/src/types/terminal.ts
+++ b/radbot/web/frontend/src/types/terminal.ts
@@ -10,6 +10,10 @@ export interface Workspace {
   last_used_at: string;
   name: string | null;
   description: string | null;
+  worker_status?: "running" | "starting" | "stopped" | "unhealthy" | null;
+  worker_uptime_seconds?: number | null;
+  worker_idle_seconds?: number | null;
+  worker_sessions?: number | null;
 }
 
 export interface TerminalSession {

--- a/radbot/worker/terminal_handler.py
+++ b/radbot/worker/terminal_handler.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 MSG_DATA = 0x01  # terminal I/O data
 MSG_RESIZE = 0x02  # client→server resize (uint16 cols + uint16 rows)
 MSG_CLOSED = 0x03  # server→client session closed (int32 exit code)
+MSG_REPLAY_END = 0x04  # marks end of scrollback replay
 
 # Configuration
 MAX_CONCURRENT_SESSIONS = 3
@@ -499,6 +500,12 @@ async def handle_terminal_websocket(
             )
         except Exception as e:
             logger.debug("Failed to replay scrollback: %s", e)
+
+    # Send replay-end marker so the frontend knows where history ends
+    try:
+        await websocket.send_bytes(bytes([MSG_REPLAY_END]))
+    except Exception:
+        pass
 
     # Start the shared PTY reader if this is the first client
     await ensure_pty_reader(session)


### PR DESCRIPTION
…onomics

Backend:
- Add MSG_REPLAY_END protocol marker for scrollback replay divider
- Enrich workspace list with worker health data (status, uptime, idle)
- Add GET /terminal/workspaces/{workspace_id}/health endpoint

Frontend:
- Add terminal search (Ctrl+Shift+F) via @xterm/addon-search
- Add font size controls (Ctrl+=/-, Ctrl+0 reset)
- Add WebSocket connection state banner (connecting/disconnected)
- Add scrollback replay divider on reconnect
- Rename "+ New Session" to "+ Scratch Workspace"
- Add git/terminal icons and colored left borders on workspace cards
- Show relative timestamps, worker status badges, branch info on cards
- Add workspace search/filter when >4 workspaces
- Add kill confirmation dialog (auto-dismiss 5s)
- Add MIC recording indicator with pulsing dot and timer
- Add session uptime display in header
- Add keyboard shortcuts (Ctrl+Shift+T/W/[/])
- Improve empty state with onboarding message
- Add health polling (10s interval) on workspace selector
- Make delete button always visible (subtle opacity)