### PR TITLE
perf(agent): restore beto's prompt cache and fix flash-alias pricing

### DIFF
--- a/radbot/agent/agent_core.py
+++ b/radbot/agent/agent_core.py
@@ -33,6 +33,7 @@ from radbot.callbacks.telemetry_callback import telemetry_after_model_callback
 from radbot.callbacks.scope_to_current_turn import (
     scope_sub_agent_context_callback,
 )
+from radbot.callbacks.filter_tool_events import filter_tool_events_from_prompt
 from radbot.config.config_loader import config_loader
 
 # Import memory tools and services
@@ -164,7 +165,11 @@ root_agent = Agent(
     sub_agents=all_sub_agents,
     tools=beto_tools,
     before_agent_callback=setup_before_agent_call,
-    before_model_callback=[scrub_empty_content_before_model, sanitize_before_model_callback],
+    before_model_callback=[
+        filter_tool_events_from_prompt,
+        scrub_empty_content_before_model,
+        sanitize_before_model_callback,
+    ],
     after_model_callback=[handle_empty_response_after_model, telemetry_after_model_callback],
     generate_content_config=types.GenerateContentConfig(temperature=0.2),
 )

--- a/radbot/callbacks/filter_tool_events.py
+++ b/radbot/callbacks/filter_tool_events.py
@@ -1,0 +1,87 @@
+"""Before-model callback that drops tool events from the root agent's
+LLM prompt.
+
+### Why
+
+Beto is a pure orchestrator: its only tools are agent-scoped memory, and
+its own output is almost always a short routing decision. Sub-agents do
+all the real tool work. But the ADK session beto shares with its
+sub-agents retains every ``function_call`` and ``function_response`` event
+those sub-agents emit, and those events flow into beto's next LLM call as
+part of ``llm_request.contents``.
+
+Tool-response blobs (e.g. a full HA entity list, a calendar query dump)
+can be tens of thousands of tokens each, change every turn, and are
+useless to beto — it doesn't need to re-read the raw HA state to pick
+which sub-agent to route to next. They also destroy prompt caching,
+because the stable cacheable prefix (instructions + tools) becomes a tiny
+fraction of a prompt dominated by churning tool blobs.
+
+Measured in production (April 2026): beto averaged 149K prompt tokens per
+call with only 2K cached — a 1.3% cache hit rate, vs. 66-82% for
+sub-agents that have their context scoped. The gap is almost entirely
+tool events.
+
+### What
+
+This callback drops ``Content`` entries from ``llm_request.contents`` whose
+parts are only ``function_call`` and/or ``function_response`` — i.e. no
+text for the LLM to read. User and assistant text survives unchanged, so
+conversational coherence is preserved across turns.
+
+Runs ``before_model_callback``, so it only affects the outgoing LLM
+request. ``session.events`` is untouched, leaving ADK's internal state
+tracking intact.
+
+Attach this to the **root agent only**. Sub-agents already have
+``scope_sub_agent_context_callback`` which trims to the current user
+turn and so don't need this.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _has_text_part(content: Any) -> bool:
+    """True when a Content has at least one part with non-empty text."""
+    try:
+        for part in getattr(content, "parts", None) or []:
+            if getattr(part, "text", None):
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def filter_tool_events_from_prompt(
+    callback_context: Any,
+    llm_request: Any,
+) -> Optional[Any]:
+    """Drop tool-only Content entries from ``llm_request.contents``.
+
+    Returns ``None`` so the filtered request proceeds to the model.
+    """
+    try:
+        contents = getattr(llm_request, "contents", None)
+        if not contents:
+            return None
+
+        original = len(contents)
+        filtered = [c for c in contents if _has_text_part(c)]
+
+        if len(filtered) == original:
+            return None
+
+        llm_request.contents = filtered
+        logger.debug(
+            "filter-tool-events: trimmed llm_request.contents %d → %d",
+            original,
+            len(filtered),
+        )
+    except Exception as e:
+        logger.debug("filter-tool-events callback error (non-fatal): %s", e)
+    return None

--- a/radbot/telemetry/usage_tracker.py
+++ b/radbot/telemetry/usage_tracker.py
@@ -15,10 +15,16 @@ from typing import Any, Dict
 _PRICING = {
     # model_prefix: (input_per_M, output_per_M, cached_input_per_M)
     "gemini-2.5-pro": (1.25, 10.00, 0.3125),
+    "gemini-2.5-flash-lite": (0.10, 0.40, 0.025),
     "gemini-2.5-flash": (0.15, 0.60, 0.0375),
     "gemini-2.0-flash": (0.10, 0.40, 0.025),
     "gemini-3.1-pro": (1.25, 10.00, 0.3125),
     "gemini-3.1-flash": (0.15, 0.60, 0.0375),
+    # Rolling aliases — Google periodically repoints these. Pricing is
+    # whatever the latest flash/pro tier costs, which tracks the explicit
+    # per-version entries above.
+    "gemini-flash-latest": (0.15, 0.60, 0.0375),
+    "gemini-pro-latest": (1.25, 10.00, 0.3125),
     # Fallback for unknown models
     "_default": (1.25, 10.00, 0.3125),
 }

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -49,10 +49,10 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 - **Global instruction**: injects today's date
 - **Tools**: `search_agent_memory`, `store_agent_memory` (via `create_agent_memory_tools("beto")`)
 - **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder, notifications, alerts, telemetry), HA client check
-- **Before-model callbacks**: `[scrub_empty_content_before_model, sanitize_before_model_callback]`
+- **Before-model callbacks**: `[filter_tool_events_from_prompt, scrub_empty_content_before_model, sanitize_before_model_callback]`
 - **After-model callbacks**: `[handle_empty_response_after_model, telemetry_after_model_callback]`
 - **Instruction file**: `config/default_configs/instructions/main_agent.md`
-- **Full conversation history**: root keeps all prior turns (unlike sub-agents, which are scoped to the current turn)
+- **Full conversation history**: root keeps all prior user/assistant text turns. Sub-agent tool_call and function_response events are dropped from the LLM prompt by `filter_tool_events_from_prompt` (session state is retained) to keep the cacheable prefix stable — without this, churning tool-response blobs pushed beto's prompt-cache hit rate to ~1%.
 
 ## Domain Agents
 
@@ -196,6 +196,7 @@ From `config/default_configs/instructions/main_agent.md`:
 | `sanitize_before_model_callback` | `callbacks/sanitize_callback.py` | beto (before_model) | Strip PII / sensitive tokens |
 | `scrub_empty_content_before_model` | `callbacks/empty_content_callback.py` | all (before_model) | Drop Content entries with empty text parts (Gemini API errors) |
 | `scope_sub_agent_context_callback` | `callbacks/scope_to_current_turn.py` | sub-agents only (before_model) | Trim to current turn |
+| `filter_tool_events_from_prompt` | `callbacks/filter_tool_events.py` | beto only (before_model) | Drop tool-only Content (function_call / function_response) from the LLM prompt so beto's cacheable prefix stays stable across turns |
 | `handle_empty_response_after_model` | `callbacks/empty_content_callback.py` | all (after_model) | Replace empty model responses with a "still thinking" marker |
 | `telemetry_after_model_callback` | `callbacks/telemetry_callback.py` | all (after_model) | Record token usage + cost in `llm_usage_log` with `session_id` |
 | `tool_call_repair_callback` | `callbacks/tool_call_repair_callback.py` | (available, not wired by default) | Repair malformed function calls |
@@ -213,4 +214,5 @@ From `config/default_configs/instructions/main_agent.md`:
 | `tools/adk_builtin/search_tool.py` | `search_agent` factory |
 | `tools/adk_builtin/code_execution_tool.py` | `code_execution_agent` factory |
 | `callbacks/scope_to_current_turn.py` | Per-turn context scoping for sub-agents |
+| `callbacks/filter_tool_events.py` | Strip tool-only Content from beto's LLM prompt to keep cacheable prefix stable |
 | `tools/shared/card_protocol.py` | `radbot:<kind>` fenced-block card emission |


### PR DESCRIPTION
## Summary

- Add a `before_model_callback` on the root agent that strips tool-only `Content` entries (function_call / function_response) from `llm_request.contents`, so beto's cacheable prefix stays stable turn-to-turn
- Plug three pricing-table gaps so rolling aliases (`gemini-flash-latest`, `gemini-pro-latest`) and the new `gemini-2.5-flash-lite` don't fall through to the PRO-rate `_default` row

## Measured problem

Production telemetry (April 1-18, 2026) surfaced an anomaly:

| Agent | Reqs | avg prompt/call | cache hit | Cost |
|---|---|---|---|---|
| **beto** | 269 | **149K tokens** | **1.3%** 🔴 | **$49.72** |
| comms | 332 | 190K | 66% | $40.15 |
| planner | 131 | 238K | 82% ✅ | $15.07 |

Beto's peers cache at 66-82%. Beto caches ~2K of its ~149K prompt — the instruction + 2 tools. The other ~147K is history that churns every turn, and that's almost entirely sub-agent tool-response blobs (HA entity lists, calendar dumps, etc.) flowing through the shared session. Sub-agents are scoped by `scope_sub_agent_context_callback`; beto is not (by design, so it stays conversationally coherent), which leaves it exposed to this leak.

## Fix

Beto is a pure orchestrator with only memory tools and ~71 output tokens per call. It doesn't need to re-read raw sub-agent tool outputs to pick the next routing step. `filter_tool_events_from_prompt` drops `Content` entries that have no text parts from `llm_request.contents`, keeping user/assistant text intact and leaving `session.events` untouched so ADK's internal state tracking is unaffected.

Companion: the `_PRICING` table's prefix-match didn't cover `gemini-flash-latest` (which sub-agents now use by default), `gemini-pro-latest`, or `gemini-2.5-flash-lite`. Those fell through to the pro-rate `_default` row, overstating cost ~8× for anything on the rolling alias. Added explicit entries.

## Projected impact

On current traffic, with beto's model also downgraded to flash (DB config change, already hot-reloaded separately):

- Before: ~$50/mo beto (pro × 149K tokens/call × 1.3% cache hit)
- After: ~$4/mo beto (flash × ~10K tokens/call × ~50%+ cache hit)

Savings come from three compounding factors: flash vs pro (~8×), smaller prompts (~15×), higher cache hit (~2×).

## Which specs did this PR update, or why was none needed?

- `specs/agents.md` — added the new callback to beto's before_model list, the Callback Inventory table, and the file-layout table. Context note on why beto's history is now text-only updated.

## Test plan

- [ ] After deploy, check `by_agent` breakdown at `/admin/api/telemetry/costs` for beto: `cache_hit%` should climb from ~1-3% toward 50%+, and avg `prompt_tokens/request` should drop from ~149K toward ~10K
- [ ] Smoke: send a handful of chat turns that exercise sub-agent transfers (e.g. HA turn off light, calendar query, todo list) and confirm beto stays coherent across turns and routes correctly
- [ ] Confirm `by_model` entries for `gemini-flash-latest` now show realistic ($0.15/M input) costs instead of pro-rate fallback pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)