### PR TITLE
docs: refresh SPEC + specs to cover 70+ commits since 2026-03-22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,11 +341,57 @@ Exception tracebacks are included in an `"exc"` field when present.
 
 ---
 
+## Spec Maintenance
+
+`SPEC.md` at the repo root + `specs/*.md` are the system of record for cross-cutting architecture. They are read by future sessions (including Claude) to orient — stale specs produce stale code.
+
+### Rule: every PR that changes shape updates the matching spec in the same PR
+
+"Changes shape" means any of:
+
+- New / removed / renamed agent, tool, or tool module
+- New / removed / renamed FunctionTool on an existing agent (update the tool table + count)
+- New / removed API router, REST endpoint, or WebSocket message type
+- New / removed / altered DB table or column
+- New / removed / altered `config:<section>` key
+- New integration (client class, credential keys, admin panel)
+- Change to session / worker / terminal architecture, callback pipeline, or routing
+- New admin UI panel or change to `NAV_ITEMS` / `PANEL_MAP`
+- Language/runtime upgrade (Python, ADK, genai, React, Node) — `specs/deployment.md`
+
+### Spec ↔ code map
+
+| If you change… | Update |
+|----------------|--------|
+| `radbot/agent/**` (factories, callbacks, routing) | `specs/agents.md` |
+| `radbot/tools/**` (new tool, new FunctionTool, new list export) | `specs/tools.md` (and `specs/agents.md` tool counts for any affected agent) |
+| `radbot/web/**` (routers, WS types, frontend pages/panels) | `specs/web.md` |
+| SQL schema / `init_*_schema()` / `web/db/**` | `specs/storage.md` |
+| `radbot/tools/<integration>/*_client.py` or new admin panel | `specs/integrations.md` (and `specs/web.md` for the panel) |
+| `radbot/config/**`, `config_schema.json`, new `config:<section>` | `specs/config.md` |
+| `radbot/worker/**`, terminal proxy, nomad templates | `specs/workers.md` |
+| Dockerfiles, CI workflows, Nomad job, runtime versions | `specs/deployment.md` |
+| Cross-cutting architectural shift | `SPEC.md` quick-ref + the domain spec |
+
+### Workflow
+
+1. Make the code change
+2. Re-read the affected spec(s) — `cat specs/<domain>.md`
+3. Edit the spec in the same commit / same PR — do not defer to a "docs PR later" (they rarely come)
+4. If the change invalidates examples / file-path refs in other specs, fix those too (search for the old name: `grep -rn "old_name" specs/ SPEC.md CLAUDE.md`)
+
+### PR template hook
+
+When opening a PR, the PR body should explicitly answer: **"Which specs did this PR update, or why was none needed?"** If the answer is "none needed," the reviewer should verify that against the spec ↔ code map above.
+
+---
+
 ## Pre-Commit Checklist
 
 Before every commit, review and update these if the changes affect them:
 
-1. **README.md** — Feature descriptions, project structure, tech stack
-2. **docs/implementation/** — Add or update implementation docs for new features
-3. **CLAUDE.md** — Update if new conventions, patterns, or architecture decisions
-4. **config_schema.json** — Update if new config sections (`radbot/config/schema/`)
+1. **Specs** — `SPEC.md` + `specs/*.md` per the spec ↔ code map above (**mandatory** when shape changes)
+2. **README.md** — Feature descriptions, project structure, tech stack
+3. **docs/implementation/** — Add or update implementation docs for new features
+4. **CLAUDE.md** — Update if new conventions, patterns, or architecture decisions
+5. **config_schema.json** — Update if new config sections (`radbot/config/schema/`)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,26 +1,38 @@
 # RadBot Spec
 
 ## Quick Ref
-- Stack: Google ADK 1.27.2 | FastAPI | React 18 | PostgreSQL | Qdrant | MCP | A2A
-- Entry: `python -m radbot.web` (web) | `python -m radbot` (CLI) | `python -m radbot.worker` (session worker)
+- Stack: Google ADK 2.0.0a3 (V1 LlmAgent mode) | FastAPI | React 18 | PostgreSQL | Qdrant | MCP | A2A
+- Runtime: Python 3.14-slim, `google-adk>=2.0.0a3,<3.0.0`, `google-genai>=1.68.0`
+- Entry: `python -m radbot.web` (web) | `python -m radbot` (CLI) | `python -m radbot.worker --workspace-id <UUID>` (terminal worker)
 - Pkg: uv — always `uv run`
 - Main agent: beto (90s SoCal personality, pure orchestrator)
+- Sub-agents: casa, planner, tracker, comms, axel, kidsvid, scout + search_agent + code_execution_agent
 
 ## Specs
 | Domain | File | Covers |
 |--------|------|--------|
-| Agents | specs/agents.md | beto routing, sub-agents, tool assignments, memory scoping |
-| Tools | specs/tools.md | FunctionTool modules, MCP, tool patterns |
-| Web | specs/web.md | FastAPI, React SPA, API routes, WS protocol, session modes |
-| Storage | specs/storage.md | PostgreSQL tables, Qdrant, credential store |
-| Integrations | specs/integrations.md | HA, Overseerr, Picnic, Jira, Gmail, ntfy, Ollama, GitHub |
-| Config | specs/config.md | cfg system, priority chain, session mode, admin UI, hot-reload |
-| Workers | specs/workers.md | Session workers, A2A protocol, Nomad jobs, proxy, idle watchdog |
-| Deployment | specs/deployment.md | Docker, Nomad, CI/CD, env vars |
+| Agents | specs/agents.md | beto routing, sub-agents (including kidsvid), tool assignments, memory scoping, per-turn context scoping callback, structured UI cards, handoff chips |
+| Tools | specs/tools.md | FunctionTool modules, MCP, tool patterns, card protocol, direct-action REST |
+| Web | specs/web.md | FastAPI, React SPA, API routes, WS protocol, session modes, admin panels, notifications, token stats |
+| Storage | specs/storage.md | PostgreSQL tables (incl. `notifications`, `llm_usage_log`, `workspace_workers`), Qdrant, credential store |
+| Integrations | specs/integrations.md | HA, Overseerr, Lidarr, Picnic, Jira, Gmail, ntfy, Ollama, GitHub, YouTube/CuriosityStream/Kideo |
+| Config | specs/config.md | cfg system, priority chain, DB sections, session mode, admin UI, hot-reload |
+| Workers | specs/workers.md | Workspace/terminal workers, PTY server, Nomad jobs, proxy, legacy session-worker notes |
+| Deployment | specs/deployment.md | Docker (main + worker), Nomad, CI/CD, env vars |
 
 ## Cross-Cutting
 
-- **Session persistence**: Two modes — `local` (in-process, state lost on restart) and `remote` (Nomad batch jobs, state survives restarts). See `specs/deployment.md` and `specs/web.md`.
+- **Chat session flow**: Always in-process `SessionRunner` with `InMemorySessionService` (last 15 messages replayed from DB on cold start). `session_mode` config now only affects terminal/workspace workers.
+- **Terminal workers**: When `session_mode = "remote"`, each cloned workspace gets a persistent Nomad service job running a lean PTY server (`python -m radbot.worker`). Workers survive main-app restarts; state is restored via saved Claude Code session ID.
+- **Per-turn context scoping**: Every sub-agent runs `scope_sub_agent_context_callback` before its LLM call — trims prompt to current user turn only. Prevents cross-domain context bleed; keeps token usage flat.
+- **UI cards**: Agents (Casa) emit ``` ```radbot:<kind> ``` fenced JSON blocks for `media` / `seasons` / `ha-device` cards. `handoff` blocks are server-injected by `session_runner.py` on every `agent_transfer`. Frontend (`AgentCards.tsx`) parses and renders.
+- **Direct-action endpoints**: `/api/media/*` and `/api/ha/*` let the frontend trigger Overseerr + HA actions directly from cards — no LLM roundtrip.
+- **Token + cost telemetry**: `telemetry_after_model_callback` writes to `llm_usage_log` with `session_id` threaded through. `GET /api/sessions/{id}/stats` exposes per-session totals + rolling today/month cost.
+- **Unified notifications**: `notifications` table aggregates scheduled-task results, reminders, alerts, ntfy inbound. `/api/notifications/*` and `pages/NotificationsPage.tsx` drive the feed + drawer.
 - **Config priority**: DB config > file config > credential store > env vars. See `specs/config.md`.
 - **Error pattern**: Agent tools return `{"status": "success/error", ...}` dicts.
 - **Logging**: Structured JSON via `radbot/logging_config.py`. One INFO per operation, DEBUG for hot loops.
+
+## Keeping Specs Up To Date
+
+**These specs are the system of record for cross-cutting architecture.** Treat them like schema: every PR that changes shape should update the matching spec in the same commit. See `CLAUDE.md` § Spec Maintenance for the full rule.

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -5,99 +5,128 @@
 Beto is a **pure orchestrator** — it holds only memory tools and routes requests to specialized sub-agents via ADK's auto-injected `transfer_to_agent`. Each sub-agent owns its domain tools and returns control by calling `transfer_to_agent(agent_name='beto')`.
 
 ```
-                         beto (orchestrator)
-                              │
-        ┌─────────┬───────────┼───────────┬──────────┐
-        │         │           │           │          │
-      casa    planner     tracker      comms       axel
-   (smart     (calendar   (todo        (email     (execution
-    home)      schedule)   projects)    jira)      infra)
-        │
-        └── scout, search_agent, code_execution_agent
+                              beto (orchestrator)
+                                    │
+     ┌─────────┬──────────┬─────────┼─────────┬──────────┬─────────┐
+     │         │          │         │         │          │         │
+   casa     planner    tracker    comms     axel     kidsvid    scout
+  (smart   (calendar  (todo +   (email +  (execution (children   (research +
+   home +   schedule + projects   Jira)     + infra)  video       design
+   media +  reminders) + webhooks)                    curation)   collab)
+   music +
+   grocery)
+                                                  │
+                              scout also peers with search_agent
+                              & code_execution_agent (ADK built-ins)
 ```
+
+**Key architectural refinements (post-2026-03-22):**
+
+- `scope_sub_agent_context_callback` (before-model callback on every sub-agent) trims LLM input to the *current user turn only*. Prevents context bleed (e.g. Casa volunteering movie cards because an earlier turn mentioned movies) and keeps sub-agent prompts from growing linearly with session length. Root Beto keeps full history for conversational coherence. See `radbot/callbacks/scope_to_current_turn.py`.
+- `/api/agents/agent-info` walks `root_agent.sub_agents` at runtime to return the live roster (name, config key, resolved model, gemini_only flag) — the frontend admin palette reads this instead of a hard-coded list.
+- Agents emit **structured UI cards** via fenced code blocks (`` ```radbot:<kind> ``). Casa ships `CARD_TOOLS` (`show_media_card`, `show_season_breakdown`, `show_ha_device_card`). Every `agent_transfer` event is also auto-wrapped as a `radbot:handoff` block by `session_runner.py` — no LLM call needed. See `radbot/tools/shared/card_protocol.py`.
 
 ## Agent Summary
 
 | Agent | Factory | Model | Tool Count | Purpose |
 |-------|---------|-------|------------|---------|
-| **beto** | `agent/agent_core.py` | `get_main_model()` (gemini-2.5-pro) | 2 | Orchestrator, routes to specialists |
-| **casa** | `agent/home_agent/factory.py` | `resolve_agent_model("casa_agent")` | 28 | Smart home, media, dashboards, grocery |
+| **beto** | `agent/agent_core.py` | `config_manager.get_main_model()` (default `gemini-2.5-pro`) | 2 | Orchestrator, routes to specialists |
+| **casa** | `agent/home_agent/factory.py` | `resolve_agent_model("casa_agent")` | ~38 | Smart home, media, music, grocery, card emission |
 | **planner** | `agent/planner_agent/factory.py` | `resolve_agent_model("planner_agent")` | 14 | Calendar, scheduling, reminders |
 | **tracker** | `agent/tracker_agent/factory.py` | `resolve_agent_model("tracker_agent")` | 13 | Tasks, projects, webhooks |
 | **comms** | `agent/comms_agent/factory.py` | `resolve_agent_model("comms_agent")` | 12 | Email (Gmail), Jira |
-| **axel** | `agent/execution_agent/factory.py` | `get_agent_model("axel_agent")` | 17+ | Shell, files, Claude Code, Nomad, MCP |
-| **scout** | `agent/research_agent/factory.py` | `get_agent_model("scout_agent")` | 2 | Research, design collaboration |
-| **search_agent** | `tools/adk_builtin/search_tool.py` | Gemini 2+ required | 1 | Google Search grounding |
-| **code_execution_agent** | `tools/adk_builtin/code_execution_tool.py` | Gemini 2+ required | 0* | Python code execution |
+| **axel** | `agent/execution_agent/factory.py` | `config_manager.get_agent_model("axel_agent_model")` | 17+ MCP | Shell, files, code exec, Claude Code, Nomad, MCP |
+| **kidsvid** | `agent/youtube_agent/factory.py` | `resolve_agent_model("kidsvid_agent")` | 17 | Children's video curation (YouTube + CuriosityStream + Kideo) |
+| **scout** | `agent/research_agent/factory.py` | `config_manager.get_agent_model("scout_agent")` | 2 | Research, design collaboration (sequential thinking) |
+| **search_agent** | `tools/adk_builtin/search_tool.py` | Gemini 2+ (hardcoded) | 1 | Google Search grounding |
+| **code_execution_agent** | `tools/adk_builtin/code_execution_tool.py` | Gemini 2+ (hardcoded) | 0* | Python code execution |
 
 \* Uses `code_executor=BuiltInCodeExecutor()`, not FunctionTools.
 
 ## Root Agent — beto
 
 - **Temperature**: 0.2
+- **Global instruction**: injects today's date
 - **Tools**: `search_agent_memory`, `store_agent_memory` (via `create_agent_memory_tools("beto")`)
-- **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder), HA client check
-- **Before-model callbacks**: `sanitize_before_model_callback`
-- **After-model callbacks**: `handle_empty_response_after_model`, `telemetry_after_model_callback`
+- **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder, notifications, alerts, telemetry), HA client check
+- **Before-model callbacks**: `[scrub_empty_content_before_model, sanitize_before_model_callback]`
+- **After-model callbacks**: `[handle_empty_response_after_model, telemetry_after_model_callback]`
 - **Instruction file**: `config/default_configs/instructions/main_agent.md`
+- **Full conversation history**: root keeps all prior turns (unlike sub-agents, which are scoped to the current turn)
 
 ## Domain Agents
 
-### casa (Smart Home & Media)
+### casa — Smart Home, Media, Music, Grocery
 
-| Tool Group | Count | Tools |
-|------------|-------|-------|
-| Home Assistant REST | 6 | `list_ha_entities`, `get_ha_entity_state`, `turn_on_ha_entity`, `turn_off_ha_entity`, `toggle_ha_entity`, `search_ha_entities` |
-| HA Dashboard (WS) | 6 | `list_ha_dashboards`, `get_ha_dashboard_config`, `create_ha_dashboard`, `update_ha_dashboard`, `delete_ha_dashboard`, `save_ha_dashboard_config` |
-| Overseerr | 4 | `search_overseerr_media`, `get_overseerr_media_details`, `request_overseerr_media`, `list_overseerr_requests` |
-| Picnic | 10 | `search_picnic_product`, `get_picnic_cart`, `add_to_picnic_cart`, `remove_from_picnic_cart`, `clear_picnic_cart`, `get_picnic_delivery_slots`, `set_picnic_delivery_slot`, `submit_shopping_list_to_picnic`, `get_picnic_order_history`, `get_picnic_delivery_details` |
-| Memory | 2 | `search_agent_memory`, `store_agent_memory` |
+| Tool Group | Count | Source |
+|------------|-------|--------|
+| Home Assistant REST | 6 | `radbot.tools.homeassistant` (`search_ha_entities`, `list_ha_entities`, `get_ha_entity_state`, `turn_on/off/toggle_ha_entity`) |
+| HA Dashboard (WS) | 6 | `radbot.tools.homeassistant.ha_dashboard_tools.HA_DASHBOARD_TOOLS` |
+| Overseerr | 4 | `radbot.tools.overseerr.OVERSEERR_TOOLS` |
+| Lidarr | 5 | `radbot.tools.lidarr.LIDARR_TOOLS` (`search_lidarr_artist`, `search_lidarr_album`, `add_lidarr_artist`, `add_lidarr_album`, `list_lidarr_quality_profiles`) |
+| Picnic | 12 | `radbot.tools.picnic.PICNIC_TOOLS` |
+| Card protocol | 3 | `radbot.tools.shared.card_protocol.CARD_TOOLS` (`show_media_card`, `show_season_breakdown`, `show_ha_device_card`) |
+| Memory | 2 | `create_agent_memory_tools("casa")` |
 
-### planner (Calendar & Scheduling)
+Emits UI cards inline with replies. Casa is the only agent that currently ships `CARD_TOOLS`.
 
-| Tool Group | Count | Tools |
-|------------|-------|-------|
-| Time | 1 | `get_current_time` |
+### planner — Calendar, Scheduling, Reminders
+
+| Tool Group | Count | Source |
+|------------|-------|--------|
+| Time | 1 | `radbot.tools.basic.get_current_time` |
 | Calendar | 5 | `list_calendar_events`, `create_calendar_event`, `update_calendar_event`, `delete_calendar_event`, `check_calendar_availability` |
-| Scheduler | 3 | `create_scheduled_task`, `list_scheduled_tasks`, `delete_scheduled_task` |
-| Reminders | 3 | `create_reminder`, `list_reminders`, `delete_reminder` |
-| Memory | 2 | `search_agent_memory`, `store_agent_memory` |
+| Scheduler | 3 | `radbot.tools.scheduler.SCHEDULER_TOOLS` |
+| Reminders | 3 | `radbot.tools.reminders.REMINDER_TOOLS` |
+| Memory | 2 | `create_agent_memory_tools("planner")` |
 
-### tracker (Tasks & Projects)
+### tracker — Tasks, Projects, Webhooks
 
-| Tool Group | Count | Tools |
-|------------|-------|-------|
-| Todo | 8 | `add_task`, `complete_task`, `remove_task`, `list_projects`, `list_project_tasks`, `list_all_tasks`, `update_task`, `update_project` |
-| Webhooks | 3 | `create_webhook`, `list_webhooks`, `delete_webhook` |
-| Memory | 2 | `search_agent_memory`, `store_agent_memory` |
+| Tool Group | Count | Source |
+|------------|-------|--------|
+| Todo | 8 | `radbot.tools.todo.ALL_TOOLS` |
+| Webhooks | 3 | `radbot.tools.webhooks.WEBHOOK_TOOLS` |
+| Memory | 2 | `create_agent_memory_tools("tracker")` |
 
-### comms (Email & Issue Tracking)
+### comms — Email, Jira
 
-| Tool Group | Count | Tools |
-|------------|-------|-------|
+| Tool Group | Count | Source |
+|------------|-------|--------|
 | Gmail | 4 | `list_emails`, `search_emails`, `get_email`, `list_gmail_accounts` |
-| Jira | 6 | `list_my_jira_issues`, `get_jira_issue`, `get_issue_transitions`, `transition_jira_issue`, `add_jira_comment`, `search_jira_issues` |
-| Memory | 2 | `search_agent_memory`, `store_agent_memory` |
+| Jira | 6 | `radbot.tools.jira.JIRA_TOOLS` |
+| Memory | 2 | `create_agent_memory_tools("comms")` |
 
-### axel (Execution & Infrastructure)
+### axel — Execution & Infrastructure
 
-| Tool Group | Count | Tools |
-|------------|-------|-------|
-| Claude Code | 6 | `clone_repository`, `claude_code_plan`, `claude_code_continue`, `claude_code_execute`, `commit_and_push`, `list_workspaces` |
-| Nomad | 7 | `list_nomad_jobs`, `get_nomad_job_status`, `get_nomad_allocation_logs`, `restart_nomad_allocation`, `plan_nomad_job_update`, `submit_nomad_job_update`, `check_nomad_service_health` |
-| Shell | 1 | `execute_shell_command` (via `get_shell_tool()`) |
+| Tool Group | Count | Source |
+|------------|-------|--------|
+| Execution | 4 | `execution_tools` list: `code_execution_tool`, `run_tests`, `validate_code`, `generate_documentation` |
+| Memory | 2 | `create_agent_memory_tools("axel")` |
+| MCP (filesystem) | variable | `create_fileserver_toolset()` |
+| MCP (dynamic) | variable | `load_dynamic_mcp_tools()` |
+| Claude Code | 6 | `CLAUDE_CODE_TOOLS`: `clone_repository`, `claude_code_plan`, `claude_code_continue`, `claude_code_execute`, `commit_and_push`, `list_workspaces` |
+| Nomad | 7 | `NOMAD_TOOLS` |
 | ADK | 1 | `load_artifacts` |
-| MCP (filesystem) | variable | Via `create_fileserver_toolset()` |
-| MCP (dynamic) | variable | Via `load_dynamic_mcp_tools()` |
-| Memory | 2 | `search_agent_memory`, `store_agent_memory` |
+| Shell | 1 | `get_shell_tool(strict_mode=True)` (when `enable_code_execution=True`) |
 
-Has `code_executor=BuiltInCodeExecutor()` enabled. Can transfer to scout for research tasks.
+`enable_code_execution=True` is set in `specialized_agent_factory._create_axel_agent`.
 
-### scout (Research & Design)
+### kidsvid — Children's Video Curation
+
+| Tool Group | Count | Source |
+|------------|-------|--------|
+| YouTube | 3 | `YOUTUBE_TOOLS`: `search_youtube_videos`, `get_youtube_video_details`, `get_youtube_channel_info` |
+| CuriosityStream | 2 | `CURIOSITYSTREAM_TOOLS`: `search_curiositystream`, `list_curiositystream_categories` |
+| Kideo library | 10 | `KIDEO_TOOLS`: `add_video_to_kideo`, `add_videos_to_kideo_batch`, `list_kideo_collections`, `create_kideo_collection`, `generate_video_tags`, `set_kideo_video_tags`, `get_kideo_popular_videos`, `get_kideo_tag_stats`, `get_kideo_channel_stats`, `retag_untagged_kideo_videos` |
+| Memory | 2 | `create_agent_memory_tools("kidsvid")` |
+
+YouTube Shorts are filtered out at ingest time in `kideo_tools.py` (both search and Kideo submission paths).
+
+### scout — Research & Design
 
 - **Tools**: 2 memory (`search_agent_memory`, `store_agent_memory`)
-- **Special**: `enable_sequential_thinking=True`
-- Wrapped by `ResearchAgent` class
+- **Special**: `enable_sequential_thinking=True`; wrapped by `ResearchAgent` class
+- Commonly used for rubber-ducking, architecture, and spec collaboration. Axel can transfer to scout for research, and vice versa.
 
 ## Built-in Agents
 
@@ -105,49 +134,83 @@ Has `code_executor=BuiltInCodeExecutor()` enabled. Can transfer to scout for res
 
 - **Tool**: `google_search` (ADK built-in grounding tool)
 - **Flags**: `disallow_transfer_to_parent=True`, `disallow_transfer_to_peers=True`
-- **Reason**: Google Search grounding tool cannot be mixed with function declarations
-- **Model**: Must be Gemini 2+ (hardcoded)
+- **Reason**: Google Search grounding cannot be mixed with function declarations in the same agent
+- **Model**: Must be Gemini 2+ (Ollama / LiteLLM won't work)
 
 ### code_execution_agent
 
 - **Tool**: `BuiltInCodeExecutor` (via `generate_content_config`)
 - **Flags**: `disallow_transfer_to_parent=True`, `disallow_transfer_to_peers=True`
-- **Reason**: Built-in tools and Function Calling cannot be combined in Gemini API
-- **Model**: Must be Gemini 2+ (hardcoded)
+- **Reason**: Built-in tools + Function Calling can't be combined in Gemini API
+- **Model**: Must be Gemini 2+
 
 ## Creation Flow
 
-1. `agent_core.py:create_agent()` creates `search_agent`, `code_execution_agent`, `scout_agent`
-2. Root agent created with those 3 as initial `sub_agents`
-3. `specialized_agent_factory.py:create_specialized_agents(root_agent)` creates casa, planner, tracker, comms, axel
-4. Each appended to `root_agent.sub_agents`
-5. **Critical**: `parent_agent` manually set on each — ADK only sets it at construction time via `model_post_init()`
-6. Before-model callbacks (`scrub_empty_content`, `sanitize`) and after-model callbacks (`handle_empty_response`, `telemetry`) attached to all sub-agents
+All assembly happens in `radbot/agent/agent_core.py` at module import time:
+
+1. `create_agent_memory_tools("beto")` — beto's 2 memory tools
+2. `create_search_agent()`, `create_code_execution_agent()`, `create_research_agent(name="scout", as_subagent=False)` — the three "peer" sub-agents
+3. `create_specialized_agents()` builds the domain agents in order: casa → planner → tracker → comms → axel → kidsvid. None-returning factories are filtered out.
+4. `all_sub_agents` = builtin sub-agents + specialized — passed to the root `Agent(...)` constructor
+5. **Before construction**, callbacks are attached to each sub-agent:
+   - `before_model_callback = [scope_sub_agent_context_callback, scrub_empty_content_before_model]`
+   - `after_model_callback = [handle_empty_response_after_model, telemetry_after_model_callback]`
+6. Root `Agent(...)` is constructed — ADK's `model_post_init()` builds the `_Mesh` routing graph once, setting `parent_agent` on every sub-agent
+
+**Critical**: agents added to `sub_agents` after construction are NOT part of the mesh — `transfer_to_agent` will not find them. See `docs/implementation/session_id_tracking.md` for history.
+
+## Per-Turn Context Scoping
+
+`scope_sub_agent_context_callback` (in `radbot/callbacks/scope_to_current_turn.py`) runs before every sub-agent LLM call. It:
+
+1. Walks `llm_request.contents` bottom-up
+2. Finds the most recent `role='user'` entry whose parts include actual text (not just a `function_response`)
+3. Slices `contents` from that index forward
+
+What remains: the current user message, any in-flight model output, any function_response parts from the current invocation. What gets dropped: every prior user/assistant turn.
+
+**Result**: Each sub-agent prompt contains only the current turn → no cross-domain context bleed, no linear token growth with session length.
 
 ## Routing Rules
 
-From `main_agent.md` instruction file:
+From `config/default_configs/instructions/main_agent.md`:
 
 | Request Type | Agent |
 |-------------|-------|
-| Smart home, lights, sensors, climate, media requests, grocery | `casa` |
+| Smart home, lights, sensors, climate, media requests, music (Lidarr), grocery (Picnic) | `casa` |
 | Calendar, reminders, scheduled tasks, time queries | `planner` |
 | Todo lists, projects, task management, webhooks | `tracker` |
 | Email (Gmail), Jira issues | `comms` |
 | Web research, design discussion, rubber-ducking | `scout` |
 | Code implementation, file ops, shell, GitHub, Nomad, alerts | `axel` |
+| Children's video curation / Kideo library | `kidsvid` |
 | Python calculations, quick code execution | `code_execution_agent` |
 | Web search grounding | `search_agent` |
 | Chitchat, greetings | `beto` (direct response) |
+
+## Callback Inventory
+
+| Callback | File | Applied To | Purpose |
+|----------|------|------------|---------|
+| `setup_before_agent_call` | `agent/agent_tools_setup.py` | beto (before_agent) | DB schema init; HA client warm-up |
+| `sanitize_before_model_callback` | `callbacks/sanitize_callback.py` | beto (before_model) | Strip PII / sensitive tokens |
+| `scrub_empty_content_before_model` | `callbacks/empty_content_callback.py` | all (before_model) | Drop Content entries with empty text parts (Gemini API errors) |
+| `scope_sub_agent_context_callback` | `callbacks/scope_to_current_turn.py` | sub-agents only (before_model) | Trim to current turn |
+| `handle_empty_response_after_model` | `callbacks/empty_content_callback.py` | all (after_model) | Replace empty model responses with a "still thinking" marker |
+| `telemetry_after_model_callback` | `callbacks/telemetry_callback.py` | all (after_model) | Record token usage + cost in `llm_usage_log` with `session_id` |
+| `tool_call_repair_callback` | `callbacks/tool_call_repair_callback.py` | (available, not wired by default) | Repair malformed function calls |
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `agent/agent_core.py` | Root agent creation, callback wiring |
+| `agent/agent_core.py` | Root agent creation, sub-agent assembly, callback wiring |
 | `agent/agent_tools_setup.py` | DB schema init callback, search/code/scout creation |
-| `agent/specialized_agent_factory.py` | Domain agent creation + parent_agent wiring |
+| `agent/specialized_agent_factory.py` | Domain agent creation (casa, planner, tracker, comms, axel, kidsvid) |
 | `agent/{domain}_agent/factory.py` | Per-domain agent factory function |
-| `config/default_configs/instructions/*.md` | Agent instruction files |
-| `tools/adk_builtin/search_tool.py` | search_agent factory |
-| `tools/adk_builtin/code_execution_tool.py` | code_execution_agent factory |
+| `agent/shared.py` | `load_agent_instruction`, `resolve_agent_model`, task/transfer instruction helpers |
+| `config/default_configs/instructions/*.md` | Agent instruction files (main_agent.md, casa.md, planner.md, tracker.md, comms.md, axel.md, scout.md, kidsvid.md) |
+| `tools/adk_builtin/search_tool.py` | `search_agent` factory |
+| `tools/adk_builtin/code_execution_tool.py` | `code_execution_agent` factory |
+| `callbacks/scope_to_current_turn.py` | Per-turn context scoping for sub-agents |
+| `tools/shared/card_protocol.py` | `radbot:<kind>` fenced-block card emission |

--- a/specs/config.md
+++ b/specs/config.md
@@ -15,54 +15,122 @@ credential_key:    # Fernet encryption key for credential store
 admin_token:       # Admin API bearer token
 ```
 
-**Do NOT add integration config to `config.yaml`.** Everything else goes in the DB credential store, managed via Admin UI at `/admin/`.
+**Do NOT add integration config to `config.yaml`.** Everything else goes in DB-backed config sections or the credential store, managed via Admin UI at `/admin/`.
+
+## Env Var Bootstrap
+
+| Env var | Purpose |
+|---------|---------|
+| `RADBOT_CREDENTIAL_KEY` | Fernet key for encrypted credentials in DB |
+| `RADBOT_ADMIN_TOKEN` | Bearer token for `/admin/` API |
+| `RADBOT_CONFIG_FILE` | Path to `config.yaml` (alias: `RADBOT_CONFIG`, default: auto-discovered) |
+| `RADBOT_ENV` | `dev` → loads `config.dev.yaml` before `config.yaml` in each search directory |
+| `RADBOT_MAIN_MODEL` / `RADBOT_SUB_MODEL` | Model overrides (if no DB/file entry exists) |
+| `RADBOT_WORKER_IMAGE_TAG` | Overrides `config:agent.worker_image_tag` for new workers |
+| `LOG_LEVEL` | Controls log verbosity at runtime (default `INFO`) |
 
 ## DB Config Sections
 
-Stored as `config:<section>` entries in `radbot_credentials` table.
+Stored as `config:<section>` entries in `radbot_credentials` (`credential_type='config'`).
 
 | Section | Keys | Purpose |
 |---------|------|---------|
-| `config:agent` | `main_model`, `sub_model`, `session_mode`, `max_session_workers`, `worker_image_tag` | Agent model selection + session worker config |
-| `config:integrations` | `overseerr.*`, `picnic.*`, `nomad.*`, `ntfy.*`, `github.*` | Integration endpoints and flags |
+| `config:agent` | `main_model`, `sub_model`, per-agent models (`casa_agent`, `planner_agent`, `tracker_agent`, `comms_agent`, `axel_agent`/`axel_agent_model`, `scout_agent`, `kidsvid_agent`), `session_mode`, `max_session_workers`, `worker_image_tag` | Agent model selection + session/worker config |
+| `config:integrations` | `home_assistant.*`, `overseerr.*`, `lidarr.*`, `picnic.*`, `jira.*`, `ntfy.*`, `github.*`, `nomad.*`, `kideo.*`, `alertmanager.*`, `ollama.*` | Integration endpoints, flags, non-secret keys |
+| `config:vector_db` | `url`, `api_key`, `host`, `port`, `collection` | Qdrant connection + collection |
 | `config:scheduler` | `enabled` | Scheduler engine toggle |
 | `config:webhooks` | `enabled` | Webhook engine toggle |
 | `config:tts` | `enabled`, `voice`, `language_code` | TTS settings |
 | `config:stt` | `enabled`, `language_code` | STT settings |
+| `config:logging` | `level`, `structured` | Logging overrides |
+| `config:mcp_servers` | list of `{name, command, args, env}` | Dynamic MCP server definitions (axel) |
+| `config:cost_tracking` | `enabled`, rate cards | Telemetry + cost calc settings |
+
+Use `config:full` as an Admin-UI read-only diagnostic that returns the merged config tree.
 
 ## Session Mode Config
 
 | Key | Values | Default | Effect |
 |-----|--------|---------|--------|
-| `session_mode` | `local`, `remote` | `local` | `local` = in-process SessionRunner; `remote` = Nomad batch job workers |
-| `max_session_workers` | integer | `10` | Max concurrent remote workers |
-| `worker_image_tag` | string | `latest` | Docker tag for worker containers |
+| `session_mode` | `local`, `remote` | `local` | **Terminal/workspace workers only** (chat is always local post-2026-03-23). `remote` spawns Nomad service jobs for each terminal workspace. |
+| `max_session_workers` | integer | `10` | Max concurrent workspace worker jobs |
+| `worker_image_tag` | string | `latest` | Docker tag for newly-spawned workers |
+
+**Note**: the `session_mode` name predates the terminal-only split. It now only affects terminal/workspace workers.
+
+## Per-Agent Model Resolution
+
+`config_manager.resolve_model(model_string)`:
+
+- Gemini strings (e.g. `gemini-2.5-pro`) → passed through unchanged
+- Ollama strings (prefix `ollama_chat/...`) → wrapped in `LiteLlm(...)` for ADK compatibility
+
+Each agent factory calls `resolve_agent_model(key)` which:
+
+1. Checks `config:agent.<key>` (e.g. `casa_agent`) — DB first
+2. Falls back to `config:agent.sub_model`
+3. Falls back to env var (`RADBOT_SUB_MODEL`)
+
+`search_agent` and `code_execution_agent` require Gemini — resolve_model does not let Ollama reach them.
 
 ## Integration Client Pattern
 
-Follow `radbot/tools/overseerr/overseerr_client.py:30-58`:
+Follow this for new integrations:
 
 ```python
+from radbot.tools.shared.config_helper import get_integration_config
+
 def _get_config() -> dict:
-    from radbot.config.config_loader import config_loader
-    cfg = config_loader.get_integrations_config().get("service", {})
-    url = cfg.get("url") or os.environ.get("SERVICE_URL")
-    api_key = cfg.get("api_key") or os.environ.get("SERVICE_API_KEY")
-    if not api_key:
-        from radbot.credentials.store import get_credential_store
-        api_key = get_credential_store().get("service_api_key")
-    return {"url": url, "api_key": api_key, "enabled": cfg.get("enabled", True)}
+    return get_integration_config(
+        "overseerr",
+        fields={"url": "OVERSEERR_URL", "api_key": "OVERSEERR_API_KEY"},
+        credential_keys={"api_key": "overseerr_api_key"},
+    )
 ```
 
-## Hot-Reload
+This resolves config → env vars → credential store automatically.
 
-Admin UI → `PUT /api/config/{section}` → `config_loader.load_db_config()` → client `reset_*_client()` singleton reset → next tool call picks up new config.
+For new integrations also:
+
+1. Add test endpoint in `web/api/admin.py` (`/admin/api/test/<service>`)
+2. Add status check in `get_integration_status()` in `admin.py`
+3. Add panel in `web/frontend/src/components/admin/panels/...`
+4. Register panel in `pages/AdminPage.tsx` (NAV_ITEMS + PANEL_MAP)
+5. Add entry to `_INTEGRATION_RESET_REGISTRY` in `admin.py` for hot-reload
+6. Update `config_schema.json` if new `config:<section>` keys are introduced
+
+## Hot-Reload Flow
+
+```
+Admin UI edits section
+   ↓
+PUT /admin/api/config/{section}  (or /admin/api/credentials/...)
+   ↓
+config_loader.load_db_config()   — merges DB overrides into in-memory config
+   ↓
+_INTEGRATION_RESET_REGISTRY      — resets affected singleton clients
+   ↓
+next tool call                   — re-initializes client with fresh config
+```
+
+## Environment Separation (Dev)
+
+Setting `RADBOT_ENV=dev`:
+
+- Loads `config.dev.yaml` before `config.yaml` in each search directory
+- Recommended: separate PostgreSQL DB (`radbot_dev`), Qdrant collection (`radbot_dev`)
+- Use `scripts/migrate_credentials_to_dev.py` (one-off) to copy prod credentials into a dev key-space
+- Startup banner logs env, config path, database, Qdrant collection — check logs to verify env
+
+See `docs/implementation/dev_environment_setup.md` for full procedure.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `config/config_loader.py` | ConfigLoader with DB merge, `get_integrations_config()` |
-| `config/schema/config_schema.json` | JSON schema for validation |
+| `config/config_loader.py` | `ConfigLoader` with DB merge, `get_integrations_config()`, `resolve_model()` |
+| `config/schema/config_schema.json` | JSON schema for validation (uses `additionalProperties: true` for agent schemas to tolerate drift) |
+| `config/default_configs/instructions/*.md` | Per-agent instruction files |
+| `config/default_configs/schemas/*` | Per-agent config sub-schemas |
 | `credentials/store.py` | Encrypted credential store (PostgreSQL-backed) |
-| `web/api/admin.py` | Admin API: save/test/status endpoints |
+| `web/api/admin.py` | Admin API: save/test/status endpoints, reset registry |

--- a/specs/deployment.md
+++ b/specs/deployment.md
@@ -4,20 +4,29 @@
 
 - **Endpoint**: `https://radbot.demonsafe.com`
 - **Nomad job**: `~/git/perrymanuk/hashi-homelab/nomad_jobs/ai-ml/radbot/nomad.job`
-- **Docker image**: `ghcr.io/perrymanuk/radbot` — auto-built by `.github/workflows/docker-build.yml` on push to `main`
+- **Docker image (main)**: `ghcr.io/perrymanuk/radbot` — auto-built by `.github/workflows/docker-build.yml` on push to `main`
+- **Docker image (worker)**: `ghcr.io/perrymanuk/radbot-worker` — separate image, separate Dockerfile (`Dockerfile.worker`), separate build pipeline
 - **Versioning**: Auto-incremented `v{MAJOR}.{BUILD}` tags (e.g. `v0.14`). Update the `image` tag in the Nomad job after pushing.
 - **Reverse proxy**: Traefik via Consul service discovery. `ProxyHeadersMiddleware` handles `X-Forwarded-Proto`.
 
+## Runtime Environment
+
+- **Python**: 3.14-slim base image for both main app and worker (upgraded in `85a258e`)
+- **Package manager**: `uv` — both containers use multi-stage builds with `uv` + GHA layer caching (`c20e8b2`, `c1cbdd8`)
+- **ADK**: `google-adk>=2.0.0a3,<3.0.0` with V1 LlmAgent mode (V2 `_Mesh` is being removed upstream — see CLAUDE.md gotchas)
+- **genai**: `google-genai>=1.68.0` (NOT the older `google-generativeai` package)
+
 ## Bootstrap Config
 
-Nomad templates a minimal `config.yaml` with only `database:` section. All other config loaded from DB credential store at startup.
+Nomad templates a minimal `config.yaml` with only `database:` section. All other config loaded from the DB credential store at startup.
 
 | Env var | Purpose |
 |---------|---------|
 | `RADBOT_CREDENTIAL_KEY` | Fernet key for encrypted credentials in DB |
 | `RADBOT_ADMIN_TOKEN` | Bearer token for `/admin/` API |
-| `RADBOT_CONFIG_FILE` | Path to `config.yaml` (default: auto-discovered) |
+| `RADBOT_CONFIG_FILE` | Path to `config.yaml` (alias: `RADBOT_CONFIG`; Nomad uses the `_FILE` variant) |
 | `RADBOT_ENV` | `dev` loads `config.dev.yaml` instead of `config.yaml` |
+| `RADBOT_WORKER_IMAGE_TAG` | Overrides `config:agent.worker_image_tag` for newly-spawned workspace workers |
 
 ## Main Nomad Job
 
@@ -31,13 +40,38 @@ health: GET /health every 30s
 resources: cpu=1000, memory=2048
 ```
 
-## Session Workers (Remote Mode)
+### Reverse Proxy Gotchas
 
-When `config:agent` → `session_mode = "remote"`, each chat session runs as a persistent Nomad service job (`type = "service"`). Workers hold full ADK session state in memory, expose A2A endpoints, and restart on crash. The main app proxies messages via `SessionProxy`.
+- FastAPI behind Traefik generates redirect URLs using the internal HTTP scheme. `ProxyHeadersMiddleware` in `web/app.py` trusts `X-Forwarded-Proto`.
+- FastAPI router root paths (`@router.get("/")`) 307-redirect without trailing slash. On HTTPS this can produce `http://` redirects that browsers block as mixed content. **Always use trailing slashes** in frontend fetch calls that hit router root paths.
 
-See **`specs/workers.md`** for full architecture, protocol details, and file inventory.
+## Workspace/Terminal Workers (Remote Mode)
+
+When `config:agent.session_mode = "remote"`, each terminal workspace runs as a persistent Nomad **service** job:
+
+- `type = "service"` with `restart: attempts=1, mode=fail`
+- Image: `ghcr.io/perrymanuk/radbot-worker:{tag}` (separate from main app)
+- Each worker registers with Nomad service discovery (`radbot-workspace`) tagged `workspace_id=<UUID>`
+- Bootstrap env templated from the main app's DB credential store (`RADBOT_CREDENTIAL_KEY`, `RADBOT_ADMIN_TOKEN`, `postgres_pass`)
+- Pre-spawned on workspace *creation* for instant cold-start on first click (`3e93b63`)
+
+Chat sessions always run in-process — `session_mode` no longer affects chat (`12e4901`).
+
+See **`specs/workers.md`** for full architecture, worker protocol, and file inventory.
 
 ## CI/CD
 
-- `.github/workflows/docker-build.yml` — builds on push to `main`, tags `v{MAJOR}.{BUILD}`
-- Image: `ghcr.io/perrymanuk/radbot`
+- `.github/workflows/docker-build.yml` — builds main image on push to `main`, tags `v{MAJOR}.{BUILD}`, pushes to GHCR
+- Separate worker image pipeline with BuildKit + GHA layer caching
+- Image: `ghcr.io/perrymanuk/radbot` (main), `ghcr.io/perrymanuk/radbot-worker` (worker)
+- Update the Nomad job's `image` tag after a new version pushes (manual step)
+
+## Environment Separation (Dev)
+
+Setting `RADBOT_ENV=dev`:
+
+- Loads `config.dev.yaml` before `config.yaml` in each search directory
+- Recommended separate prod/dev: PostgreSQL DB (`radbot_dev`), Qdrant collection (`radbot_dev`)
+- Startup banner in `app.py` logs env, config path, database, qdrant collection — check at startup to verify
+
+See `docs/implementation/dev_environment_setup.md` for full procedure.

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -10,27 +10,34 @@ All integrations follow a common pattern:
 4. **Singleton client**: Module-level `_client` + `get_client()` / `reset_client()`
 5. **Hot-reload**: Admin UI save → `reset_*_client()` → next call picks up new config
 
-Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
+Canonical example: `radbot/tools/overseerr/overseerr_client.py`. Prefer `get_integration_config()` from `tools/shared/config_helper.py` for new clients.
 
 ## Integration Matrix
 
 | Service | Client Class | Connection | Config Keys | Admin Panel | Test Endpoint |
 |---------|-------------|------------|-------------|-------------|---------------|
-| Home Assistant | `HomeAssistantRESTClient` | HTTP REST + WebSocket | `integrations.home_assistant.url`, credential: `ha_token` | ConnectionPanels | `/api/test/home-assistant` |
-| Overseerr | `OverseerrClient` | HTTP REST | `integrations.overseerr.url`, credential: `overseerr_api_key` | ConnectionPanels | `/api/test/overseerr` |
-| Picnic | `PicnicClientWrapper` | HTTP REST (python_picnic_api2) | credential: `picnic_username`, `picnic_password`, `picnic_country_code` | MediaPanels | `/api/test/picnic` |
-| Jira | `atlassian.Jira` | HTTP REST (atlassian lib) | `integrations.jira.url`, `jira.email`, credential: `jira_api_token` | ConnectionPanels | `/api/test/jira` |
-| Gmail | `GmailManager` | Google API (OAuth) | credential: `gmail_token_<account>` (JSON) | SecurityPanels | `/api/test/gmail` |
-| Google Calendar | `CalendarManager` | Google API (SA/OAuth) | credential: `calendar_token` (JSON) | SecurityPanels | `/api/test/calendar` |
-| ntfy | `NtfyClient` | async HTTP (httpx) | `integrations.ntfy.url`, `ntfy.topic`, credential: `ntfy_token` | NotificationPanels | `/api/test/ntfy` |
-| GitHub | `GitHubAppClient` | HTTP REST (JWT auth) | `integrations.github.app_id`, `github.installation_id`, credential: `github_app_private_key` | DeveloperPanels | `/api/test/github` |
-| Nomad | `NomadClient` | async HTTP (httpx) | `integrations.nomad.addr`, credential: `nomad_token` | InfrastructurePanels | `/api/test/nomad` |
-| Claude Code | subprocess CLI | subprocess | credential: `claude_code_oauth_token` | DeveloperPanels | `/api/test/claude-code` |
-| Google API | — | — | credential store (API key) | CorePanels | `/api/test/google` |
-| Qdrant | `QdrantMemoryService` | gRPC | `qdrant.host`, `qdrant.port` | CorePanels | `/api/test/qdrant` |
-| TTS | `TTSService` | HTTP REST (urllib) | Google API key | — | — |
-| STT | `STTService` | HTTP REST (urllib) | Google API key | — | — |
-| MCP Servers | stdio subprocess | stdio | Dynamic config | MCPPanel | — |
+| Home Assistant | `HomeAssistantRESTClient` + WS client | HTTP REST + WebSocket | `integrations.home_assistant.url`, credential: `ha_token` | `HomeAssistantPanel` | `/admin/api/test/home-assistant` |
+| Overseerr | `OverseerrClient` | HTTP REST | `integrations.overseerr.url`, credential: `overseerr_api_key` | `OverseerrPanel` | `/admin/api/test/overseerr` |
+| Lidarr | `LidarrClient` | HTTP REST | `integrations.lidarr.url`, credential: `lidarr_api_key` | `LidarrPanel` | `/admin/api/test/lidarr` |
+| Picnic | `PicnicClientWrapper` | HTTP REST (python_picnic_api2) | credentials: `picnic_username`, `picnic_password`, `picnic_country_code`, `picnic_auth_token` (cached) | `PicnicPanel` | `/admin/api/test/picnic` |
+| Jira | `atlassian.Jira` | HTTP REST (atlassian lib) | `integrations.jira.url`, `jira.email`, credential: `jira_api_token` | `JiraPanel` | `/admin/api/test/jira` |
+| Gmail | `GmailManager` | Google API (OAuth) | credential: `gmail_token_<account>` (JSON) | `GmailPanel` | `/admin/api/test/gmail` |
+| Google Calendar | `CalendarManager` | Google API (SA/OAuth) | credential: `calendar_token` (JSON) | `CalendarPanel` | `/admin/api/test/calendar` |
+| ntfy | `NtfyClient` + `NtfySubscriber` | async HTTP (httpx) + SSE | `integrations.ntfy.url`, `ntfy.topic`, credential: `ntfy_token` | `NtfyPanel` | `/admin/api/test/ntfy` |
+| GitHub App | `GitHubAppClient` | HTTP REST (JWT auth) | `integrations.github.app_id`, `github.installation_id`, credential: `github_app_private_key` | `GitHubAppPanel` | `/admin/api/test/github` |
+| Nomad | `NomadClient` | async HTTP (httpx) | `integrations.nomad.addr`, credential: `nomad_token` | `NomadPanel` | `/admin/api/test/nomad` |
+| Alertmanager | (pipeline — no client) | Inbound webhook | `integrations.alertmanager.*` | `AlertmanagerPanel` | — |
+| Claude Code | subprocess CLI | subprocess | credential: `claude_code_oauth_token` | `ClaudeCodePanel` | `/admin/api/test/claude-code` |
+| Google API | — | — | credential store (API key) | `GooglePanel` | `/admin/api/test/google` |
+| Qdrant | `QdrantMemoryService` | gRPC/HTTP | `vector_db.host`, `vector_db.port`, `vector_db.collection`, `vector_db.url`, `vector_db.api_key` | `QdrantPanel` | `/admin/api/test/qdrant` |
+| PostgreSQL | shared pool | libpq | `database.*` in `config.yaml` | `PostgresqlPanel` | `/admin/api/test/postgres` |
+| TTS | `TTSService` | HTTP REST (urllib) | Google API key | `TTSPanel` | — |
+| STT | `STTService` | HTTP REST (urllib) | Google API key | `STTPanel` | — |
+| Ollama | `OllamaClient` | HTTP REST | `integrations.ollama.base_url` | (integrated into model pickers) | — |
+| YouTube Data API | `YouTubeClient` | HTTP REST | credential: `youtube_api_key` | `YouTubePanel` | `/admin/api/test/youtube` |
+| CuriosityStream | `CuriosityStreamClient` | HTTP REST | credential: `curiositystream_api_key` | (in `YouTubePanel` or separate) | — |
+| Kideo | `KideoClient` | HTTP REST | `integrations.kideo.*` | `KideoPanel` | `/admin/api/test/kideo` |
+| MCP Servers | stdio subprocess | stdio | Dynamic config in `config:mcp_servers` | `MCPServersPanel` | — |
 
 ## Integration Details
 
@@ -38,33 +45,41 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
 
 - **Client**: `tools/homeassistant/ha_rest_client.py` — `HomeAssistantRESTClient`
 - **WebSocket**: `tools/homeassistant/ha_websocket_client.py` — async WS at `wss://host/api/websocket`
+- **State cache**: `tools/homeassistant/ha_state_cache.py` — in-memory snapshot for `search_ha_entities`
 - **Auth**: Long-lived access token in `Authorization: Bearer` header
-- **Config**: `HA_URL`, `HA_TOKEN` env vars or DB config
 - **Singletons**: Separate for REST (`ha_client_singleton.py`) and WS (`ha_ws_singleton.py`)
 - **Health check**: `GET /api/` → expects "API running." message
 - **Dashboard CRUD**: WebSocket only (Lovelace API not available via REST)
+- **Direct REST endpoints**: `web/api/ha.py` exposes `GET /api/ha/state/{entity_id}` + `POST /api/ha/service` for frontend device buttons (bypasses agent)
 
 ### Overseerr
 
 - **Client**: `tools/overseerr/overseerr_client.py` — `OverseerrClient`
 - **Auth**: API key in `X-Api-Key` header
-- **Config**: `OVERSEERR_URL`, `OVERSEERR_API_KEY` env vars or DB config
 - **Health check**: `GET /api/v1/status` → returns version info
 - **Methods**: `search()`, `get_movie()`, `get_tv()`, `create_request()`, `list_requests()`
+- **TMDB poster helper**: `tmdb_poster_url()` — used by Casa's `show_media_card` and by `web/api/media.py`
+- **Direct REST**: `web/api/media.py` wraps Overseerr for `/api/media/search`, `/api/media/{tmdb_id}`, `/api/media/request` — no agent LLM call needed for the quick-action frontend buttons
+
+### Lidarr (new 2026-03-23)
+
+- **Client**: `tools/lidarr/lidarr_client.py` — `LidarrClient`
+- **Auth**: API key in `X-Api-Key` header
+- **Config**: `integrations.lidarr.url`, credential `lidarr_api_key`
+- **Methods**: `search_artist()`, `search_album()`, `add_artist()`, `add_album()`, `list_quality_profiles()`
+- **Wired on**: Casa agent
 
 ### Picnic
 
 - **Client**: `tools/picnic/picnic_client.py` — `PicnicClientWrapper` (wraps `python_picnic_api2.PicnicAPI`)
 - **Auth**: Username/password → cached auth token in credential store (`picnic_auth_token`)
-- **Config**: `PICNIC_USERNAME`, `PICNIC_PASSWORD` env vars or DB config
-- **Country code**: `picnic_country_code` (default "DE")
+- **Country code**: `picnic_country_code` (default `"DE"`)
 - **Health check**: `get_cart()` during initialization
 
 ### Jira
 
 - **Client**: `tools/jira/jira_client.py` — uses `atlassian.Jira` library directly
 - **Auth**: Email + API token (Jira Cloud basic auth)
-- **Config**: `JIRA_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` env vars or DB config
 - **Health check**: `myself()` → verifies auth + returns display name
 
 ### Gmail
@@ -88,9 +103,9 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
 ### ntfy
 
 - **Client**: `tools/ntfy/ntfy_client.py` — `NtfyClient` (async httpx, 10s timeout)
+- **Subscriber**: `tools/ntfy/ntfy_subscriber.py` — SSE listener for inbound notifications; writes to the `notifications` table
 - **Auth**: Optional bearer token in `Authorization` header
 - **Config**: `NTFY_URL` (default `https://ntfy.sh`), `NTFY_TOPIC`, `NTFY_TOKEN`
-- **Subscriber**: `ntfy_subscriber.py` — SSE listener for incoming notifications
 - **Priorities**: min, low, default, high, max
 - **Health check**: Sends test notification
 
@@ -98,26 +113,43 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
 
 - **Client**: `tools/github/github_app_client.py` — `GitHubAppClient`
 - **Auth**: JWT (10 min TTL) → installation token (1 hour TTL, cached)
-- **Config**: `GITHUB_APP_ID`, `GITHUB_INSTALLATION_ID`, credential: `github_app_private_key` (PEM)
 - **Git operations**: subprocess with token in URL auth
 - **Methods**: `clone_repo()`, `push_changes()`
+- **Worker usage**: Workspace workers load DB config on startup to reach GitHub credentials (fix in commit `2694efa`)
 
 ### Nomad
 
 - **Client**: `tools/nomad/nomad_client.py` — `NomadClient` (async httpx, 15s timeout)
 - **Auth**: Optional `X-Nomad-Token` header (ACL token)
-- **Config**: `NOMAD_ADDR`, `NOMAD_TOKEN`, `NOMAD_NAMESPACE` (default "default")
-- **Query params**: Auto-include namespace on all requests
+- **Service discovery**: `list_services(name)`, `find_service_by_tag(name, tag)` — used for worker discovery by `WorkspaceProxy`. Switched from Consul → Nomad service discovery in commit `ccfeeb3`, with Consul fallback in `2811156`.
+- **Query params**: Auto-include namespace on all requests (default `"default"`)
+
+### Alertmanager
+
+- **Pipeline**: `tools/alertmanager/processor.py` — `process_alert_from_payload()`
+- **ntfy bridge**: `tools/alertmanager/ntfy_handler.py` — relays alerts to ntfy
+- **Inbound endpoint**: `POST /api/alerts/webhook`
+- **Remediation**: auto-applies policies from `alert_remediation_policies` (action, max_auto_remediations, window_minutes, enabled). Axel is consulted for complex remediations.
 
 ### Claude Code
 
-- **Client**: `tools/claude_code/claude_code_client.py` — subprocess wrapper (not a traditional client)
+- **Client**: `tools/claude_code/claude_code_client.py` — subprocess wrapper
 - **Auth types**:
   - API key (`sk-ant-*`) → `ANTHROPIC_API_KEY` env var
   - OAuth token → written to `~/.claude/remote/.oauth_token`
 - **Credential**: `claude_code_oauth_token` in credential store
-- **Onboarding**: Writes `hasCompletedOnboarding` + trust dialog settings before each run
+- **Onboarding**: Writes `hasCompletedOnboarding` + trust dialog settings before each run (bypasses interactive prompts, see commit `76b86b0`)
+- **Session persistence**: Last session ID stored on `coder_workspaces.last_session_id` so `--resume` works across container restarts (`1b3b29c`)
 - **Modes**: plan (`--print`, read-only), execute (`--print --output-format stream-json`)
+
+### YouTube / CuriosityStream / Kideo (new 2026-04-12)
+
+- **YouTube Data API**: `tools/youtube/youtube_client.py`
+- **CuriosityStream**: `tools/youtube/curiositystream_client.py`
+- **Kideo (internal video library)**: `tools/youtube/kideo_client.py`
+- **Tag generation**: `tools/youtube/tag_generator.py` — uses transcript + description via Gemini for AI tagging
+- **Shorts filter**: Rejects YouTube Shorts at search/ingest time (`5051c45`)
+- **Wired on**: `kidsvid` agent
 
 ### TTS (Text-to-Speech)
 
@@ -126,7 +158,6 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
 - **API**: `https://texttospeech.googleapis.com/v1/text:synthesize` (v1beta1 for Chirp3-HD voices)
 - **Cache**: In-memory LRU
 - **Output**: MP3 bytes
-- **Singleton**: `create_instance()` / `get_instance()`
 
 ### STT (Speech-to-Text)
 
@@ -135,44 +166,32 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py:30-58`
 - **API**: `https://speech.googleapis.com/v1/speech:recognize`
 - **Input**: WEBM/Opus at 48000 Hz (browser MediaRecorder format)
 - **Model**: `latest_long`
-- **Singleton**: `create_instance()` / `get_instance()`
 
 ### MCP Servers
 
-- **Location**: `tools/mcp/mcp_tools.py` (re-export hub)
-- **Clients**: `context7_client.py`, `mcp_fileserver_client.py`, `mcp_stdio_client.py`
+- **Location**: `tools/mcp/mcp_tools.py` (re-export hub), `tools/mcp/dynamic_tools_loader.py`
 - **Connection**: stdio subprocess
-- **Tools**: Dynamically loaded, variable count
+- **Config**: `config:mcp_servers` DB entry (list of `{name, command, args, env}`)
+- **Tools**: Dynamically loaded, variable count — attached to axel only
+
+### Ollama (local LLM)
+
+- **Client**: `tools/ollama/ollama_client.py` — `OllamaClient` (admin model management)
+- **Models**: Prefix `ollama_chat/<model>` (e.g. `ollama_chat/mistral-small3.2`) — wrapped in `LiteLlm` by `config_manager.resolve_model()`
+- **Limitations**: `search_agent` (google_search) and `code_execution_agent` (BuiltInCodeExecutor) require Gemini — will NOT work with Ollama
 
 ## Admin UI Panels
 
-| Panel File | Integrations |
-|-----------|--------------|
-| `CorePanels.tsx` | Google API key, Qdrant |
-| `ConnectionPanels.tsx` | Home Assistant, Jira, Overseerr |
-| `SecurityPanels.tsx` | Gmail (OAuth), Google Calendar (OAuth) |
-| `NotificationPanels.tsx` | ntfy |
-| `MediaPanels.tsx` | Picnic |
-| `DeveloperPanels.tsx` | GitHub App, Claude Code |
-| `InfrastructurePanels.tsx` | Nomad |
-| `MCPPanel.tsx` | MCP servers |
+See `specs/web.md` § Admin Panel Modules for the full flat list. Location: `radbot/web/frontend/src/components/admin/panels/`. Registered in `pages/AdminPage.tsx` via `NAV_ITEMS` + `PANEL_MAP`.
 
-Location: `radbot/web/frontend/src/components/admin/panels/`
+## Hot-Reload Registry
 
-## Hot-Reload
+When the admin UI saves config via `PUT /admin/api/config/{section}`, `_INTEGRATION_RESET_REGISTRY` in `web/api/admin.py` is consulted to reset affected singleton clients:
 
-When the admin UI saves config via `PUT /api/config/{section}`, all singleton clients are reset:
-
-```python
-# admin.py — save_config_section()
-if section == "integrations":
-    reset_overseerr_client()
-    reset_ha_client()
-    reset_ha_ws_client()
-    reset_ntfy_client()
-    reset_picnic_client()
-    reset_github_client()
-    reset_nomad_client()
+```
+reset_overseerr_client, reset_lidarr_client, reset_ha_client, reset_ha_ws_client,
+reset_ntfy_client, reset_picnic_client, reset_github_client, reset_nomad_client,
+reset_jira_client, reset_kideo_client, reset_youtube_client, ...
 ```
 
 Next tool call on any agent triggers re-initialization with fresh config from DB.
@@ -183,7 +202,10 @@ Next tool call on any agent triggers re-initialization with fresh config from DB
 |------|---------|
 | `tools/{service}/{service}_client.py` | Integration client implementation |
 | `tools/{service}/{service}_tools.py` | FunctionTool wrappers |
+| `tools/shared/config_helper.py` | `get_integration_config()` resolver (preferred) |
+| `tools/shared/client_utils.py` | `client_or_error()` singleton helper |
 | `config/config_loader.py` | `get_integrations_config()` — merged file+DB config |
 | `credentials/store.py` | Encrypted credential store |
-| `web/api/admin.py` | Test endpoints, hot-reload, status aggregation |
+| `web/api/admin.py` | Test endpoints, hot-reload registry, status aggregation |
+| `web/api/media.py` + `web/api/ha.py` | Direct-action REST endpoints (bypass agent) |
 | `web/frontend/src/components/admin/panels/` | React admin panels |

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -2,7 +2,7 @@
 
 ## PostgreSQL
 
-Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_cursor()`).
+Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_cursor()`, `get_db_connection()`).
 
 ### Main DB Tables
 
@@ -11,39 +11,50 @@ Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_
 | `tasks` | `tools/todo/db/schema.py` | `task_id` (UUID), `project_id`, `title`, `status` (backlog/inprogress/done), `related_info` (JSONB) |
 | `projects` | `tools/todo/db/schema.py` | `project_id` (UUID), `name` (UNIQUE) |
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
+| `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
 | `webhook_definitions` | `tools/webhooks/db.py` | `webhook_id` (UUID), `name` (UNIQUE), `path_suffix` (UNIQUE), `prompt_template`, `secret` |
-| `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `radbot_credentials` | `credentials/store.py` | `name` (PK), `encrypted_value`, `salt`, `credential_type` |
 | `coder_workspaces` | `tools/claude_code/db.py` | `workspace_id` (UUID), `owner`, `repo`, `branch`, `local_path`, `status`, `last_session_id`, `name`, `description` |
-| `alert_events` | `tools/alertmanager/db.py` | `alert_id` (UUID), `fingerprint`, `alertname`, `status`, `severity`, `instance`, `raw_payload` (JSONB) |
+| `alert_events` | `tools/alertmanager/db.py` | `alert_id` (UUID), `fingerprint`, `alertname`, `status`, `severity`, `instance`, `raw_payload` (JSONB), `remediation_action`, `remediation_result` |
 | `alert_remediation_policies` | `tools/alertmanager/db.py` | `policy_id` (UUID), `alertname_pattern`, `action`, `max_auto_remediations`, `window_minutes`, `enabled` |
+| `notifications` | `tools/notifications/db.py` | `notification_id` (UUID), `type` (`scheduled_task`/`reminder`/`alert`/`ntfy_outbound`/`ntfy_inbound`), `title`, `message`, `source_id`, `session_id`, `priority`, `read` (BOOLEAN), `metadata` (JSONB), `created_at` |
+| `llm_usage_log` | `telemetry/db.py` | `id`, `created_at`, `agent_name`, `model`, `prompt_tokens`, `cached_tokens`, `output_tokens`, `cost_usd`, `cost_without_cache_usd`, `session_id` (nullable), `run_label` |
 | `session_workers` | `worker/db.py` | `session_id` (UUID PK), `nomad_job_id`, `worker_url`, `status` (starting/healthy/stopped), `image_tag` |
 | `workspace_workers` | `worker/db.py` | `workspace_id` (UUID PK), `nomad_job_id`, `worker_url`, `status` (starting/healthy/stopped), `image_tag` |
 
 ### Chat History DB (separate pool)
 
-Uses `radbot_chathistory` schema with its own pool in `web/db/connection.py`.
+Uses the `radbot_chathistory` database with its own pool in `web/db/connection.py`.
 
 | Table | Module | Key columns |
 |-------|--------|-------------|
 | `chat_sessions` | `web/db/chat_operations.py` | `session_id` (UUID), `name`, `description`, `user_id`, `preview`, `is_active` |
 | `chat_messages` | `web/db/chat_operations.py` | `message_id` (UUID), `session_id`, `role`, `content`, `agent_name`, `metadata` (JSONB) |
 
+### Indexes Worth Knowing
+
+| Table | Index | Purpose |
+|-------|-------|---------|
+| `notifications` | `idx_notifications_type`, `idx_notifications_unread` (partial on `read=FALSE`), `idx_notifications_created (DESC)` | Feed filtering |
+| `llm_usage_log` | `idx_llm_usage_log_created (created_at DESC)`, `idx_llm_usage_log_label` | Rolling cost queries + session filters |
+
 ### Schema Init
 
-All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS`. Called from:
-- `agent_tools_setup.py:setup_before_agent_call()` — agent-side tables
-- `web/app.py:initialize_app_startup()` — web-side tables
+All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS` (or the `init_table_schema()` helper in `tools/shared/db_schema.py`). Called from:
+
+- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, notifications, llm_usage_log, alerts)
+- `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history)
+- `worker/__main__.py` — worker-side schema init (calls directly, not via ADK callback)
 
 ## Qdrant
 
 Semantic memory via `radbot/memory/enhanced_memory/`.
 
-- **Collection**: `radbot` (or `radbot_dev` when `RADBOT_ENV=dev`)
+- **Collection**: `radbot_memories` (prod) / `radbot_dev` (when `RADBOT_ENV=dev`)
 - **Embedding model**: `gemini-embedding-001` with `output_dimensionality=768`
 - **Scoping**: Per-agent memory via `source_agent` tag (see `create_agent_memory_tools()`)
-- **User ID**: Fixed `"web_user"` across all sessions
+- **User ID**: Fixed `"web_user"` across all sessions (single-user system)
 
 ## Credential Store
 
@@ -51,4 +62,37 @@ Semantic memory via `radbot/memory/enhanced_memory/`.
 
 - Key: `RADBOT_CREDENTIAL_KEY` env var
 - Access: `get_credential_store().get("key_name")`
-- Admin UI: `/admin/` manages credentials
+- Admin UI: `/admin/` manages credentials + `config:<section>` entries
+
+### Known Credential Keys (non-exhaustive)
+
+| Key | Used by |
+|-----|---------|
+| `overseerr_api_key`, `lidarr_api_key` | Casa integrations |
+| `ha_token` | Home Assistant |
+| `picnic_username`, `picnic_password`, `picnic_country_code`, `picnic_auth_token` | Picnic |
+| `jira_api_token`, `jira_email` | Jira |
+| `gmail_token_<account>`, `calendar_token` | Google OAuth tokens (JSON) |
+| `ntfy_token`, `ntfy_topic` | ntfy.sh |
+| `github_app_private_key` | GitHub App |
+| `nomad_token` | Nomad ACL |
+| `claude_code_oauth_token` | Claude Code CLI |
+| `youtube_api_key`, `curiositystream_api_key`, `kideo_*` | kidsvid integrations |
+| `postgres_pass` | Bootstrap-templated to worker jobs |
+
+## Two Worker Tables (2026-03-22/23)
+
+Commits `4719880` + `f988aca` introduced two distinct worker kinds:
+
+- **`session_workers`** — chat-session workers (keyed by `session_id`). Not used for routing chat anymore (see `specs/web.md`), but schema retained for historical/backward-compat.
+- **`workspace_workers`** — terminal workspace workers (keyed by `workspace_id`). Used when a user opens a terminal session for a cloned workspace. Each workspace gets a persistent Nomad service job, proxied by `WorkspaceProxy` in `web/api/terminal_proxy.py`.
+
+Operations on both tables: `upsert_worker`, `get_worker`, `update_worker_status`, `touch_worker`, `list_active_workers`, `count_active_workers`, `delete_worker`.
+
+## Schema Drift / Migrations
+
+No formal migration tool — all schemas use `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` idempotently on startup. Schema changes should:
+
+1. Update the table's `init_*_schema()` with `IF NOT EXISTS` clauses for new columns
+2. Guard reads against missing columns during the migration window
+3. Update this spec

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -2,32 +2,39 @@
 
 ## Architecture
 
-All agent tools are `google.adk.tools.FunctionTool` wrappers around plain Python functions. Tools return `{"status": "success/error", ...}` dicts. Each tool module exports an `ALL_TOOLS` or named list (e.g., `HA_TOOLS`, `SCHEDULER_TOOLS`) for registration in agent factories.
+All agent tools are `google.adk.tools.FunctionTool` wrappers around plain Python functions. Tools return `{"status": "success/error", ...}` dicts. Each tool module exports an `ALL_TOOLS` or named list (e.g., `HA_DASHBOARD_TOOLS`, `SCHEDULER_TOOLS`, `CARD_TOOLS`) for registration in agent factories.
 
-Non-tool services (TTS, STT, ntfy) expose REST endpoints only — they are not registered as agent FunctionTools.
+Non-tool services (TTS, STT, ntfy) expose REST endpoints only — they are not registered as agent FunctionTools. A new class of **card-rendering tools** exists: they return pre-formatted ` ```radbot:<kind> ` fenced JSON blocks that the agent includes verbatim in its reply, which the frontend parses into UI components.
 
 ## Tool Inventory
 
 | Module | Count | Agent | Tool Names |
 |--------|-------|-------|------------|
 | `tools/basic/` | 1 | planner | `get_current_time` |
-| `tools/memory/` | 2/agent | all | `search_agent_memory`, `store_agent_memory` |
-| `tools/todo/api/` | 8 | tracker | `add_task`, `complete_task`, `remove_task`, `list_projects`, `list_project_tasks`, `list_all_tasks`, `update_task`, `update_project` |
+| `tools/memory/` | 2/agent | all | `search_agent_memory`, `store_agent_memory` (scoped per agent) |
+| `tools/todo/` | 8 | tracker | `add_task`, `complete_task`, `remove_task`, `list_projects`, `list_project_tasks`, `list_all_tasks`, `update_task`, `update_project` |
 | `tools/calendar/` | 5 | planner | `list_calendar_events`, `create_calendar_event`, `update_calendar_event`, `delete_calendar_event`, `check_calendar_availability` |
 | `tools/gmail/` | 4 | comms | `list_emails`, `search_emails`, `get_email`, `list_gmail_accounts` |
 | `tools/homeassistant/` (REST) | 6 | casa | `list_ha_entities`, `get_ha_entity_state`, `turn_on_ha_entity`, `turn_off_ha_entity`, `toggle_ha_entity`, `search_ha_entities` |
-| `tools/homeassistant/` (Dashboard) | 6 | casa | `list_ha_dashboards`, `get_ha_dashboard_config`, `create_ha_dashboard`, `update_ha_dashboard`, `delete_ha_dashboard`, `save_ha_dashboard_config` |
+| `tools/homeassistant/` (Dashboard WS) | 6 | casa | `list_ha_dashboards`, `get_ha_dashboard_config`, `create_ha_dashboard`, `update_ha_dashboard`, `delete_ha_dashboard`, `save_ha_dashboard_config` |
 | `tools/scheduler/` | 3 | planner | `create_scheduled_task`, `list_scheduled_tasks`, `delete_scheduled_task` |
 | `tools/reminders/` | 3 | planner | `create_reminder`, `list_reminders`, `delete_reminder` |
 | `tools/webhooks/` | 3 | tracker | `create_webhook`, `list_webhooks`, `delete_webhook` |
 | `tools/overseerr/` | 4 | casa | `search_overseerr_media`, `get_overseerr_media_details`, `request_overseerr_media`, `list_overseerr_requests` |
-| `tools/picnic/` | 10 | casa | `search_picnic_product`, `get_picnic_cart`, `add_to_picnic_cart`, `remove_from_picnic_cart`, `clear_picnic_cart`, `get_picnic_delivery_slots`, `set_picnic_delivery_slot`, `submit_shopping_list_to_picnic`, `get_picnic_order_history`, `get_picnic_delivery_details` |
+| `tools/lidarr/` | 5 | casa | `search_lidarr_artist`, `search_lidarr_album`, `add_lidarr_artist`, `add_lidarr_album`, `list_lidarr_quality_profiles` |
+| `tools/picnic/` | 12 | casa | `search_picnic_product`, `get_picnic_cart`, `add_to_picnic_cart`, `remove_from_picnic_cart`, `clear_picnic_cart`, `get_picnic_delivery_slots`, `set_picnic_delivery_slot`, `submit_shopping_list_to_picnic`, `get_picnic_lists`, `get_picnic_list_details`, `get_picnic_order_history`, `get_picnic_delivery_details` |
 | `tools/jira/` | 6 | comms | `list_my_jira_issues`, `get_jira_issue`, `get_issue_transitions`, `transition_jira_issue`, `add_jira_comment`, `search_jira_issues` |
-| `tools/shell/` | 1 | axel | `execute_shell_command` |
+| `tools/shell/` | 1 | axel | `execute_shell_command` (via `get_shell_tool()`) |
 | `tools/claude_code/` | 6 | axel | `clone_repository`, `claude_code_plan`, `claude_code_continue`, `claude_code_execute`, `commit_and_push`, `list_workspaces` |
 | `tools/nomad/` | 7 | axel | `list_nomad_jobs`, `get_nomad_job_status`, `get_nomad_allocation_logs`, `restart_nomad_allocation`, `plan_nomad_job_update`, `submit_nomad_job_update`, `check_nomad_service_health` |
+| `tools/youtube/` (YouTube) | 3 | kidsvid | `search_youtube_videos`, `get_youtube_video_details`, `get_youtube_channel_info` |
+| `tools/youtube/` (CuriosityStream) | 2 | kidsvid | `search_curiositystream`, `list_curiositystream_categories` |
+| `tools/youtube/` (Kideo) | 10 | kidsvid | `add_video_to_kideo`, `add_videos_to_kideo_batch`, `list_kideo_collections`, `create_kideo_collection`, `generate_video_tags`, `set_kideo_video_tags`, `get_kideo_popular_videos`, `get_kideo_tag_stats`, `get_kideo_channel_stats`, `retag_untagged_kideo_videos` |
+| `tools/shared/card_protocol.py` (cards) | 3 | casa | `show_media_card`, `show_season_breakdown`, `show_ha_device_card` |
+| Axel execution tools | 4 | axel | `code_execution_tool`, `run_tests`, `validate_code`, `generate_documentation` |
+| `load_artifacts` (ADK) | 1 | axel | built-in |
 
-**Total**: ~68 FunctionTools + variable MCP tools + 2 ADK built-ins
+**Total**: ~105 FunctionTools + variable MCP tools + 2 ADK built-ins (`google_search`, `BuiltInCodeExecutor`).
 
 ## Module Details
 
@@ -63,138 +70,209 @@ Global variants (`search_past_conversations`, `store_important_information`) exi
 
 ### calendar — `tools/calendar/calendar_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_calendar_events` | `calendar_id`, `max_results`, `query`, `days_ahead`, `is_workspace` | List upcoming events |
-| `create_calendar_event` | `summary`, `start_time`, `end_time`, `description`, `location`, `attendees`, `calendar_id`, `timezone`, `is_workspace` | Create event |
-| `update_calendar_event` | `event_id`, `summary`, `start_time`, `end_time`, `description`, `location`, `attendees`, `calendar_id`, `timezone`, `is_workspace` | Update event |
-| `delete_calendar_event` | `event_id`, `calendar_id`, `is_workspace` | Delete event |
-| `check_calendar_availability` | `calendar_ids`, `days_ahead`, `is_workspace` | Check free/busy times |
+| Tool | Parameters |
+|------|-----------|
+| `list_calendar_events` | `calendar_id`, `max_results`, `query`, `days_ahead`, `is_workspace` |
+| `create_calendar_event` | `summary`, `start_time`, `end_time`, `description`, `location`, `attendees`, `calendar_id`, `timezone`, `is_workspace` |
+| `update_calendar_event` | `event_id`, `summary`, `start_time`, `end_time`, `description`, `location`, `attendees`, `calendar_id`, `timezone`, `is_workspace` |
+| `delete_calendar_event` | `event_id`, `calendar_id`, `is_workspace` |
+| `check_calendar_availability` | `calendar_ids`, `days_ahead`, `is_workspace` |
 
 ### gmail — `tools/gmail/gmail_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_emails` | `max_results`, `label`, `account` | List recent emails |
-| `search_emails` | `query`, `max_results`, `account` | Search with Gmail query syntax |
-| `get_email` | `message_id`, `account` | Get full email content |
-| `list_gmail_accounts` | — | List configured accounts |
+| Tool | Parameters |
+|------|-----------|
+| `list_emails` | `max_results`, `label`, `account` |
+| `search_emails` | `query`, `max_results`, `account` |
+| `get_email` | `message_id`, `account` |
+| `list_gmail_accounts` | — |
 
-### homeassistant — `tools/homeassistant/ha_tools_impl.py`
+### homeassistant (REST) — `tools/homeassistant/ha_tools_impl.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_ha_entities` | — | List all entities |
-| `get_ha_entity_state` | `entity_id` | Get entity state + attributes |
-| `turn_on_ha_entity` | `entity_id` | Turn on device |
-| `turn_off_ha_entity` | `entity_id` | Turn off device |
-| `toggle_ha_entity` | `entity_id` | Toggle on/off |
-| `search_ha_entities` | `search_term`, `domain_filter` | Search by name/ID |
+| Tool | Parameters |
+|------|-----------|
+| `list_ha_entities` | — |
+| `get_ha_entity_state` | `entity_id` |
+| `turn_on_ha_entity` | `entity_id` |
+| `turn_off_ha_entity` | `entity_id` |
+| `toggle_ha_entity` | `entity_id` |
+| `search_ha_entities` | `search_term`, `domain_filter` |
 
-### homeassistant dashboard — `tools/homeassistant/ha_dashboard_tools.py`
+### homeassistant (Dashboard) — `tools/homeassistant/ha_dashboard_tools.py`
 
 Uses WebSocket client (`ha_websocket_client.py`) for Lovelace CRUD.
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_ha_dashboards` | — | List all Lovelace dashboards |
-| `get_ha_dashboard_config` | `url_path` | Get dashboard views/cards config |
-| `create_ha_dashboard` | `url_path`, `title`, `icon`, `require_admin` | Create new dashboard |
-| `update_ha_dashboard` | `dashboard_id`, `title`, `icon`, `require_admin` | Update dashboard metadata |
-| `delete_ha_dashboard` | `dashboard_id` | Delete dashboard |
-| `save_ha_dashboard_config` | `config`, `url_path` | Save full Lovelace config JSON |
+| Tool | Parameters |
+|------|-----------|
+| `list_ha_dashboards` | — |
+| `get_ha_dashboard_config` | `url_path` |
+| `create_ha_dashboard` | `url_path`, `title`, `icon`, `require_admin` |
+| `update_ha_dashboard` | `dashboard_id`, `title`, `icon`, `require_admin` |
+| `delete_ha_dashboard` | `dashboard_id` |
+| `save_ha_dashboard_config` | `config`, `url_path` |
 
 ### scheduler — `tools/scheduler/schedule_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `create_scheduled_task` | `name`, `cron_expression`, `prompt`, `description` | Create recurring cron task |
-| `list_scheduled_tasks` | — | List all scheduled tasks |
-| `delete_scheduled_task` | `task_id` | Delete scheduled task |
+| Tool | Parameters |
+|------|-----------|
+| `create_scheduled_task` | `name`, `cron_expression`, `prompt`, `description` |
+| `list_scheduled_tasks` | — |
+| `delete_scheduled_task` | `task_id` |
 
 ### reminders — `tools/reminders/reminder_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `create_reminder` | `message`, `remind_at`, `delay_minutes`, `timezone_name` | Set one-shot reminder |
-| `list_reminders` | `status` (pending/completed/cancelled/all) | List reminders |
-| `delete_reminder` | `reminder_id` | Cancel/delete reminder |
+| Tool | Parameters |
+|------|-----------|
+| `create_reminder` | `message`, `remind_at`, `delay_minutes`, `timezone_name` |
+| `list_reminders` | `status` (pending/completed/cancelled/all) |
+| `delete_reminder` | `reminder_id` |
 
 ### webhooks — `tools/webhooks/webhook_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `create_webhook` | `name`, `path_suffix`, `prompt_template`, `secret` | Register webhook endpoint |
-| `list_webhooks` | — | List registered webhooks |
-| `delete_webhook` | `webhook_id` | Delete webhook |
+| Tool | Parameters |
+|------|-----------|
+| `create_webhook` | `name`, `path_suffix`, `prompt_template`, `secret` |
+| `list_webhooks` | — |
+| `delete_webhook` | `webhook_id` |
 
 ### overseerr — `tools/overseerr/overseerr_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `search_overseerr_media` | `query`, `page` | Search movies/TV shows |
-| `get_overseerr_media_details` | `tmdb_id`, `media_type` | Get movie/TV details |
-| `request_overseerr_media` | `tmdb_id`, `media_type`, `seasons` | Request media download |
-| `list_overseerr_requests` | `max_results`, `filter_status` | List current requests |
+| Tool | Parameters |
+|------|-----------|
+| `search_overseerr_media` | `query`, `page` |
+| `get_overseerr_media_details` | `tmdb_id`, `media_type` |
+| `request_overseerr_media` | `tmdb_id`, `media_type`, `seasons` |
+| `list_overseerr_requests` | `max_results`, `filter_status` |
+
+### lidarr — `tools/lidarr/lidarr_tools.py`
+
+| Tool | Parameters |
+|------|-----------|
+| `search_lidarr_artist` | `query` |
+| `search_lidarr_album` | `query` |
+| `add_lidarr_artist` | `foreign_artist_id`, `quality_profile_id`, `root_folder_path`, `monitor` |
+| `add_lidarr_album` | `foreign_album_id`, `quality_profile_id`, `root_folder_path`, `monitor` |
+| `list_lidarr_quality_profiles` | — |
 
 ### picnic — `tools/picnic/picnic_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `search_picnic_product` | `query` | Search grocery catalog |
-| `get_picnic_cart` | — | View shopping cart |
-| `add_to_picnic_cart` | `product_id`, `count` | Add product to cart |
-| `remove_from_picnic_cart` | `product_id`, `count` | Remove from cart |
-| `clear_picnic_cart` | — | Clear all items |
-| `get_picnic_delivery_slots` | — | List available delivery times |
-| `set_picnic_delivery_slot` | `slot_id` | Place order (commits) |
-| `submit_shopping_list_to_picnic` | `project_name` | Add todo items to cart |
-| `get_picnic_order_history` | — | View past orders |
-| `get_picnic_delivery_details` | `delivery_id` | Get items in past order |
+| Tool | Parameters |
+|------|-----------|
+| `search_picnic_product` | `query` |
+| `get_picnic_cart` | — |
+| `add_to_picnic_cart` | `product_id`, `count` |
+| `remove_from_picnic_cart` | `product_id`, `count` |
+| `clear_picnic_cart` | — |
+| `get_picnic_delivery_slots` | — |
+| `set_picnic_delivery_slot` | `slot_id` |
+| `submit_shopping_list_to_picnic` | `project_name` |
+| `get_picnic_lists` | — |
+| `get_picnic_list_details` | `list_id` |
+| `get_picnic_order_history` | — |
+| `get_picnic_delivery_details` | `delivery_id` |
 
 ### jira — `tools/jira/jira_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_my_jira_issues` | `project`, `status`, `priority`, `max_results` | List assigned issues |
-| `get_jira_issue` | `issue_key` | Get issue details |
-| `get_issue_transitions` | `issue_key` | List valid status transitions |
-| `transition_jira_issue` | `issue_key`, `status_name` | Change issue status |
-| `add_jira_comment` | `issue_key`, `comment` | Add comment |
-| `search_jira_issues` | `jql`, `max_results` | Search with JQL |
+| Tool | Parameters |
+|------|-----------|
+| `list_my_jira_issues` | `project`, `status`, `priority`, `max_results` |
+| `get_jira_issue` | `issue_key` |
+| `get_issue_transitions` | `issue_key` |
+| `transition_jira_issue` | `issue_key`, `status_name` |
+| `add_jira_comment` | `issue_key`, `comment` |
+| `search_jira_issues` | `jql`, `max_results` |
 
 ### shell — `tools/shell/shell_tool.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `execute_shell_command` | `command`, `arguments`, `timeout` | Run shell command (allow-listed in strict mode) |
+| Tool | Parameters |
+|------|-----------|
+| `execute_shell_command` | `command`, `arguments`, `timeout` — allow-listed in strict mode |
 
 ### claude_code — `tools/claude_code/claude_code_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `clone_repository` | `owner`, `repo`, `branch` | Clone GitHub repo via GitHub App |
-| `claude_code_plan` | `prompt`, `work_folder`, `session_id` | Run Claude Code in plan-only mode |
-| `claude_code_continue` | `prompt`, `session_id`, `work_folder` | Continue planning with feedback |
-| `claude_code_execute` | `prompt`, `work_folder`, `session_id` | Execute approved plan |
-| `commit_and_push` | `work_folder`, `commit_message`, `branch` | Commit and push via GitHub App |
-| `list_workspaces` | — | List active Claude Code workspaces |
+| Tool | Parameters |
+|------|-----------|
+| `clone_repository` | `owner`, `repo`, `branch` |
+| `claude_code_plan` | `prompt`, `work_folder`, `session_id` |
+| `claude_code_continue` | `prompt`, `session_id`, `work_folder` |
+| `claude_code_execute` | `prompt`, `work_folder`, `session_id` |
+| `commit_and_push` | `work_folder`, `commit_message`, `branch` |
+| `list_workspaces` | — |
 
 ### nomad — `tools/nomad/nomad_tools.py`
 
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `list_nomad_jobs` | `prefix` | List Nomad jobs |
-| `get_nomad_job_status` | `job_id` | Job status + allocations |
-| `get_nomad_allocation_logs` | `job_id`, `task`, `log_type`, `lines` | Fetch allocation logs |
-| `restart_nomad_allocation` | `job_id`, `task` | Restart allocation |
-| `plan_nomad_job_update` | `job_file_path` | Plan job update (dry-run) |
-| `submit_nomad_job_update` | `job_file_path` | Submit job update |
-| `check_nomad_service_health` | `service_name` | Check service health |
+| Tool | Parameters |
+|------|-----------|
+| `list_nomad_jobs` | `prefix` |
+| `get_nomad_job_status` | `job_id` |
+| `get_nomad_allocation_logs` | `job_id`, `task`, `log_type`, `lines` |
+| `restart_nomad_allocation` | `job_id`, `task` |
+| `plan_nomad_job_update` | `job_file_path` |
+| `submit_nomad_job_update` | `job_file_path` |
+| `check_nomad_service_health` | `service_name` |
+
+### youtube — `tools/youtube/`
+
+Three client modules wired onto the kidsvid agent.
+
+**YouTube** (`youtube_tools.py`, `youtube_client.py`):
+
+| Tool | Parameters |
+|------|-----------|
+| `search_youtube_videos` | `query`, `max_results`, `safe_search` — blocks YouTube Shorts at ingest |
+| `get_youtube_video_details` | `video_id` |
+| `get_youtube_channel_info` | `channel_id` |
+
+**CuriosityStream** (`curiositystream_tools.py`, `curiositystream_client.py`):
+
+| Tool | Parameters |
+|------|-----------|
+| `search_curiositystream` | `query`, `max_results` |
+| `list_curiositystream_categories` | — |
+
+**Kideo library** (`kideo_tools.py`, `kideo_client.py`, `tag_generator.py`):
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `add_video_to_kideo` | `video_id`, `collection_id`, `tags` | Blocks Shorts |
+| `add_videos_to_kideo_batch` | `video_ids`, `collection_id` | Bulk ingest |
+| `list_kideo_collections` | — | |
+| `create_kideo_collection` | `name`, `description` | |
+| `generate_video_tags` | `video_id` | AI tags from transcript + description |
+| `set_kideo_video_tags` | `video_id`, `tags` | Overwrite tags |
+| `get_kideo_popular_videos` | `limit` | Analytics: play counts |
+| `get_kideo_tag_stats` | — | Tag usage stats |
+| `get_kideo_channel_stats` | `channel_id` | Per-channel analytics |
+| `retag_untagged_kideo_videos` | `batch_size` | Backfill AI tags |
+
+### card_protocol — `tools/shared/card_protocol.py`
+
+Emits ` ```radbot:<kind> ` fenced JSON blocks the agent includes verbatim in its reply. Frontend parses into UI components.
+
+Valid kinds: `media`, `seasons`, `ha-device`, `handoff`.
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `show_media_card` | `tmdb_id`, `media_type`, `title`, `year`, ... | Best-effort Overseerr poster lookup when `tmdb_id` + `media_type` known |
+| `show_season_breakdown` | `tmdb_id`, `title`, `seasons` (list) | Per-season progress/status |
+| `show_ha_device_card` | `entity_id`, `state`, `brightness_pct`, ... | Domain-inferred icon |
+
+`handoff` blocks are emitted server-side, not by agents — `session_runner.py` wraps every `agent_transfer` event as a `radbot:handoff` block (reflexive/duplicate transfers filtered).
+
+### execution tools — `agent/execution_agent/tools.py`
+
+Axel-specific (not a standalone module):
+
+| Tool | Purpose |
+|------|---------|
+| `code_execution_tool` | Runs Python code in a temp file via shell (30s timeout) |
+| `run_tests` | pytest runner |
+| `validate_code` | Syntax/lint validation |
+| `generate_documentation` | Docstring / README generation |
 
 ## MCP Tools
 
-Loaded dynamically on axel agent:
+Loaded dynamically on the axel agent only:
 
 - **Filesystem MCP**: `create_fileserver_toolset()` — file read/write via MCP stdio server
 - **Dynamic MCP**: `load_dynamic_mcp_tools()` — additional MCP servers from config
@@ -206,19 +284,23 @@ Tool count varies based on available MCP servers.
 | Tool | Agent | Type |
 |------|-------|------|
 | `google_search` | search_agent | Grounding tool (cannot mix with FunctionTools) |
-| `BuiltInCodeExecutor` | code_execution_agent, axel | Code executor (via `generate_content_config`) |
+| `BuiltInCodeExecutor` | code_execution_agent, axel | Code executor (via `generate_content_config` / `code_executor=`) |
 | `load_artifacts` | axel | ADK artifact loading |
 
 ## Non-Tool Services
 
-These expose REST endpoints but are not registered as agent FunctionTools:
+REST-only, not registered as agent FunctionTools:
 
 | Service | Class | Endpoint | Purpose |
 |---------|-------|----------|---------|
 | TTS | `TTSService` | `POST /api/tts/synthesize` | Google Cloud Text-to-Speech |
 | STT | `STTService` | `POST /api/stt/transcribe` | Google Cloud Speech-to-Text |
-| ntfy | `NtfyClient` | (push, no REST endpoint) | Push notifications via ntfy.sh |
+| ntfy | `NtfyClient` | (push + SSE subscriber, no REST endpoint) | Push notifications + inbound triggers |
 | Alertmanager | `process_alert_from_payload()` | `POST /api/alerts/webhook` | Alert ingestion + remediation pipeline |
+| Notifications | unified store | `GET/POST /api/notifications/*` | Cross-source notification feed (scheduled, reminder, alert, ntfy) |
+| Direct media actions | Overseerr wrapper | `GET/POST /api/media/*` | Non-agent media search + request |
+| Direct HA actions | HA REST wrapper | `GET/POST /api/ha/*` | Non-agent device state + service calls |
+| Per-session token stats | `llm_usage_log` aggregation | `GET /api/sessions/{id}/stats` | Session token/cost totals |
 
 ## Key Files
 
@@ -226,6 +308,11 @@ These expose REST endpoints but are not registered as agent FunctionTools:
 |------|---------|
 | `tools/{module}/{module}_tools.py` | Tool function definitions + FunctionTool wrapping |
 | `tools/{module}/__init__.py` | Exports `ALL_TOOLS` / named tool lists |
-| `tools/specialized/base_toolset.py` | Base class for domain toolsets |
-| `tools/specialized/*_toolset.py` | Toolset factories combining tools per agent |
 | `tools/memory/agent_memory_factory.py` | `create_agent_memory_tools()` scoped memory factory |
+| `tools/shared/card_protocol.py` | Card block formatting + `CARD_TOOLS` |
+| `tools/shared/config_helper.py` | `get_integration_config()` resolver |
+| `tools/shared/client_utils.py` | `client_or_error()`, singleton helpers |
+| `tools/shared/tool_decorator.py` | `@tool_error_handler` |
+| `tools/shared/retry.py` | `@retry_on_error` |
+| `tools/shared/db_schema.py` | `init_table_schema()` idempotent helper |
+| `agent/factory_utils.py` | `load_tools(module, attr, agent, label)` |

--- a/specs/web.md
+++ b/specs/web.md
@@ -6,90 +6,190 @@ FastAPI backend (`radbot/web/`) + React SPA frontend (`radbot/web/frontend/`).
 
 | Layer | Stack | Entry |
 |-------|-------|-------|
-| Backend | FastAPI, uvicorn | `python -m radbot.web` |
-| Frontend | React 18, Vite 6, TypeScript, Tailwind | `make dev-frontend` (dev) / `make build-frontend` (prod) |
+| Backend | FastAPI, uvicorn[standard], Python 3.14 | `python -m radbot.web` |
+| Frontend | React 18, Vite 6, TypeScript, Tailwind, Zustand | `make dev-frontend` (dev) / `make build-frontend` (prod) |
 | State | Zustand | `stores/app-store.ts` |
 | WS | native WebSocket + reconnect | `hooks/use-websocket.ts` |
 
 ## Session Modes
 
-| Mode | Config | Behavior |
-|------|--------|----------|
-| `local` (default) | `config:agent` → `session_mode = "local"` | In-process `SessionRunner` with `InMemorySessionService` |
-| `remote` | `config:agent` → `session_mode = "remote"` | `SessionProxy` spawns Nomad batch jobs, proxies via A2A |
+**Chat sessions always run in-process** via `SessionRunner` — the `session_mode` config setting no longer affects chat. Remote Nomad workers are now **only used for terminal/workspace sessions**, managed separately by `radbot/web/api/terminal.py` + `terminal_proxy.py`.
 
-### Local Mode
+This was changed in commit `12e4901` (2026-03-23) to fix `AttributeError` on session_service access when chat was incorrectly routed through `SessionProxy`.
 
 ```
-Browser ◄──WS──► FastAPI app.py ──► SessionRunner ──► ADK Runner ──► root_agent
+Chat:     Browser ◄──WS──► FastAPI app.py ──► SessionRunner ──► ADK Runner ──► root_agent
+Terminal: Browser ◄──WS──► FastAPI terminal.py ──► WorkspaceProxy ──► Nomad Worker (PTY only)
 ```
 
-- `SessionRunner` wraps ADK `Runner` + `InMemorySessionService`
-- Session state lost on restart; last 15 messages replayed from DB
-- `SessionManager` holds runners in `Dict[str, SessionRunner]`
-
-### Remote Mode
-
-```
-Browser ◄──WS──► FastAPI app.py ──► SessionProxy ──A2A──► Nomad Worker Job
-```
-
-- `SessionProxy` same interface as `SessionRunner` (duck-typed `process_message()`)
-- Worker holds full ADK state in memory as long as it runs
-- Falls back to local `SessionRunner` if Nomad unreachable or worker limit hit
-- See `specs/deployment.md` for worker lifecycle details
+See `specs/workers.md` for worker/terminal architecture.
 
 ### Key Session Files
 
 | File | Purpose |
 |------|---------|
-| `web/api/session/session_runner.py` | Local ADK runner, event processing, history loading |
-| `web/api/session/session_proxy.py` | Remote proxy: Nomad lifecycle + A2A communication |
-| `web/api/session/session_manager.py` | Runner registry, local/remote mode switching |
-| `web/api/session/dependencies.py` | FastAPI dep: creates Runner or Proxy based on mode |
-| `worker/history_loader.py` | Shared: loads chat DB history into ADK session |
+| `web/api/session/session_runner.py` | ADK runner, event processing, history loading, card/handoff block injection |
+| `web/api/session/session_manager.py` | Per-session `SessionRunner` registry with lock-based TOCTOU guard |
+| `web/api/session/dependencies.py` | FastAPI dep: `get_or_create_runner_for_session()` |
+| `web/api/session/memory_api.py` | `/api/memory` router for explicit memory store/recall |
+| `web/api/session_proxy.py` (legacy) | No longer used for chat — reference only |
+| `worker/history_loader.py` | Shared: seeds ADK session from chat DB history |
 
 ## WebSocket Protocol
 
-Endpoint: `GET /ws/{session_id}`
+Endpoint: `GET /ws/{session_id}` (handled in `radbot/web/app.py`)
 
 ### Client → Server
 
 ```json
-{"message": "user text"}           // chat message
-{"type": "heartbeat"}               // keep-alive
-{"type": "history_request", "limit": 50}  // request history
+{"message": "user text"}                    // chat message
+{"type": "heartbeat"}                        // keep-alive
+{"type": "history_request", "limit": 50}    // request replay
 ```
 
-### Server → Client
+### Server → Client (`type` values in use)
 
-```json
-{"type": "status", "content": "ready"}      // ready for input
-{"type": "status", "content": "thinking"}   // processing
-{"type": "events", "content": [...]}        // agent events
-{"type": "message", "content": "text"}      // final response
-```
+| Type | Payload | Purpose |
+|------|---------|---------|
+| `status` | `{content: "ready"|"thinking"|...}` | Ready / processing / done indicators |
+| `events` | `{content: [event, ...]}` | Streaming agent events (tool calls, transfers) |
+| `message` | `{content: "text"}` | Final assistant reply |
+| `model_response` | `{content, agent_name, ...}` | Model response event |
+| `heartbeat` | (empty) | Server echo |
+| `history` | `{session_id, messages: [...]}` | Replay of prior session messages |
+| `sync_response` | `{messages: [...]}` | Reply to sync request |
+| `system` | `{content: "..."}` | System-injected messages |
+
+**Inline UI cards** and **agent handoff chips** travel as fenced code blocks inside `message` payloads — they do NOT use dedicated WS message types. See `specs/tools.md` § `card_protocol`.
 
 ## API Routes
 
-| Router | Prefix | Purpose |
-|--------|--------|---------|
-| `api/sessions.py` | `/api/sessions` | Session CRUD |
+All registered in `radbot/web/app.py` via `app.include_router()` / `register_*_router()`.
+
+| File | Prefix | Purpose |
+|------|--------|---------|
+| `api/sessions.py` | `/api/sessions` | Session CRUD + `GET /{id}/stats` (token/cost totals) + reset |
 | `api/messages.py` | `/api/messages` | Chat message history |
-| `api/admin.py` | `/admin/api` | Config, credentials, status |
-| `api/tasks_api.py` | `/api/tasks` | Todo task CRUD |
-| `api/scheduler_api.py` | `/api/scheduler` | Scheduled tasks |
-| `api/reminders_api.py` | `/api/reminders` | Reminders |
-| `api/webhooks_api.py` | `/api/webhooks` | Webhook definitions |
-| `api/alerts_api.py` | `/api/alerts` | Alert events + policies |
-| `api/terminal.py` | `/terminal` | Terminal PTY sessions |
+| `api/events.py` | `/api/events` | Event log per session |
+| `api/agent_info.py` | `/api/agents` + `/api/claude` | Dynamic agent roster (reads live `root_agent.sub_agents`) + Claude metadata |
+| `api/session/memory_api.py` | `/api/memory` | Memory store/recall |
+| `api/admin.py` | `/admin/api/*` | Config, credentials, test endpoints, hot-reload triggers |
+| `api/tasks_api.py` via admin | `/api/tasks` | Todo CRUD (registered elsewhere) |
+| `api/scheduler.py` | `/api/scheduler` | Scheduled tasks REST |
+| `api/reminders.py` | `/api/reminders` | Reminders REST |
+| `api/webhooks.py` | `/api/webhooks` | Webhook definitions + inbound endpoints |
+| `api/alerts.py` | `/api/alerts` | Alertmanager ingestion + policies |
+| `api/notifications.py` | `/api/notifications` | Unified notification feed (new 2026-04-11) |
+| `api/media.py` | `/api/media` | Direct Overseerr/TMDB actions — bypasses agent (new 2026-04-18) |
+| `api/ha.py` | `/api/ha` | Direct Home Assistant state + service — bypasses agent (new 2026-04-18) |
+| `api/terminal.py` | `/terminal` | Terminal PTY WebSocket + workspace REST |
+| `api/terminal_proxy.py` | (helper) | `WorkspaceProxy`: workspace worker lifecycle |
 | `api/tts.py` | `/api/tts` | Text-to-speech |
 | `api/stt.py` | `/api/stt` | Speech-to-text |
+| `api/health.py` | `/health` | Liveness endpoint for Nomad health check |
+| `api/malformed_function_handler.py` | (helper) | Malformed-tool-call repair utilities |
+
+## Direct-Action Endpoints (2026-04-18)
+
+Frontend buttons on Casa-rendered UI cards hit these REST endpoints directly — no LLM roundtrip needed for quick actions.
+
+### Media (`/api/media`) — `web/api/media.py`
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/media/search?query=X` | `MediaCardData[]` with TMDB `poster_url` (max 15 results) |
+| `GET` | `/api/media/{tmdb_id}?media_type=movie\|tv` | Enriched detail (seasons, on-server fractions, content_rating) |
+| `POST` | `/api/media/request` | Wraps Overseerr `create_request` — auto-fills all seasons for TV |
+
+### Home Assistant (`/api/ha`) — `web/api/ha.py`
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/ha/state/{entity_id}` | Normalized `HaDevice` (domain-inferred icon, `brightness_pct`, state mapping) |
+| `POST` | `/api/ha/service` | `ha_client.call_service()`, returns fresh entity state |
+
+## Per-Session Token Stats (2026-04-18)
+
+`telemetry_after_model_callback` threads `_invocation_context.session.id` into `llm_usage_log.session_id` (new nullable column). Aggregation exposed via:
+
+- `GET /api/sessions/{session_id}/stats` → `SessionStats` (camelCase): `inputTokens`, `outputTokens`, `totalTokens`, `costToday`, `costMonth`, `contextWindow`
+- `radbot/telemetry/db.py:get_session_stats(session_id)` — per-session totals + rolling today/month cost
+- Known-model context window map in `telemetry/db.py`, 200k default fallback
+
+Frontend calls the stats endpoint after each turn and renders in the chat footer.
+
+## Notifications Feed (2026-04-11)
+
+Unified notification store (`tools/notifications/db.py`) tracks scheduled-task results, reminder deliveries, alert events, and inbound ntfy messages with read/unread state.
+
+Endpoints (`api/notifications.py`, prefix `/api/notifications`):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/` | List with filters (`type`, `unread_only`, `limit`, `offset`) |
+| `GET` | `/unread-count` | Badge count |
+| `GET` | `/{notification_id}` | Single notification |
+| `POST` | `/{notification_id}/read` | Mark read |
+| `POST` | `/read-all` | Bulk read (optional type filter) |
+| `DELETE` | `/{notification_id}` | Delete |
+
+Frontend: `pages/NotificationsPage.tsx` — date-grouped feed + a notifications drawer on the chat page.
+
+## Dynamic Agent Info (2026-04-18)
+
+`GET /api/agents/agent-info` walks `root_agent.sub_agents` at request time and returns:
+
+```json
+{
+  "sub_agents_detail": [
+    {"name": "casa", "config_key": "casa_agent", "resolved_model": "gemini-2.5-flash", "gemini_only": false},
+    {"name": "search_agent", "config_key": null, "resolved_model": "gemini-2.5-flash", "gemini_only": true},
+    ...
+  ]
+}
+```
+
+The admin UI palette reads this to render model pickers dynamically — no hardcoded agent list to maintain.
 
 ## Frontend
 
 Build: `make build-frontend` → `radbot/web/static/dist/`
+Dev: `make dev-frontend` → Vite at `:5173`, proxies `/api` and `/ws` to FastAPI on `:8000`.
 
-Feature flag: if `static/dist/index.html` exists, FastAPI serves React SPA; otherwise legacy vanilla JS.
+Feature flag: if `static/dist/index.html` exists, FastAPI serves the React SPA; otherwise legacy vanilla JS served from `web/static/` (retained for emergency fallback).
 
-Key dirs: `components/`, `hooks/`, `stores/`, `pages/`, `lib/`
+### Pages (`radbot/web/frontend/src/pages/`)
+
+| Page | Purpose |
+|------|---------|
+| `ChatPage.tsx` | Main chat UI; renders inline cards + handoff chips; calls `/api/sessions/{id}/stats` after each turn |
+| `TerminalPage.tsx` | Terminal emulator with workspace search, health indicator, scrollback replay, binary WS protocol, GPU renderer, multi-client WS |
+| `NotificationsPage.tsx` | Unified notification feed with date grouping |
+| `AdminPage.tsx` | Admin panels + palette refresh; dynamic agent roster |
+
+### Admin Panel Modules (`components/admin/panels/`)
+
+Flat panel structure (no more grouping superclasses).
+
+| Module | Panels |
+|--------|--------|
+| `CorePanels.tsx` | `GooglePanel`, `AgentModelsPanel`, `WebServerPanel`, `LoggingPanel` |
+| `ConnectionPanels.tsx` | `GmailPanel`, `CalendarPanel`, `JiraPanel`, `OverseerrPanel`, `LidarrPanel`, `HomeAssistantPanel`, `PicnicPanel`, `FilesystemPanel`, `YouTubePanel`, `KideoPanel` |
+| `SecurityPanels.tsx` | `SanitizationPanel` |
+| `AlertmanagerPanels.tsx` | `NomadPanel`, `AlertmanagerPanel` |
+| `AutomationPanels.tsx` | `SchedulerPanel`, `WebhooksPanel` |
+| `MediaPanels.tsx` | `TTSPanel`, `STTPanel` |
+| `NotificationPanels.tsx` | `NtfyPanel` |
+| `DeveloperPanels.tsx` | `GitHubAppPanel`, `ClaudeCodePanel` |
+| `InfrastructurePanels.tsx` | `PostgresqlPanel`, `QdrantPanel` |
+| `TelemetryPanels.tsx` | `CostTrackingPanel` |
+| `MCPPanel.tsx` | `MCPServersPanel` |
+| `CredentialsPanel.tsx` | `CredentialsPanel` |
+| `RawConfigPanel.tsx` | `RawConfigPanel` |
+
+Registered in `pages/AdminPage.tsx` via `NAV_ITEMS` + `PANEL_MAP`.
+
+### Chat Components (post-refresh 2026-04-18)
+
+- `components/chat/AgentCards.tsx` — renders `MediaCard`, `SeasonBreakdownCard`, `HaDeviceCard`, `HandoffLine` (parses ` ```radbot:<kind> ` fenced blocks from message text)
+- Terminal refresh: mascot, stats footer, notifications drawer — see commit `9ebfb9f`

--- a/specs/workers.md
+++ b/specs/workers.md
@@ -1,226 +1,170 @@
-# Session Workers
+# Workers
 
 ## Overview
 
-Session workers run agent sessions as independent persistent Nomad service jobs. Each worker holds full ADK session state in memory and exposes an A2A (Agent-to-Agent) HTTP endpoint. The main radbot app acts as a gateway — the WebSocket handler delegates to a `SessionProxy` that manages worker lifecycle and proxies messages.
+Workers are persistent Nomad service jobs spawned by the main radbot app for **terminal/workspace** sessions. Each worker runs a minimal PTY server — no ADK, no agent stack, no A2A — and serves the terminal over WebSocket. The main app acts as a gateway: `WorkspaceProxy` in `web/api/terminal_proxy.py` manages lifecycle and proxies WebSocket frames.
 
-**Why**: `InMemorySessionService` loses all state on restart. Workers keep sessions alive as independent processes — surviving main app restarts, providing resource isolation, and enabling horizontal scaling. Primary use case is persistent Claude Code terminal environments.
+**Design shift (2026-03-22)**: the worker was originally designed to host the full ADK agent stack and proxy chat via A2A. That path was reverted in commit `393c173` (and the session-worker chat flow finally removed in `12e4901`) because:
 
-**Design principle**: Workers are persistent session holders. They run the agent runtime (including Claude Code CLI) and hold state indefinitely. Workers restart on crash and run until explicitly stopped — there is no idle self-termination. The main app evolves independently — new features don't require restarting existing workers.
+- Keeping ADK state per session was expensive and rarely needed for chat
+- `InMemorySessionService` already reseeds from chat DB on cold starts (good enough)
+- Terminal (Claude Code CLI) is the real use case for per-session workers — it genuinely needs persistent state (the Claude Code session ID for `--resume`)
 
-## Architecture
+**Current state**: workers are persistent, lean PTY servers. Chat always runs in-process in the main app.
+
+## Two Worker Flavors
+
+Both share `radbot/worker/` and the `workspace_workers` / `session_workers` tables in PostgreSQL.
+
+| Flavor | Spec builder | DB table | Active usage |
+|--------|--------------|----------|--------------|
+| Workspace worker (terminal) | `build_workspace_worker_spec()` | `workspace_workers` | Active — each cloned workspace gets one |
+| Session worker (chat, legacy) | `build_worker_job_spec()` | `session_workers` | Not used for routing chat post-`12e4901`; code kept for potential revival |
+
+Only the workspace worker is active in production flow.
+
+## Architecture (Active — Workspace/Terminal)
 
 ```
                     ┌──────────────────────────────────┐
                     │       Main radbot App             │
                     │   (Gateway / UI / Scheduler)      │
                     │                                   │
-  Browser ◄──WS──► │  /ws/{session_id}                 │
+  Browser ◄──WS──► │  /terminal/ws/{workspace_id}      │
                     │       │                           │
-                    │  SessionManager                   │
-                    │   mode=remote? ──► SessionProxy   │
-                    │   mode=local?  ──► SessionRunner  │
-                    │                        │          │
-                    └────────────────────────┼──────────┘
-                                             │ A2A HTTP
-                              ┌──────────────▼──────────────┐
-                              │    Nomad Batch Job           │
-                              │  radbot-session-{id[:8]}     │
-                              │                              │
-                              │  python -m radbot.worker     │
-                              │    --session-id <UUID>       │
-                              │                              │
-                              │  ┌─────────────────────┐     │
-                              │  │ Starlette (to_a2a)  │     │
-                              │  │  /.well-known/agent  │     │
-                              │  │  /health             │     │
-                              │  │  /info               │     │
-                              │  └─────────┬───────────┘     │
-                              │            │                 │
-                              │  ┌─────────▼───────────┐     │
-                              │  │ ADK Runner           │     │
-                              │  │  InMemorySession     │     │
-                              │  │  root_agent (beto)   │     │
-                              │  │  all sub-agents      │     │
-                              │  │  memory service      │     │
-                              │  └─────────────────────┘     │
-                              │                              │
-                              │  ActivityWatchdog (tracking)  │
-                              └──────────────────────────────┘
+                    │  WorkspaceProxy                   │
+                    │   mode=remote? spawn Nomad job    │
+                    │   mode=local?  local PTY          │
+                    └──────────────────────┼────────────┘
+                                           │ WebSocket
+                              ┌────────────▼─────────────┐
+                              │   Nomad Service Job       │
+                              │  radbot-workspace-{id[:8]}│
+                              │                           │
+                              │  python -m radbot.worker  │
+                              │    --workspace-id <UUID>  │
+                              │                           │
+                              │  Starlette + uvicorn      │
+                              │    /ws (PTY WebSocket)    │
+                              │    /health, /info         │
+                              │                           │
+                              │  TerminalManager          │
+                              │    PTY (Claude Code CLI)  │
+                              └───────────────────────────┘
 ```
 
 ## Worker Process
 
-### Entry Point: `radbot/worker/__main__.py`
+### Entry Point — `radbot/worker/__main__.py`
 
 ```
-python -m radbot.worker --session-id <UUID> [--host 0.0.0.0] [--port 8000]
+python -m radbot.worker --workspace-id <UUID> [--host 0.0.0.0] [--port 8000]
 ```
 
-Startup sequence:
-1. Bootstrap logging, env vars, DB config (same as `radbot.web`)
-2. Import `root_agent` from `radbot.agent.agent_core` (creates full agent tree)
-3. Run `setup_before_agent_call()` (DB schema init)
-4. Create `Runner` with `InMemorySessionService`, `InMemoryArtifactService`, memory service
-5. Enable context caching (intervals=20, ttl=3600s, min_tokens=1024)
-6. Call `to_a2a(root_agent, runner=runner)` → Starlette app with A2A routes
-7. Add `ActivityMiddleware` (touches watchdog on every request)
-8. Add `/health` and `/info` routes
-9. On startup: start watchdog + seed session from chat DB history
-10. Run with `uvicorn`
+Startup (minimal — no ADK):
 
-### A2A Protocol
+1. `setup_logging()` + `load_dotenv()`
+2. Schema init (workspace_workers, coder_workspaces) — called directly, NOT via ADK callback (`ec49f62`)
+3. DB config load so GitHub App credentials are available for clones (`2694efa`)
+4. Build Starlette app with routes:
+   - `GET /health` — returns `{status, workspace_id, idle_seconds, uptime_seconds}`
+   - `GET /info` — metadata
+   - `WS /ws` — PTY terminal (delegated to `terminal_handler.handle_terminal_websocket`)
+5. `ActivityMiddleware` touches a watchdog on every request
+6. Add `ActivityWatchdog` for observability only (no idle-shutdown — `f988aca`)
+7. Run with `uvicorn` (`uvicorn[standard]` for WebSocket support — `ab13a23`)
 
-Workers use Google ADK's built-in A2A support:
+Workers use a `Starlette` lifespan context manager (`b9465ed`) and an empty `__init__.py` built into the Dockerfile (`5252d0c`) to avoid shared-app import fallout (`2e3efd3`, `db2a290`).
 
-| Component | Role |
-|-----------|------|
-| `to_a2a()` | Converts `BaseAgent` into Starlette app with A2A JSON-RPC routes |
-| `A2aAgentExecutor` | Wraps `Runner`, processes A2A messages → ADK events → A2A responses |
-| `AgentCardBuilder` | Auto-generates `/.well-known/agent.json` from agent metadata |
-| `a2a-sdk` | Protocol types, server framework, client library |
+### Docker Image
 
-The A2A endpoint handles:
-- Agent card discovery (`/.well-known/agent.json`)
-- Message send (JSON-RPC `message/send`)
-- Task management (submit, status, artifacts)
+- Separate from main app: `radbot-worker` built via `Dockerfile.worker`
+- Multi-stage build with `uv` + GHA layer caching (`c20e8b2`, `c1cbdd8`)
+- Python 3.14-slim base
+- Shell ergonomics preinstalled (`485b83d`): `zsh`, `fzf`, `git-delta`, `jq`, `tree`, `bat`, `fd-find`, `less`
+- Bundles Claude Code CLI
 
-### Endpoints
+### Terminal Handler
 
-| Path | Method | Purpose |
-|------|--------|---------|
-| `/health` | GET | Health check — returns `{status, session_id, idle_seconds, uptime_seconds}` |
-| `/info` | GET | Metadata — returns `{session_id, agent_name, idle_seconds, uptime_seconds}` |
-| `/.well-known/agent.json` | GET | A2A agent card (auto-generated) |
-| `/` | POST | A2A JSON-RPC endpoint (message/send, tasks) |
+`radbot/worker/terminal_handler.py` — shared module also used by `web/api/terminal.py` for local-mode.
 
-### Idle Watchdog: `radbot/worker/idle_watchdog.py`
+- `TerminalManager` — per-workspace map of `TerminalSession`s
+- `TerminalSession` — PTY subprocess (Claude Code CLI by default), `TERM=xterm-256color` (`e8b5b47`), scrollback buffer, multi-client fan-out
+- **Binary WebSocket protocol** (`661ff39`) for PTY I/O — shorter frames, GPU canvas addon on the frontend
+- **Multi-client** (`0442134`) — multiple browsers can share one PTY
+- **Scrollback replay** on reconnect (`324611f`)
+- **Session-ID persistence** (`1b3b29c`) — Claude Code's session ID is saved to `coder_workspaces.last_session_id` so the next spawn does `claude --resume`
+- **Directory auto-recreate** (`6e38f25`) — if a workspace dir is missing after container restart, re-clone from GitHub App
 
-Two components:
-- **`ActivityWatchdog`**: Tracks `last_activity` and `uptime_seconds` via `time.monotonic()`. Pure observability — no shutdown logic. Health and info endpoints report these values.
-- **`ActivityMiddleware`**: Starlette middleware that calls `watchdog.touch()` on every HTTP request.
+### Idle Watchdog — `radbot/worker/idle_watchdog.py`
 
-Workers are persistent — they do not self-terminate. Stop them explicitly via `NomadClient.stop_job()` or workspace deletion.
+Two components, **observability only**:
 
-### History Seeding: `radbot/worker/history_loader.py`
+- `ActivityWatchdog` — tracks `last_activity` + `uptime_seconds`
+- `ActivityMiddleware` — calls `watchdog.touch()` on every HTTP/WS request
 
-On startup, the worker pre-loads chat history from PostgreSQL:
-1. Query `chat_messages` table for the session (limit: `max_history * 2`, default 30)
-2. Take last `max_history` messages (default 15)
-3. Create ADK `Event` objects with user/assistant roles
-4. Group user+assistant pairs under shared `invocation_id`
-5. Append to session via `session_service.append_event()`
+Workers do NOT self-terminate on idle (`f988aca`). Stop them explicitly via `NomadClient.stop_job()` or workspace deletion.
 
-This function is shared between the worker and `SessionRunner` (web app).
+## Gateway Side (Main App)
 
-## Gateway (Main App Side)
+### WorkspaceProxy — `radbot/web/api/terminal_proxy.py`
 
-### SessionProxy: `radbot/web/api/session/session_proxy.py`
+Duck-typed replacement for local PTY flow when `session_mode=remote`:
 
-Duck-typed replacement for `SessionRunner` — same `process_message(message) → dict` interface.
+- Spawns Nomad service job on first terminal open
+- Discovers existing worker via Nomad service catalog (`find_service_by_tag("workspace_id=<UUID>")`)
+- Falls back to `session_workers` / `workspace_workers` DB rows, then DB config → Consul if needed (`2811156`)
+- Proxies WebSocket frames 1:1 between browser and worker (`/ws`)
+- Pre-spawns the worker on workspace *creation*, not just first open (`3e93b63`), to avoid cold-start on first click
+- Guards against duplicate spawns with a lock (`08e59bf`) and a 120s startup timeout
 
-#### Message Flow
+### Terminal Router — `radbot/web/api/terminal.py`
 
-```python
-async def process_message(message, run_config=None) -> dict:
-    worker_url = await self._ensure_worker()    # spawn if needed
-    if not worker_url:
-        return await self._fallback_local(...)  # degrade gracefully
+- REST endpoints: list workspaces, clone, delete, workspace health
+- `register_terminal_websocket(app)` wires the WS route — delegates to `WorkspaceProxy` when remote, or to the local `terminal_handler` when local
+- Differentiates OAuth vs. API-key token injection for Claude Code PTY (`be55369`)
+- Scrollable workspace tabs in header bar (`7548aa5`)
+- Multiple workspaces per repo/branch supported (`dd9919e`)
+- Onboarding bypass + trust prompts pre-answered (`76b86b0`)
 
-    response_text = await self._send_a2a_message(worker_url, message)
-    if response_text is None:
-        return await self._fallback_local(...)  # A2A failed
+## Nomad Job Templates — `radbot/worker/nomad_template.py`
 
-    return {"response": response_text, "events": [], "source": "remote_worker"}
-```
+Two builder functions (both return `{"Job": {...}}` for Nomad HTTP API):
 
-#### Worker Discovery
+| Function | Purpose |
+|----------|---------|
+| `build_worker_job_spec(session_id=..., ...)` | Legacy session worker (chat) — kept for potential future use |
+| `build_workspace_worker_spec(workspace_id=..., ...)` | Active workspace worker (terminal) |
 
-Priority order:
-1. **Cached URL** — check health, use if still healthy
-2. **Nomad service discovery** — `GET /v1/service/radbot-session`, filter by `session_id` tag
-3. **DB fallback** — `session_workers` table lookup
-4. **Spawn new** — submit Nomad service job, poll until healthy
+Shared properties:
 
-#### Spawning
-
-1. Check concurrency limit (`max_session_workers`, default 10)
-2. Read bootstrap secrets from main app's env (`RADBOT_CREDENTIAL_KEY`, `RADBOT_ADMIN_TOKEN`) + DB config (`postgres_pass`)
-3. Generate job spec via `nomad_template.build_worker_job_spec()`
-4. Submit via `NomadClient.submit_job()`
-5. Record in `session_workers` table (status=`starting`)
-6. Poll Nomad service discovery until worker registers + passes health check (timeout: 120s)
-7. Update DB record (status=`healthy`, `worker_url`)
-
-#### A2A Client
-
-Uses `a2a-sdk` directly (not `RemoteA2aAgent`):
-1. Resolve agent card from `{worker_url}/.well-known/agent.json`
-2. Create `A2AClientFactory` with `httpx.AsyncClient`
-3. Build `A2AMessage` with user text
-4. Send via `a2a_client.send_message()`, iterate response stream
-5. Extract text from response parts
-
-#### Fallback
-
-Falls back to local `SessionRunner` when:
-- Nomad client not configured
-- Worker limit reached
-- Worker fails to start within 120s
-- A2A message fails
-- Any unhandled exception
-
-Fallback result includes `"source": "local_fallback"` for observability.
-
-### SessionManager: `radbot/web/api/session/session_manager.py`
-
-Extended with `mode` property (lazy-loaded from `config:agent` → `session_mode`):
-- `"local"` (default): creates `SessionRunner`
-- `"remote"`: creates `SessionProxy`
-
-### Dependencies: `radbot/web/api/session/dependencies.py`
-
-FastAPI dependency `get_or_create_runner_for_session()` checks `session_manager.mode` and creates the appropriate handler.
-
-## Nomad Job Template: `radbot/worker/nomad_template.py`
-
-Generates JSON job spec (Python dict) compatible with Nomad HTTP API.
-
-```python
-build_worker_job_spec(
-    session_id="...",       # full UUID
-    image_tag="v0.14",      # Docker tag
-    credential_key="...",   # RADBOT_CREDENTIAL_KEY
-    admin_token="...",      # RADBOT_ADMIN_TOKEN
-    postgres_pass="...",    # DB password
-    # Optional:
-    cpu=500, memory=1024,
-    dns_server=None, extra_env=None,
-) -> {"Job": {...}}
-```
-
-Key properties:
 - `type = "service"` — Nomad restarts on crash, runs until explicitly stopped
 - `restart: attempts=1, mode=fail` — minimal retry, no restart loop
 - Dynamic port on `host_network = "lan"`
-- Service `radbot-session` with tag `session_id=<UUID>` for discovery
+- Service name with `workspace_id=<UUID>` or `session_id=<UUID>` tag for discovery
 - Health check `GET /health` every 30s
-- Config via Nomad template stanza (same pattern as main job)
+- Config via Nomad template stanza mirrors main job's credential bootstrap
 
-## Worker DB: `radbot/worker/db.py`
+## Worker DB — `radbot/worker/db.py`
 
-Table: `session_workers`
+Two tables, same shape:
+
+**`session_workers`** (legacy, not used for chat routing):
 
 | Column | Type | Purpose |
 |--------|------|---------|
 | `session_id` | UUID PK | Links to `chat_sessions` |
-| `nomad_job_id` | TEXT | Nomad job ID (e.g. `radbot-session-550e8400`) |
-| `worker_url` | TEXT | Discovered URL (e.g. `http://10.0.1.5:28432`) |
+| `nomad_job_id` | TEXT | e.g. `radbot-session-550e8400` |
+| `worker_url` | TEXT | e.g. `http://10.0.1.5:28432` |
 | `status` | TEXT | `starting` → `healthy` → `stopped` / `failed` |
-| `created_at` | TIMESTAMPTZ | When job was submitted |
-| `last_active_at` | TIMESTAMPTZ | Updated on each proxied message |
-| `image_tag` | TEXT | Docker image tag at spawn time |
-| `metadata` | JSONB | Extensible metadata |
+| `created_at` | TIMESTAMPTZ | |
+| `last_active_at` | TIMESTAMPTZ | |
+| `image_tag` | TEXT | |
+| `metadata` | JSONB | |
+
+**`workspace_workers`** (active):
+
+Same columns, keyed by `workspace_id` UUID PK.
 
 Operations: `upsert_worker`, `get_worker`, `update_worker_status`, `touch_worker`, `list_active_workers`, `count_active_workers`, `delete_worker`.
 
@@ -231,129 +175,98 @@ Added to `NomadClient` (`radbot/tools/nomad/nomad_client.py`):
 | Method | API | Purpose |
 |--------|-----|---------|
 | `list_services(name)` | `GET /v1/service/{name}` | All registrations for a service |
-| `find_service_by_tag(name, tag)` | filters above | Find worker by `session_id=<UUID>` tag |
+| `find_service_by_tag(name, tag)` | filter above | Find worker by `workspace_id=<UUID>` tag |
+
+Consul remains as a fallback (`2811156`), but Nomad's native service discovery is the primary path (`ccfeeb3`).
 
 ## Config
 
 | Key | Location | Default | Purpose |
 |-----|----------|---------|---------|
-| `session_mode` | `config:agent` | `local` | `local` = in-process; `remote` = Nomad workers |
-| `max_session_workers` | `config:agent` | `10` | Max concurrent worker jobs |
-| `worker_image_tag` | `config:agent` or `RADBOT_WORKER_IMAGE_TAG` | `latest` | Docker tag for new workers |
+| `session_mode` | `config:agent` | `local` | Terminal/workspace workers only — `local` = local PTY, `remote` = Nomad workers |
+| `max_session_workers` | `config:agent` | `10` | Max concurrent worker jobs (shared budget) |
+| `worker_image_tag` | `config:agent` or `RADBOT_WORKER_IMAGE_TAG` | `latest` | Docker tag for newly-spawned workers |
 
 ## Sequence Diagrams
 
-### New Session (Remote Mode)
+### Open a terminal (remote mode, cold)
 
 ```
-Browser ──WS──► /ws/{session_id}
+Browser ──WS──► /terminal/ws/{workspace_id}
                   │
                   ▼
-            SessionManager.get_runner() → None (new session)
-            dependencies → SessionProxy(session_id)
-                  │
-                  ▼ process_message("hello")
-            SessionProxy._ensure_worker()
-              ├─ _discover_worker() → None
+            WorkspaceProxy._ensure_worker()
+              ├─ _discover_worker() → None (first open)
               └─ _spawn_worker()
                    ├─ count_active_workers() < limit
-                   ├─ build_worker_job_spec()
+                   ├─ build_workspace_worker_spec()
                    ├─ NomadClient.submit_job()
                    ├─ upsert_worker(status="starting")
                    └─ _wait_for_healthy()
                         └─ poll find_service_by_tag() + /health
                              │
                              ▼ worker healthy
-            SessionProxy._send_a2a_message(worker_url, "hello")
-              ├─ resolve agent card
-              ├─ A2AClient.send_message()
-              └─ extract text response
-                  │
-                  ▼
-            return {"response": "...", "source": "remote_worker"}
+            WorkspaceProxy bridges WS frames ──► worker /ws (PTY)
 ```
 
-### Reconnect After Main App Restart
+### Reconnect after main app restart
 
 ```
-Browser ──WS──► /ws/{session_id}
+Browser ──WS──► /terminal/ws/{workspace_id}
                   │
                   ▼
-            SessionProxy._ensure_worker()
+            WorkspaceProxy._ensure_worker()
               └─ _discover_worker()
-                   └─ find_service_by_tag("session_id=xxx")
+                   └─ find_service_by_tag("workspace_id=xxx")
                         │
-                        ▼ worker still running!
+                        ▼ worker still running
                    _check_health(url) → 200 OK
                   │
                   ▼
-            SessionProxy._send_a2a_message()
-              └─ Worker has FULL session state (in-memory, never lost)
-                  No history reconstruction needed
+            Bridge WS frames — Claude Code can --resume from saved session ID
+            Scrollback buffer replayed on WS reconnect
 ```
 
-### Worker Explicit Stop
+### Worker crash
 
 ```
-Admin or workspace delete
+PTY subprocess exits / allocation OOMs
       │
-SessionProxy.stop_worker()
-      └─ NomadClient.stop_job("radbot-session-{id}")
-           └─ DELETE /v1/job/{id}
-                │
-                ▼
-    Nomad deregisters job, kills allocation
-    session_workers.status → "stopped"
-```
-
-### Worker Crash Recovery
-
-```
-Worker process crashes (OOM, unhandled exception)
-      │
-Nomad RestartPolicy (attempts=3, mode=delay)
-      └─ Restart allocation after 15s delay
-           └─ Worker boots, re-seeds from DB
-                └─ Claude Code can --resume from saved session ID
+Nomad service job restart policy
+      └─ Fresh allocation on same host (or rescheduled)
+           └─ Worker boots, mounts workspace dir (auto-recreate if missing)
+                └─ Terminal client reconnects, resumes Claude Code session
 ```
 
 ## Testing
 
-### Unit Tests: `tests/unit/test_worker_components.py`
+### Unit Tests — `tests/unit/test_worker_components.py`
 
 | Class | Tests | Covers |
 |-------|-------|--------|
-| `TestNomadJobTemplate` | 13 | Job structure, args, env, service tags, resources, constraints, serialization |
-| `TestActivityWatchdog` | 3 | Activity tracking, touch reset, uptime |
-| `TestHistoryLoader` | 6 | DB loading, empty handling, max limit, invocation ID pairing |
-| `TestSessionManagerMode` | 5 | Mode switching, runner registry |
-| `TestSessionProxyUnit` | 7 | Health checks, fallback, concurrency limits, message routing |
+| `TestNomadJobTemplate` | Job structure, args, env, service tags, resources, constraints, serialization |
+| `TestActivityWatchdog` | Activity tracking, touch reset, uptime |
+| `TestHistoryLoader` | DB loading (legacy chat path), empty handling, invocation ID pairing |
 
-### E2E Tests: `tests/e2e/test_session_worker.py`
+### E2E Tests — `tests/e2e/test_session_worker.py` + `tests/e2e/test_terminal_worker.py`
 
-| Class | Mark | Tests | Covers |
-|-------|------|-------|--------|
-| `TestSessionWorkerAPI` | `e2e` | 2 | Health endpoint, schema init |
-| `TestNomadJobSubmission` | `requires_nomad` | 3 | Nomad connectivity, template validation |
-| `TestSessionProxyFlow` | `requires_nomad` + `requires_gemini` | 3 | Full WS→proxy→worker→A2A→response, worker reuse |
-| `TestSessionProxyFallback` | `e2e` | 2 | Local mode default, local sessions work |
-| `TestWorkerDBTracking` | `e2e` | 6 | CRUD on session_workers table |
-| `TestNomadServiceDiscovery` | `requires_nomad` | 2 | Service lookup edge cases |
+- `TestSessionWorkerAPI` — `/health` endpoint, schema init
+- `TestNomadJobSubmission` — Nomad connectivity, template validation (`requires_nomad`)
+- `TestWorkerDBTracking` — CRUD on both worker tables
+- `TestNomadServiceDiscovery` — Service lookup edge cases
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `radbot/worker/__init__.py` | Package |
-| `radbot/worker/__main__.py` | Entry point: A2A + terminal routes, --workspace-id/--session-id |
-| `radbot/worker/terminal_handler.py` | Shared PTY module: `TerminalManager`, `TerminalSession`, binary WS handler |
-| `radbot/worker/idle_watchdog.py` | `ActivityWatchdog` + `ActivityMiddleware` |
-| `radbot/worker/history_loader.py` | Shared: seed ADK session from chat DB |
+| `radbot/worker/__init__.py` | Package marker |
+| `radbot/worker/__main__.py` | Entry point — PTY server with /health, /info, /ws |
+| `radbot/worker/terminal_handler.py` | Shared PTY module — `TerminalManager`, `TerminalSession`, binary WS handler |
+| `radbot/worker/idle_watchdog.py` | `ActivityWatchdog` + `ActivityMiddleware` (observability only) |
 | `radbot/worker/nomad_template.py` | `build_worker_job_spec()` + `build_workspace_worker_spec()` |
-| `radbot/worker/db.py` | `session_workers` + `workspace_workers` tables |
-| `radbot/web/api/terminal.py` | Terminal REST + WS proxy (local/remote mode) |
-| `radbot/web/api/terminal_proxy.py` | `WorkspaceProxy`: workspace worker lifecycle |
-| `radbot/web/api/session/session_proxy.py` | `SessionProxy`: chat session A2A proxy |
-| `radbot/web/api/session/session_manager.py` | Mode switching (local/remote) |
-| `radbot/web/api/session/dependencies.py` | FastAPI dep: Runner or Proxy based on mode |
+| `radbot/worker/db.py` | `session_workers` + `workspace_workers` CRUD |
+| `radbot/worker/history_loader.py` | Shared: seed ADK session from chat DB (used by main-app chat, not workers) |
+| `radbot/web/api/terminal.py` | Terminal REST + WS registration (local/remote mode) |
+| `radbot/web/api/terminal_proxy.py` | `WorkspaceProxy` — workspace worker lifecycle + WS bridge |
+| `radbot/web/api/session/session_manager.py` | Chat `SessionRunner` registry (always local) |
 | `radbot/tools/nomad/nomad_client.py` | `list_services()`, `find_service_by_tag()` |


### PR DESCRIPTION
## Summary

- Refreshed `SPEC.md` and all eight `specs/*.md` to reflect the 70+ commits landed since the last spec update on 2026-03-22.
- Added a **Spec Maintenance** section to `CLAUDE.md` with a spec ↔ code map and a PR-body rule so future changes update specs in the same PR.

## What's newly documented

- **kidsvid agent** — YouTube + CuriosityStream + Kideo (15 tools) + 2 memory, Shorts filtering, AI tag generation
- **Lidarr** — music collection integration on Casa (5 tools) + admin panel
- **Per-turn context scoping** — `scope_sub_agent_context_callback` trims sub-agent prompts to the current user turn; root keeps full history
- **Structured UI cards** — `` ```radbot:<kind> `` fenced blocks (`media`, `seasons`, `ha-device`, `handoff`), Casa's `CARD_TOOLS`, server-injected handoff chips
- **Direct-action REST** — `/api/media/*` and `/api/ha/*` bypass the LLM for quick frontend buttons
- **Per-session token stats** — `llm_usage_log.session_id` + `GET /api/sessions/{id}/stats`
- **Unified notifications** — `notifications` table, `/api/notifications/*`, `NotificationsPage.tsx`
- **Chat is always local** — `session_mode` now only affects terminal/workspace workers
- **Workspace vs session workers** — current architecture (workspace = active PTY workers, session = legacy)
- **Runtime** — Python 3.14, `google-adk>=2.0.0a3,<3.0.0` with V1 LlmAgent mode, separate worker image
- **Admin panels** — flat structure, full current panel inventory (including `LidarrPanel`, `YouTubePanel`, `KideoPanel`, `CostTrackingPanel`)

## Spec ↔ Code map (now in CLAUDE.md)

Every future PR that changes shape (new agent/tool/router/table/config section/integration/callback/runtime version) is expected to update the matching spec in the same PR and declare it in the PR body.

## Test plan

- [ ] Skim each spec to sanity-check the tables against the current code
- [ ] Confirm no broken spec-to-spec links
- [ ] Verify `CLAUDE.md` Pre-Commit Checklist now leads with spec updates
- [ ] No code changes — nothing to runtime-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)