### PR TITLE
feat(telos): persistent user-context store for beto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ radbot/
 │   ├── tracker_agent/            # Tracker agent (Todo + Webhooks)
 │   ├── comms_agent/              # Comms agent (Gmail + Jira)
 │   ├── execution_agent/          # Axel agent (shell + filesystem + MCP)
-│   └── research_agent/           # Scout agent (research + sequential thinking)
+│   ├── research_agent/           # Scout agent (research + sequential thinking)
+│   └── youtube_agent/            # Kidsvid agent (YouTube + CuriosityStream + Kideo)
 ├── tools/                        # All tool modules (see inventory below)
 ├── web/
 │   ├── app.py                    # FastAPI app, startup, route registration
@@ -125,7 +126,7 @@ Beto routes requests via ADK's `transfer_to_agent` — no wrapper tools needed.
 
 | Agent | Factory location | Tools | Purpose |
 |---|---|---|---|
-| **beto** (root) | `agent/agent_core.py` | 2 memory | Orchestrator, routes to specialists |
+| **beto** (root) | `agent/agent_core.py` | 2 memory + 18 telos | Orchestrator, routes to specialists; owns persistent user context (Telos) |
 | **casa** | `agent/home_agent/factory.py` | 6 HA + 4 Overseerr + 5 Lidarr + 8 Picnic + 2 memory | Smart home, media requests, music collection, grocery ordering |
 | **planner** | `agent/planner_agent/factory.py` | 1 time + 5 calendar + 3 scheduler + 3 reminder + 2 memory | Calendar, scheduling, reminders |
 | **tracker** | `agent/tracker_agent/factory.py` | 8 todo + 3 webhook + 2 memory | Task/project management |
@@ -155,6 +156,7 @@ Beto routes requests via ADK's `transfer_to_agent` — no wrapper tools needed.
 | `tools/homeassistant/` | `ha_tools_impl.py`, `ha_rest_client.py` | `list_ha_entities`, `get_ha_entity_state`, `turn_on/off/toggle_ha_entity`, `search_ha_entities` | Home Assistant REST |
 | `tools/scheduler/` | `schedule_tools.py`, `db.py`, `engine.py` | `create_scheduled_task_tool`, `list_scheduled_tasks_tool`, `delete_scheduled_task_tool` | APScheduler cron tasks |
 | `tools/reminders/` | `reminder_tools.py`, `db.py` | `create_reminder_tool`, `list_reminders_tool`, `delete_reminder_tool` | One-shot reminders |
+| `tools/telos/` | `telos_tools.py`, `db.py`, `loader.py`, `callback.py`, `markdown_io.py`, `cli.py` | 18 telos tools (read + silent-update + confirm-required) | Persistent user context store (identity, mission, goals, problems, projects, challenges, wisdom, predictions, journal, etc.). Beto-only. Injected into beto's `system_instruction` via `inject_telos_context` (anchor every turn, full block session-start). Onboarding: `uv run python -m radbot.tools.telos.cli onboard`. See `docs/implementation/telos.md` |
 | `tools/webhooks/` | `webhook_tools.py`, `db.py`, `template_renderer.py` | `create_webhook_tool`, `list_webhooks_tool`, `delete_webhook_tool` | External POST webhooks |
 | `tools/overseerr/` | `overseerr_tools.py`, `overseerr_client.py` | `search_overseerr_media_tool`, `request_overseerr_media_tool`, +2 more | Media requests |
 | `tools/lidarr/` | `lidarr_tools.py`, `lidarr_client.py` | `search_lidarr_artist_tool`, `add_lidarr_artist_tool`, +3 more | Music collection (Lidarr) |
@@ -187,6 +189,7 @@ All tables use the shared pool from `radbot/tools/todo/db/connection.py` unless 
 | `projects` | `tools/todo/db/schema.py` | `project_id` (UUID), `name` (UNIQUE) |
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
+| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section`, `ref_code`, `content`, `metadata` (JSONB), `status`, `sort_order`, UNIQUE (section, ref_code) |
 | `webhook_definitions` | `tools/webhooks/db.py` | `webhook_id` (UUID), `name` (UNIQUE), `path_suffix` (UNIQUE), `prompt_template`, `secret` |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `radbot_credentials` | `credentials/store.py` | `name` (PK), `encrypted_value`, `salt`, `credential_type` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,6 +29,7 @@
 - **Direct-action endpoints**: `/api/media/*` and `/api/ha/*` let the frontend trigger Overseerr + HA actions directly from cards — no LLM roundtrip.
 - **Token + cost telemetry**: `telemetry_after_model_callback` writes to `llm_usage_log` with `session_id` threaded through. `GET /api/sessions/{id}/stats` exposes per-session totals + rolling today/month cost.
 - **Unified notifications**: `notifications` table aggregates scheduled-task results, reminders, alerts, ntfy inbound. `/api/notifications/*` and `pages/NotificationsPage.tsx` drive the feed + drawer.
+- **Telos (persistent user context)**: beto owns a structured persona / context store (mission, problems, goals, projects, challenges, wisdom, predictions, taste, journal) in `telos_entries`. `inject_telos_context` (on beto only — sub-agents don't get it) appends a ~300B anchor to `system_instruction` every turn and a ~2KB full block on the first turn of each session. One-time onboarding via `uv run python -m radbot.tools.telos.cli onboard`. Beto keeps the file alive via silent tools (journal, predictions, wisdom, taste) and confirm-required tools (goals, mission, problems). See `docs/implementation/telos.md`.
 - **Config priority**: DB config > file config > credential store > env vars. See `specs/config.md`.
 - **Error pattern**: Agent tools return `{"status": "success/error", ...}` dicts.
 - **Logging**: Structured JSON via `radbot/logging_config.py`. One INFO per operation, DEBUG for hot loops.

--- a/docs/implementation/telos.md
+++ b/docs/implementation/telos.md
@@ -1,0 +1,521 @@
+# Telos — Persistent Self-Context for radbot
+
+## Purpose
+
+Give beto and all sub-agents a structured, always-loaded understanding of the
+user (role, mission, goals, projects, challenges, wisdom, taste, calibration
+history, journal). The file is **alive**: the agent writes to it during
+interactions so it compounds over time, instead of sitting frozen as a prompt
+append.
+
+Adapted from [Daniel Miessler's Telos framework](https://github.com/danielmiessler/Telos).
+The conceptual path — **Problems → Mission → Narratives → Goals → Challenges →
+Strategies → Projects → Journal** — is preserved so the file roundtrips with
+canonical Telos markdown (paste in, paste out, shared across tools).
+
+Single-user system (`user_id = "web_user"`); no user scoping in schema.
+
+---
+
+## Data model
+
+One table, one source of truth. Section-specific metadata lives in JSONB so we
+don't churn the schema when adding sections.
+
+```sql
+CREATE TABLE telos_entries (
+    entry_id     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    section      TEXT NOT NULL,          -- see section catalogue below
+    ref_code     TEXT,                   -- "G1", "P3", "PRED4" — human-readable, unique within section
+    content      TEXT NOT NULL,          -- the main body of the entry
+    metadata     JSONB NOT NULL DEFAULT '{}'::jsonb,  -- section-specific fields
+    status       TEXT NOT NULL DEFAULT 'active',      -- active | completed | archived | superseded
+    sort_order   INTEGER NOT NULL DEFAULT 0,          -- for user-defined ordering of goals, problems, etc.
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (section, ref_code)
+);
+
+CREATE INDEX idx_telos_section_status ON telos_entries (section, status);
+CREATE INDEX idx_telos_active ON telos_entries (section) WHERE status = 'active';
+CREATE INDEX idx_telos_journal_recent ON telos_entries (created_at DESC) WHERE section = 'journal';
+```
+
+`identity` is a special single-entry section: enforced by convention (the tools
+only ever upsert one entry with `ref_code = 'ME'`), not by a DB constraint.
+
+### Section catalogue
+
+Each section's `metadata` JSONB shape is documented here. The loader, tools,
+and markdown parser all agree on these shapes.
+
+| Section         | Cardinality | Metadata fields |
+|-----------------|-------------|-----------------|
+| `identity`      | 1           | `{name, location, role, pronouns?}` |
+| `history`       | N           | `{}` (prose) |
+| `problems`      | N           | `{}` — top-level things the user is trying to solve |
+| `mission`       | N           | `{}` — usually 1-3 entries |
+| `narratives`    | N           | `{}` — self-story sentences |
+| `goals`         | N           | `{deadline?, kpi?, parent_problem?, status_notes?}` |
+| `challenges`    | N           | `{parent_goal?}` |
+| `strategies`    | N           | `{parent_goal?, parent_challenge?}` |
+| `projects`      | N           | `{priority?, parent_goal?, due?}` |
+| `wisdom`        | N           | `{origin?}` — principles user lives by |
+| `ideas`         | N           | `{}` — opinions / hot takes |
+| `predictions`   | N           | `{probability, deadline, resolution?, resolved_at?, outcome?}` |
+| `wrong_about`   | N           | `{origin_date?, source?}` — calibration history |
+| `best_books`    | N           | `{sentiment: strong_positive, note?}` |
+| `best_movies`   | N           | `{sentiment, note?}` |
+| `best_music`    | N           | `{sentiment, note?}` |
+| `taste`         | N           | `{category, sentiment}` — misc preferences (food, tools, games) |
+| `traumas`       | N           | `{}` — sensitive, on-demand only |
+| `metrics`       | N           | `{target?, current?, unit?}` — long-lived KPIs |
+| `journal`       | N           | `{event_type?, related_refs?: [str]}` — append-only stream |
+
+`status` values:
+- `active` — currently true / in force
+- `completed` — goal achieved, prediction resolved, challenge overcome
+- `archived` — no longer relevant but kept for history
+- `superseded` — replaced by a newer entry (store the new `ref_code` in `metadata.superseded_by`)
+
+---
+
+## Injection model
+
+Telos is beto-only. Sub-agents (casa, planner, tracker, comms, axel, scout)
+are tool executors — they need scoped instructions + their tools, not the
+user's mission / wisdom / journal. Injecting Telos into their prompts would
+bloat them for zero benefit and muddy their single-purpose framing.
+
+Within beto, the block is **not** sent with every turn. That's wasteful as
+Telos grows and dilutes signal on routing-heavy turns where persona is
+irrelevant. Three tiers strike the balance:
+
+| Tier | When | Size | Purpose |
+|---|---|---|---|
+| 1. Anchor | Every turn | ~300 bytes | Identity + Mission + pointer to tools |
+| 2. Full block | First turn of each session | ~2KB | Ground beto in the user's full context at session start |
+| 3. On-demand sections | Tool call | arbitrary | Deep dive when relevant |
+
+### Why session-start works
+
+ADK chat sessions have stable IDs; each new web chat or CLI session gets a
+fresh one. The full block is injected into the **conversation history** on
+turn 1, so it stays in-context for all subsequent turns in that session
+without re-sending. Subsequent turns carry only the anchor (in
+`system_instruction`) — enough to keep beto grounded and to remind it that
+`telos_get_section` / `telos_get_full` exist for deeper lookups.
+
+When ADK eventually compacts / summarises old turns, the turn-1 Telos block
+may get compressed out. The anchor present on every turn ensures beto
+always knows how to re-fetch.
+
+### Implementation — beto-only, via `before_model_callback`
+
+`global_instruction` is **not** used for Telos — ADK propagates it to sub-
+agents. Instead, a callback on beto's `before_model_callback` chain
+appends to beto's `system_instruction` at request time:
+
+```python
+# radbot/tools/telos/callback.py
+_ANCHOR_TEMPLATE = """TELOS ANCHOR: {identity_line}
+Mission: {mission_line}
+{counts_line}
+Use telos_get_section(name) or telos_get_full() for details.
+"""
+
+def inject_telos_context(callback_context, llm_request):
+    anchor, full_block = build_telos_tiers()  # loader builds both
+    if not anchor:
+        return  # empty Telos — callback is a no-op
+
+    # Tier 1: anchor goes on every turn
+    existing = llm_request.config.system_instruction or ""
+    llm_request.config.system_instruction = f"{existing}\n\n{anchor}"
+
+    # Tier 2: full block on first turn of session only
+    if not callback_context.state.get("telos_bootstrapped"):
+        llm_request.contents = inject_system_note_at_start(
+            llm_request.contents, full_block
+        )
+        callback_context.state["telos_bootstrapped"] = True
+```
+
+Tier 2 is injected as a synthetic first "system note" turn in
+`llm_request.contents` so it lands in the conversation history and stays
+visible for the whole session. Tier 1 goes into `system_instruction` so
+it's present on every call regardless of history compaction.
+
+The callback is registered only on the root `beto` agent in
+`agent_core.py:168` — sub-agents' callback chains are untouched.
+
+### Anchor contents (Tier 1, every turn)
+
+Kept deliberately small:
+
+```
+TELOS ANCHOR: Perry (realitysandwich@gmail.com), <role>, <location>
+Mission: <first active mission, one line>
+Active: N goals, M projects, K problems, J active journal entries
+Use telos_get_section(name) or telos_get_full() for details.
+```
+
+Hard cap: 500 bytes. If Identity or Mission entries are long, truncate to
+one line each.
+
+### Full block contents (Tier 2, session start)
+
+Built by `build_telos_tiers()`, returned alongside the anchor. Contents, in
+order, each skipped if empty:
+
+1. **Identity** — one-liner
+2. **Mission** — all `active`
+3. **Problems** — all `active` (summary only: `ref_code: content`)
+4. **Goals** — all `active`, sorted by `sort_order`
+5. **Active projects** — `active` only
+6. **Challenges** — `active` only
+7. **Wisdom** — all (usually short list)
+8. **Recent journal** — last 5 entries, `created_at` desc
+
+Hard budget: target ~2KB, truncate journal first if over. On a fresh
+install (empty DB), both anchor and full_block are empty and the callback
+is a no-op — beto runs with its normal instruction only.
+
+### Mid-session data changes
+
+Ambient writes by beto during a session (new journal entry, resolved
+prediction, added wisdom) are already visible to beto in the transcript —
+beto saw its own tool call. No re-injection needed within the session.
+
+Admin-UI edits during a live session are rare for a single-user setup. If
+it becomes a real issue, the anchor can include a `telos_version` derived
+from `SELECT MAX(updated_at) FROM telos_entries` (cached for a few
+seconds). Comparing against `callback_context.state["telos_bootstrapped_version"]`
+lets us re-trigger Tier 2 when they diverge. Deferred until needed —
+overkill for Phase 1.
+
+### On-demand sections (Tier 3)
+
+Beto calls `telos_get_section(section)` or `telos_get_full()` when a
+section is relevant to the current request. Full list of retrievable
+sections matches the catalogue above. `traumas` is on-demand only (never
+always-loaded — privacy).
+
+---
+
+## Tools (FunctionTools on beto)
+
+All tools return `{"status": "success" | "error", ...}` per radbot convention.
+Silent vs. confirm-required is enforced by the agent's instructions, not the
+tool signature — the tool just does what it's asked.
+
+### Read tools
+
+| Tool | Purpose |
+|---|---|
+| `telos_get_section(section: str)` | Return all active entries in a section |
+| `telos_get_entry(section: str, ref_code: str)` | Fetch one entry by ref_code |
+| `telos_get_full()` | Return full Telos as canonical markdown (for review / export) |
+| `telos_search_journal(query: str, limit: int = 20)` | Simple ILIKE search over journal content |
+
+### Silent-update tools (no confirmation required)
+
+| Tool | Trigger heuristic |
+|---|---|
+| `telos_add_journal(entry, event_type=None, related_refs=None)` | Anything notable that happens in the conversation |
+| `telos_add_prediction(claim, probability, deadline)` | User makes a claim with a probability or timeframe |
+| `telos_resolve_prediction(ref_code, outcome, actual_value=None)` | Resolution moment; auto-adds a `wrong_about` entry if `outcome == False` and `probability >= 0.75` |
+| `telos_note_wrong(thing, why)` | User acknowledges being wrong about something |
+| `telos_note_taste(category, item, sentiment, note=None)` | Strong opinion on a book/movie/music/food/tool |
+| `telos_add_wisdom(principle, origin=None)` | User voices a quotable principle they live by |
+| `telos_add_idea(idea)` | User voices a strong opinion/hot-take |
+
+### Confirmation-required tools (agent proposes, user approves in plain language)
+
+| Tool | Why it's structural |
+|---|---|
+| `telos_upsert_identity(...)` | Changes the always-loaded one-liner about who you are |
+| `telos_add_problem(description)` / `telos_update_problem(ref_code, ...)` | Top-level framing — rare, high-impact |
+| `telos_upsert_mission(content, replace_ref=None)` | Rare, reframes everything downstream |
+| `telos_add_narrative(content)` / `telos_update_narrative(ref_code, ...)` | Self-story — structural |
+| `telos_add_goal(title, deadline=None, kpi=None, parent_problem=None)` | Significant commitment |
+| `telos_update_goal(ref_code, status=None, deadline=None, kpi=None, notes=None)` | Changes live commitment |
+| `telos_complete_goal(ref_code, resolution)` | Marks success; auto-adds journal entry |
+| `telos_add_challenge(description, parent_goal=None)` | Structural |
+| `telos_add_strategy(content, parent_goal=None, parent_challenge=None)` | Structural |
+| `telos_add_project(name, priority=None, parent_goal=None, due=None)` / `telos_update_project(...)` | Active work scope |
+| `telos_archive(section, ref_code, reason)` | Soft-delete — always confirm before losing state |
+
+Policy enforcement lives in `main_agent.md`:
+
+> **Telos update policy.** You have tools that modify the user's persistent
+> Telos file. For tools marked silent (journal, predictions, wrong-about,
+> taste, wisdom, ideas), update freely when the conversation clearly warrants
+> it — do not ask permission. For all other telos_* tools, propose the change
+> in one plain sentence and wait for confirmation before calling. Never
+> archive without explicit approval.
+
+### Ref-code assignment
+
+When creating entries in sections that use ref_codes (problems, goals,
+predictions, projects, challenges, strategies, narratives), the tool auto-
+assigns the next available code: `P1`, `P2`, … for problems; `G1`, `G2`, …
+for goals; `PRED1` … for predictions. Prefix table lives in `models.py`.
+Users can override by passing `ref_code` explicitly.
+
+---
+
+## Markdown I/O
+
+`radbot/tools/telos/markdown_io.py` provides:
+
+- `parse_telos_markdown(text: str) -> list[Entry]` — strict parser for the
+  canonical Telos format (`## SECTION` headers, `- REF: content` bullets).
+- `render_telos_markdown(entries: list[Entry]) -> str` — inverse.
+
+Round-trip rule: parse → render → parse must be idempotent. Unknown sections
+parse into `metadata.raw_section_name` and render back unchanged.
+
+Used by:
+- `telos_get_full()` tool (export)
+- Admin UI "Import" textarea (paste a canonical Telos md file)
+- CLI one-shot: `uv run python -m radbot.tools.telos.cli import path/to/telos.md`
+
+---
+
+## File layout
+
+```
+radbot/tools/telos/
+├── __init__.py          # exports init_telos_schema, build_telos_context, tool list
+├── db.py                # init_telos_schema(), CRUD (add_entry, update_entry, list_by_section, archive, bulk_upsert)
+├── models.py            # Entry dataclass, Section enum, REF_PREFIX map
+├── telos_tools.py       # FunctionTools — all telos_* tools wrapped here
+├── loader.py            # build_telos_tiers() -> (anchor_str, full_block_str)
+├── callback.py          # inject_telos_context — tier 1 every turn, tier 2 session-start only (state flag)
+├── markdown_io.py       # parse_telos_markdown, render_telos_markdown
+└── cli.py               # uv run python -m radbot.tools.telos.cli {onboard|import|export|show|reset}
+```
+
+Admin API and UI (Phase 2) live in the standard locations:
+- `radbot/web/api/telos.py` — REST router
+- `radbot/web/frontend/src/components/admin/panels/TelosPanel.tsx` — edit UI
+
+---
+
+## Integration points
+
+All file:line refs verified against current `main`:
+
+| Change | Location |
+|---|---|
+| Register schema init | `radbot/agent/agent_tools_setup.py:27` — add `("telos_init", "radbot.tools.telos", "init_telos_schema")` to `_SCHEMA_INITS` |
+| Inject Telos into **beto only** | `radbot/agent/agent_core.py:168` — add `inject_telos_context` from `radbot.tools.telos.callback` to the root agent's `before_model_callback` list. Do **not** use `global_instruction` (propagates to sub-agents). Do **not** add to `_before_cbs` used by sub-agents at line 151 |
+| Register beto's read + write tools | `radbot/agent/agent_core.py` — where `beto_tools` is assembled (just before line 160); add the Telos tool list alongside memory tools |
+| Agent guidance | `radbot/config/default_configs/instructions/main_agent.md` — add "Telos update policy" section only (silent vs. confirm tools). No onboarding text |
+| Startup schema init (idempotent safety net) | `radbot/web/app.py :: initialize_app_startup()` — add `from radbot.tools.telos import init_telos_schema; init_telos_schema()` alongside existing schema inits |
+
+**Scoped memory vs Telos**: sub-agents keep their per-agent Qdrant memory
+(source_agent tag). Telos lives **only** on beto — sub-agents are tool
+executors and don't need the user's mission / wisdom / journal in their
+prompts. The callback is deliberately attached to beto's callback chain,
+not the shared `_before_cbs` list used by sub-agents.
+
+---
+
+## Admin UI (Phase 2)
+
+Single navigation entry at `/admin/` → "Telos". The panel branches on
+`GET /api/telos/status`:
+
+- **`has_identity === false`** → render the onboarding wizard (see
+  Onboarding section above). One-time; never shown again after Identity
+  is saved.
+- **`has_identity === true`** → render the normal editor:
+  - **Identity** — single form (name, location, role, pronouns)
+  - **Mission / Problems / Goals / Projects / Challenges** — editable lists with add/archive/complete
+  - **Predictions** — list with "resolve" buttons (prompts for outcome)
+  - **Journal** — chronological feed, read-only except for manual add
+  - **Wisdom / Ideas / Taste** — editable lists
+  - **Wrong About** — list (rarely edited)
+  - **History / Traumas** — freeform prose editors, collapsed by default
+  - **Import / Export** — markdown textarea + download/upload buttons
+
+Follows existing admin-panel patterns in
+`radbot/web/frontend/src/components/admin/panels/`. No credential store
+integration — Telos isn't secret, just user content in a regular DB table.
+
+Not required for Phase 1 — CLI onboarding and direct DB editing cover
+the one-time bootstrap.
+
+---
+
+## Onboarding
+
+Radbot is single-user, single-install. Onboarding is a **one-time setup
+event**, not an agent conversation — the agent shouldn't know about it at
+all. Baking the interview into `main_agent.md` or a skill file would waste
+prompt tokens forever after it's done, and complicates beto's framing for a
+task beto doesn't need to own.
+
+Instead, onboarding runs **outside the agent loop**, directly populating the
+DB. Two entry points, both writing via the same REST endpoints:
+
+### Primary: admin panel wizard
+
+A guided form in the existing admin UI at `/admin/` → "Telos" →
+"Onboarding" (only shown while the DB is empty; hidden once Identity
+exists). Multi-step wizard covering the same 9 sections:
+
+1. Identity (name, location, role, pronouns) — single form
+2. Problems (1–3, add rows)
+3. Mission (1–2 sentences)
+4. Goals (add rows, each with optional deadline + KPI)
+5. Projects (add rows, optional priority + due)
+6. Challenges (add rows, optional parent goal dropdown)
+7. Wisdom (add rows, optional origin)
+8. Taste — best books / movies (add rows)
+9. History (freeform textarea — optional, explicitly skippable)
+
+Each step has "Skip" and "Save & Next." At any point the user can "Finish"
+to commit what they have. Final step saves everything in one transaction
+via `POST /api/telos/bulk` and flips the wizard to hidden on subsequent
+loads.
+
+Traumas and predictions are not part of the wizard — too sensitive /
+session-dependent. Those populate through ambient agent updates later.
+
+### Secondary: CLI
+
+Power-user alternative, for folks who'd rather answer in a terminal:
+
+```bash
+uv run python -m radbot.tools.telos.cli onboard
+```
+
+Interactive prompt loop, same 9 questions, same destination. Also:
+
+```bash
+uv run python -m radbot.tools.telos.cli import path/to/my_telos.md
+uv run python -m radbot.tools.telos.cli export > my_telos.md
+uv run python -m radbot.tools.telos.cli reset   # wipes all entries (confirms)
+```
+
+### Completion marker
+
+Presence of an `identity` entry. The admin panel checks
+`GET /api/telos/status` → `{has_identity: bool}` to decide whether to show
+the onboarding wizard or the normal editor. That's the only place the
+"onboarded?" question is asked — beto never sees this flag.
+
+### Agent involvement: none
+
+- `main_agent.md` gets only the Telos **update policy** (silent vs.
+  confirm tools). No onboarding instructions, no skill file, no nudges.
+- No `telos_onboarding_status` tool. Deleted from the tool list.
+- `before_model_callback` does not inject any onboarding hint. On empty
+  Telos it simply injects nothing.
+- `telos_import_markdown` **stays** as an agent tool — it's a legit
+  utility ("load this Telos file I just pasted") unrelated to onboarding.
+
+---
+
+## Phased plan
+
+### Phase 1 — Backend MVP + CLI onboarding (1 PR)
+
+Ships the smallest thing that works end-to-end: schema, agent tools, beto
+injection, and a way to actually populate the DB (CLI onboarding + markdown
+import).
+
+1. `radbot/tools/telos/` module: `db.py`, `models.py`, `loader.py`,
+   `callback.py`, `markdown_io.py`, `telos_tools.py`, `cli.py`
+2. Register schema init in `agent_tools_setup.py` + `app.py`
+3. Wire `inject_telos_context` into **beto's** `before_model_callback` list
+   in `agent_core.py:168` — **not** into the shared `_before_cbs` used by
+   sub-agents (line 151). Not via `global_instruction`
+4. Register Telos read + write tools on beto (`telos_get_*`, silent tools,
+   confirm-required tools, `telos_import_markdown`). No
+   `telos_onboarding_status`
+5. Update `main_agent.md` with the Telos **update policy** only (silent vs.
+   confirm-required tools). No onboarding instructions
+6. CLI onboarding: `uv run python -m radbot.tools.telos.cli onboard`
+   (interactive prompts), plus `import`, `export`, `show`, `reset`
+   subcommands
+7. Unit tests: markdown round-trip; silent tool creates entry; confirm-
+   required tool creates entry (no enforcement at tool layer — instructions
+   do that); `build_telos_tiers()` anchor ≤500 bytes; full block ≤2KB;
+   callback injects full block only on first turn (state flag gates it);
+   subsequent turns receive anchor only; callback does nothing when DB
+   is empty; callback is present on beto but absent from sub-agents
+8. Update `specs/tools.md` (new section listing), `specs/agents.md` (beto
+   tool count), `specs/storage.md` (new table), `SPEC.md` (quick-ref)
+
+**Bootstrap path for first run**: after deploying, run
+`uv run python -m radbot.tools.telos.cli onboard` once in the terminal to
+populate the DB. From there, the agent keeps it alive ambiently. Admin UI
+onboarding wizard is Phase 2.
+
+### Phase 2 — Admin UI + onboarding wizard (1 PR)
+
+1. `radbot/web/api/telos.py` — REST router:
+   - `GET /api/telos/status` → `{has_identity}`
+   - `GET /api/telos/section/{section}` / `GET /api/telos/full`
+   - `PUT /api/telos/entry/{section}/{ref_code}` / `POST /api/telos/entry/{section}`
+   - `POST /api/telos/archive/{section}/{ref_code}`
+   - `POST /api/telos/bulk` — atomic multi-section upsert (used by wizard)
+   - `POST /api/telos/import` (markdown body) / `GET /api/telos/export`
+2. `TelosOnboardingWizard.tsx` — multi-step form, only rendered when
+   `status.has_identity === false`
+3. `TelosPanel.tsx` — normal editor for sections (identity, mission,
+   problems, goals, projects, challenges, wisdom, ideas, predictions with
+   resolve, journal feed, taste, wrong-about, history, traumas); shown
+   when `status.has_identity === true`. Includes import/export markdown
+   textarea
+4. Register in `AdminPage.tsx` NAV_ITEMS + PANEL_MAP (single "Telos"
+   entry; the panel internally branches wizard vs. editor on status)
+5. Update `specs/web.md` (new router + panel)
+
+### Phase 3 — Review loop (optional, 1 PR)
+
+A scheduled task that runs weekly (via existing `tools/scheduler/`):
+
+> "Review predictions past their deadlines, goals nearing their deadlines,
+>  recent journal entries that might be wisdom worth canonicalizing, and
+>  active problems that haven't had journal activity in 60+ days."
+
+Agent proposes edits, user approves. Uses only existing tools; no new code
+beyond registering the scheduled task prompt.
+
+---
+
+## Open design questions (to decide before coding)
+
+1. **Should `telos_resolve_prediction` auto-create a `wrong_about` entry on
+   miscalibration?** Current draft says yes when `outcome == False` and
+   `probability >= 0.75` (you were confident and wrong). Could also cover the
+   symmetric case (outcome True, probability ≤ 0.25). Tradeoff: automatic
+   miscalibration logging is the whole point of predictions, but feels
+   presumptuous if the agent does it silently. Proposal: silent, because the
+   user can always ask the agent to remove entries.
+
+2. **Section size caps for always-loaded?** e.g. if you have 50 active goals
+   the `global_instruction` bloats. Proposal: hard cap of 15 goals / 10
+   projects / 10 challenges / 20 wisdom items in always-loaded; the full list
+   is still available via `telos_get_section`. Overflow is surfaced in the
+   injection as `"(+N more — call telos_get_section('goals') for full list)"`.
+
+3. **Multi-line content** (e.g. long mission paragraphs) — supported in the
+   DB (content is TEXT), but canonical Telos markdown uses single-line
+   bullets. Proposal: markdown parser allows indented continuation lines and
+   joins them with `\n`; renderer emits them the same way.
+
+4. **ref_code collisions on markdown import** — if an imported file reuses a
+   code that's already in the DB, either overwrite or renumber. Proposal:
+   import is always "merge into current" (update existing by ref_code, add
+   new ones). A separate `--replace` flag wipes the section first.
+
+5. **Journal retention** — unbounded growth is fine for now (one user, text
+   is cheap). Revisit if the table exceeds ~10K rows; add an archive job
+   that moves entries older than 2 years to `status='archived'` so the
+   "recent 5" query stays fast (the partial index already handles this).

--- a/radbot/agent/agent_core.py
+++ b/radbot/agent/agent_core.py
@@ -39,6 +39,7 @@ from radbot.config.config_loader import config_loader
 # Import memory tools and services
 from radbot.memory.qdrant_memory import QdrantMemoryService
 from radbot.tools.memory.agent_memory_factory import create_agent_memory_tools
+from radbot.tools.telos import TELOS_TOOLS, inject_telos_context
 
 # Get the instruction from the config manager
 instruction = config_manager.get_instruction("main_agent")
@@ -116,8 +117,9 @@ logger.debug(f"Using model: {model_name}")
 # Get today's date for the global instruction
 today = date.today()
 
-# Beto's tools: only agent-scoped memory tools (orchestrator pattern)
-beto_tools = create_agent_memory_tools("beto")
+# Beto's tools: agent-scoped memory + Telos (persistent user persona / context store).
+# Sub-agents do NOT get Telos tools — they're tool executors, not persona-aware.
+beto_tools = create_agent_memory_tools("beto") + list(TELOS_TOOLS)
 
 # ---------------------------------------------------------------------------
 # Create ALL sub-agents BEFORE the root Agent constructor.
@@ -169,6 +171,10 @@ root_agent = Agent(
         filter_tool_events_from_prompt,
         scrub_empty_content_before_model,
         sanitize_before_model_callback,
+        # Telos: inject user persona/context into beto's system_instruction.
+        # Anchor every turn, full block session-start only (state-gated).
+        # Attached to beto ONLY — sub-agents don't need user persona context.
+        inject_telos_context,
     ],
     after_model_callback=[handle_empty_response_after_model, telemetry_after_model_callback],
     generate_content_config=types.GenerateContentConfig(temperature=0.2),

--- a/radbot/agent/agent_tools_setup.py
+++ b/radbot/agent/agent_tools_setup.py
@@ -29,6 +29,7 @@ _SCHEMA_INITS = [
     ("scheduler_init", "radbot.tools.scheduler", "init_scheduler_schema"),
     ("webhook_init", "radbot.tools.webhooks", "init_webhook_schema"),
     ("reminder_init", "radbot.tools.reminders", "init_reminder_schema"),
+    ("telos_init", "radbot.tools.telos", "init_telos_schema"),
 ]
 
 

--- a/radbot/config/default_configs/instructions/main_agent.md
+++ b/radbot/config/default_configs/instructions/main_agent.md
@@ -82,3 +82,27 @@ To delegate work, call the agent by name as a tool (e.g., `casa(goal="turn on th
 - **"cart"**, **"Picnic"**, **"order"**, **"delivery"** → casa (Picnic grocery integration)
 - **"shopping list"**, **"grocery list"**, **"todo"**, **"task"** → tracker (todo system)
 - The tracker shopping list can be synced to Picnic later via casa's bridge tool
+
+## Telos — persistent user context
+
+You have access to the user's Telos: a structured, long-lived record of their identity, mission, goals, problems, projects, challenges, wisdom, predictions, taste, and journal. A short anchor is injected into your context every turn; the full block loads once per session. For any section not in the anchor (or if you need detail beyond what's shown), call `telos_get_section(name)` or `telos_get_full()`.
+
+Sections: `identity`, `mission`, `problems`, `narratives`, `goals`, `challenges`, `strategies`, `projects`, `wisdom`, `ideas`, `predictions`, `wrong_about`, `best_books`, `best_movies`, `best_music`, `taste`, `history`, `traumas`, `metrics`, `journal`. Reference `traumas` only when clearly relevant to the conversation.
+
+### Update policy
+
+**Silent updates** — call without asking. Use when the conversation clearly warrants it:
+- `telos_add_journal` — notable events, decisions, moods, interactions worth remembering.
+- `telos_add_prediction` — user voices a forecast with a probability or timeframe.
+- `telos_resolve_prediction` — a prior prediction resolved; outcome known.
+- `telos_note_wrong` — user concedes they were wrong about something.
+- `telos_note_taste` — user expresses a clear opinion on a book / movie / music / food / tool / game.
+- `telos_add_wisdom` — user voices a quotable principle they live by.
+- `telos_add_idea` — user voices a strong opinion or hot-take.
+
+**Confirm-required** — propose the change in one plain sentence and wait for user agreement before calling:
+- `telos_upsert_identity`, `telos_add_entry` (for problems/mission/narratives/strategies), `telos_update_entry`, `telos_add_goal`, `telos_complete_goal`, `telos_archive`, `telos_import_markdown` with `replace=True`.
+
+**Never archive** a Telos entry without explicit user approval. Never invent goals, missions, or problems the user hasn't stated.
+
+Do not mention the Telos mechanism to the user unless they ask. Just use it to ground your responses.

--- a/radbot/tools/telos/__init__.py
+++ b/radbot/tools/telos/__init__.py
@@ -1,0 +1,21 @@
+"""Telos — persistent user-context store for beto.
+
+Single table (``telos_entries``) holds structured sections: identity,
+mission, problems, goals, projects, challenges, wisdom, predictions,
+journal, etc. Beto reads it on every turn (anchor) and at session start
+(full block), and writes to it during interactions via FunctionTools.
+
+See ``docs/implementation/telos.md`` for the full design.
+"""
+
+from .callback import inject_telos_context
+from .db import init_telos_schema
+from .loader import build_telos_tiers
+from .telos_tools import TELOS_TOOLS
+
+__all__ = [
+    "TELOS_TOOLS",
+    "build_telos_tiers",
+    "init_telos_schema",
+    "inject_telos_context",
+]

--- a/radbot/tools/telos/callback.py
+++ b/radbot/tools/telos/callback.py
@@ -1,0 +1,109 @@
+"""Before-model callback that injects Telos context into beto's prompt.
+
+Two-tier injection:
+
+* Tier 1 — anchor (~300B, capped at 500): appended to
+  ``llm_request.config.system_instruction`` on EVERY turn. Keeps beto
+  grounded in identity + mission + pointer to tools.
+
+* Tier 2 — full block (~2KB, capped at 2048): appended to
+  ``llm_request.config.system_instruction`` on the FIRST turn of each
+  session only, gated by ``callback_context.state["telos_bootstrapped"]``.
+  Subsequent turns in the same session drop it to save context window.
+
+  (Per-turn re-injection is unnecessary because once the model has seen
+  the full block in a session, the ensuing conversation history keeps it
+  fresh in-context. If ADK compacts old turns, the anchor remains.)
+
+Attach to beto's ``before_model_callback`` list only. Do NOT add to the
+shared ``_before_cbs`` used by sub-agents — sub-agents are tool executors
+and don't need user persona context.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_BOOTSTRAP_STATE_KEY = "telos_bootstrapped"
+
+
+def inject_telos_context(callback_context: Any, llm_request: Any) -> Optional[Any]:
+    """Inject Telos tiers into ``llm_request.config.system_instruction``.
+
+    Returns ``None`` so the modified request proceeds to the model.
+    """
+    try:
+        from .loader import build_telos_tiers
+
+        anchor, full_block = build_telos_tiers()
+        if not anchor and not full_block:
+            return None  # empty Telos — no-op
+
+        # Session-start gate: first turn gets anchor + full block;
+        # subsequent turns get anchor only.
+        state = _get_state(callback_context)
+        is_first_turn = not state.get(_BOOTSTRAP_STATE_KEY)
+
+        if is_first_turn and full_block:
+            injection = f"{anchor}\n\n{full_block}" if anchor else full_block
+            try:
+                state[_BOOTSTRAP_STATE_KEY] = True
+            except Exception as e:
+                logger.debug("could not set telos bootstrap state flag: %s", e)
+        else:
+            injection = anchor
+
+        if injection:
+            _append_to_system_instruction(llm_request, injection)
+    except Exception as e:
+        logger.warning("inject_telos_context error (non-fatal): %s", e)
+    return None
+
+
+def _get_state(callback_context: Any) -> Any:
+    """Access callback_context.state defensively."""
+    state = getattr(callback_context, "state", None)
+    if state is None:
+        return {}
+    return state
+
+
+def _append_to_system_instruction(llm_request: Any, text: str) -> None:
+    """Append text to ``llm_request.config.system_instruction``.
+
+    ADK passes a ``google.genai.types.GenerateContentConfig`` as
+    ``llm_request.config``. ``system_instruction`` on that config may be
+    ``None``, a ``str``, or a ``Content``. We coerce to string and append.
+    """
+    config = getattr(llm_request, "config", None)
+    if config is None:
+        return
+    existing = getattr(config, "system_instruction", None)
+    if existing is None:
+        config.system_instruction = text
+        return
+    if isinstance(existing, str):
+        config.system_instruction = f"{existing}\n\n{text}"
+        return
+    # Content-like: try to extract text from parts.
+    existing_text = _content_to_text(existing)
+    config.system_instruction = (
+        f"{existing_text}\n\n{text}" if existing_text else text
+    )
+
+
+def _content_to_text(content: Any) -> str:
+    """Best-effort string extraction from a Content-like object."""
+    try:
+        parts = getattr(content, "parts", None) or []
+        chunks = []
+        for part in parts:
+            t = getattr(part, "text", None)
+            if t:
+                chunks.append(t)
+        return "\n".join(chunks)
+    except Exception:
+        return ""

--- a/radbot/tools/telos/cli.py
+++ b/radbot/tools/telos/cli.py
@@ -1,0 +1,345 @@
+"""Telos command-line interface.
+
+    uv run python -m radbot.tools.telos.cli {onboard|import|export|show|reset}
+
+* onboard — interactive one-time setup (9-question interview).
+* import FILE — load a canonical Telos markdown file (merge into DB).
+* export — print current Telos as canonical markdown to stdout.
+* show — print a human-readable summary of the current state.
+* reset — wipe ALL entries (asks for confirmation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from . import db as telos_db
+from .markdown_io import parse_telos_markdown, render_telos_markdown
+from .models import IDENTITY_REF, Entry, Section
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompts
+# ---------------------------------------------------------------------------
+
+
+def _prompt_line(label: str, allow_skip: bool = True) -> Optional[str]:
+    """Single-line prompt. Returns None on empty/skip."""
+    hint = " (enter to skip)" if allow_skip else ""
+    sys.stdout.write(f"{label}{hint}: ")
+    sys.stdout.flush()
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    line = line.strip()
+    return line or None
+
+
+def _prompt_multiline(label: str) -> str:
+    """Multi-line prompt. Blank line ends input."""
+    print(f"{label} (blank line to finish):")
+    lines: List[str] = []
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        stripped = line.rstrip("\n")
+        if stripped == "":
+            break
+        lines.append(stripped)
+    return "\n".join(lines).strip()
+
+
+def _prompt_list(label: str, min_count: int = 0) -> List[str]:
+    """Collect multiple items, one per line. Blank line ends input."""
+    print(f"{label} (one per line; blank line to finish):")
+    items: List[str] = []
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        stripped = line.strip()
+        if not stripped:
+            if len(items) >= min_count:
+                break
+            print(f"  need at least {min_count}; keep going (or empty line to abort step).")
+            continue
+        items.append(stripped)
+    return items
+
+
+def _confirm(prompt: str, default: bool = False) -> bool:
+    default_label = "Y/n" if default else "y/N"
+    sys.stdout.write(f"{prompt} [{default_label}]: ")
+    sys.stdout.flush()
+    line = sys.stdin.readline()
+    if not line:
+        return default
+    ans = line.strip().lower()
+    if not ans:
+        return default
+    return ans in ("y", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Onboard flow
+# ---------------------------------------------------------------------------
+
+
+def onboard() -> int:
+    if telos_db.has_identity():
+        print("Telos Identity is already set. Nothing to onboard.")
+        print("(To redo onboarding, run `telos reset` first.)")
+        return 0
+
+    print("=" * 60)
+    print("Telos onboarding — one-time setup, ~5 minutes.")
+    print("Skip any question with an empty line.")
+    print("=" * 60)
+
+    # 1. Identity (committed immediately so the sentinel flips).
+    print("\n[1/9] Identity")
+    name = _prompt_line("Your name", allow_skip=False)
+    location = _prompt_line("Where you're based")
+    role = _prompt_line("What you do (role / occupation)")
+    pronouns = _prompt_line("Pronouns")
+    if name is None:
+        print("Name is required. Aborting.")
+        return 1
+    content_bits = [name]
+    if location:
+        content_bits.append(f"based in {location}")
+    if role:
+        content_bits.append(role)
+    identity_content = ", ".join(content_bits)
+    metadata = {
+        k: v
+        for k, v in {
+            "name": name,
+            "location": location or "",
+            "role": role or "",
+            "pronouns": pronouns or "",
+        }.items()
+        if v
+    }
+    telos_db.upsert_singleton(
+        Section.IDENTITY, IDENTITY_REF, identity_content, metadata
+    )
+    print(f"  ✓ Identity saved.")
+
+    # 2. Problems.
+    print("\n[2/9] Problems — big things you're trying to solve.")
+    problems = _prompt_list("Problems (1-3)")
+    for p in problems:
+        telos_db.add_entry(Section.PROBLEMS, p)
+    if problems:
+        print(f"  ✓ {len(problems)} problem(s) saved.")
+
+    # 3. Mission.
+    print("\n[3/9] Mission — what you want to put into the world.")
+    mission = _prompt_multiline("Mission")
+    if mission:
+        telos_db.add_entry(Section.MISSION, mission)
+        print("  ✓ Mission saved.")
+
+    # 4. Goals.
+    print("\n[4/9] Goals — what you're working toward right now.")
+    print("       (You can add deadlines/KPIs later.)")
+    goals = _prompt_list("Goals")
+    for g in goals:
+        telos_db.add_entry(Section.GOALS, g)
+    if goals:
+        print(f"  ✓ {len(goals)} goal(s) saved.")
+
+    # 5. Projects.
+    print("\n[5/9] Projects — concrete things you're actively working on.")
+    projects = _prompt_list("Projects")
+    for p in projects:
+        telos_db.add_entry(Section.PROJECTS, p)
+    if projects:
+        print(f"  ✓ {len(projects)} project(s) saved.")
+
+    # 6. Challenges.
+    print("\n[6/9] Challenges — what's actively blocking you.")
+    challenges = _prompt_list("Challenges")
+    for c in challenges:
+        telos_db.add_entry(Section.CHALLENGES, c)
+    if challenges:
+        print(f"  ✓ {len(challenges)} challenge(s) saved.")
+
+    # 7. Wisdom.
+    print("\n[7/9] Wisdom — principles you live by; things radbot should remember.")
+    wisdom = _prompt_list("Wisdom")
+    for w in wisdom:
+        telos_db.add_entry(Section.WISDOM, w)
+    if wisdom:
+        print(f"  ✓ {len(wisdom)} wisdom entry/entries saved.")
+
+    # 8. Taste.
+    print("\n[8/9] Taste — best book / movie / anything worth knowing about your taste.")
+    book = _prompt_line("Best book")
+    if book:
+        telos_db.add_entry(
+            Section.BEST_BOOKS, book, metadata={"sentiment": "love"}
+        )
+    movie = _prompt_line("Best movie")
+    if movie:
+        telos_db.add_entry(
+            Section.BEST_MOVIES, movie, metadata={"sentiment": "love"}
+        )
+
+    # 9. History (optional).
+    print("\n[9/9] History — background that shapes how you think. Optional.")
+    if _confirm("Want to add history now?"):
+        history = _prompt_multiline("History")
+        if history:
+            telos_db.add_entry(Section.HISTORY, history)
+            print("  ✓ History saved.")
+
+    print("\n" + "=" * 60)
+    print("Onboarding complete. Telos is live.")
+    print("From here, beto will keep it updated from your conversations.")
+    print("Run `python -m radbot.tools.telos.cli show` any time to review.")
+    print("=" * 60)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Import / export / show / reset
+# ---------------------------------------------------------------------------
+
+
+def cmd_import(path: str, replace: bool = False) -> int:
+    source = Path(path)
+    if not source.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 1
+    text = source.read_text(encoding="utf-8")
+    entries = parse_telos_markdown(text)
+    if not entries:
+        print("Parsed zero entries — input may not be canonical Telos markdown.")
+        return 1
+    if replace:
+        if not _confirm(f"REPLACE all existing Telos entries and load {len(entries)} from {path}?"):
+            print("Aborted.")
+            return 1
+        telos_db.reset_all()
+    rows = telos_db.bulk_upsert(entries)
+    print(f"Imported {len(rows)} entries from {path} (replace={replace}).")
+    return 0
+
+
+def cmd_export() -> int:
+    entries = telos_db.list_all()
+    sys.stdout.write(render_telos_markdown(entries))
+    return 0
+
+
+def cmd_show() -> int:
+    if not telos_db.has_identity():
+        print("Telos is empty. Run `onboard` to set it up.")
+        return 0
+    grouped = telos_db.list_all_active()
+    journal = telos_db.recent_journal(limit=10)
+    for section in Section:
+        items = grouped.get(section, [])
+        if not items and section != Section.JOURNAL:
+            continue
+        if section == Section.JOURNAL:
+            items = journal
+            if not items:
+                continue
+        print(f"\n=== {section.value.upper()} ({len(items)}) ===")
+        for e in items:
+            ref = f"[{e.ref_code}] " if e.ref_code else ""
+            print(f"  {ref}{e.content}")
+            if e.metadata:
+                meta_short = ", ".join(f"{k}={v}" for k, v in e.metadata.items() if v)
+                if meta_short:
+                    print(f"      ({meta_short})")
+    return 0
+
+
+def cmd_reset(section: Optional[str] = None) -> int:
+    if section:
+        try:
+            sec = Section(section)
+        except ValueError:
+            print(f"Unknown section: {section}", file=sys.stderr)
+            return 1
+        if not _confirm(f"Delete ALL entries in section '{sec.value}'?"):
+            print("Aborted.")
+            return 1
+        n = telos_db.reset_all(section=sec)
+        print(f"Deleted {n} entries in {sec.value}.")
+    else:
+        if not _confirm("Delete ALL Telos entries across ALL sections?"):
+            print("Aborted.")
+            return 1
+        n = telos_db.reset_all()
+        print(f"Deleted {n} entries. Telos is now empty.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    logging.basicConfig(
+        level=logging.WARNING, format="%(levelname)s: %(message)s"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m radbot.tools.telos.cli",
+        description="Telos CLI — manage the persistent user-context store.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("onboard", help="Interactive one-time setup")
+
+    imp = sub.add_parser("import", help="Import a Telos markdown file")
+    imp.add_argument("path", help="Path to the markdown file")
+    imp.add_argument(
+        "--replace",
+        action="store_true",
+        help="Wipe all existing entries before import (default: merge)",
+    )
+
+    sub.add_parser("export", help="Print current Telos as canonical markdown")
+    sub.add_parser("show", help="Print a human-readable summary")
+
+    rst = sub.add_parser("reset", help="Delete all entries (asks confirmation)")
+    rst.add_argument(
+        "--section",
+        help="Delete only one section instead of all",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Make sure the schema exists before any command runs.
+    telos_db.init_telos_schema()
+
+    if args.command == "onboard":
+        return onboard()
+    if args.command == "import":
+        return cmd_import(args.path, replace=args.replace)
+    if args.command == "export":
+        return cmd_export()
+    if args.command == "show":
+        return cmd_show()
+    if args.command == "reset":
+        return cmd_reset(section=args.section)
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/radbot/tools/telos/db.py
+++ b/radbot/tools/telos/db.py
@@ -1,0 +1,435 @@
+"""Database operations for the Telos user-context store.
+
+Single table `telos_entries` backs all sections. Section-specific fields
+live in JSONB `metadata`. Reuses the shared PostgreSQL pool from
+`radbot.tools.todo.db.connection`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import psycopg2
+import psycopg2.extras
+
+from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+from .models import REF_PREFIX, STATUS_VALUES, Entry, Section
+
+logger = logging.getLogger(__name__)
+
+
+def init_telos_schema() -> None:
+    """Create the telos_entries table (idempotent)."""
+    from radbot.tools.shared.db_schema import init_table_schema
+
+    init_table_schema(
+        table_name="telos_entries",
+        create_table_sql="""
+            CREATE TABLE telos_entries (
+                entry_id     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                section      TEXT NOT NULL,
+                ref_code     TEXT,
+                content      TEXT NOT NULL,
+                metadata     JSONB NOT NULL DEFAULT '{}'::jsonb,
+                status       TEXT NOT NULL DEFAULT 'active',
+                sort_order   INTEGER NOT NULL DEFAULT 0,
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (section, ref_code)
+            );
+        """,
+        create_index_sqls=[
+            "CREATE INDEX idx_telos_section_status ON telos_entries (section, status);",
+            "CREATE INDEX idx_telos_active ON telos_entries (section) WHERE status = 'active';",
+            "CREATE INDEX idx_telos_journal_recent ON telos_entries (created_at DESC) WHERE section = 'journal';",
+        ],
+    )
+
+
+def _row_to_entry(row: Dict[str, Any]) -> Entry:
+    return Entry(
+        entry_id=str(row["entry_id"]),
+        section=Section(row["section"]),
+        ref_code=row["ref_code"],
+        content=row["content"],
+        metadata=row["metadata"] or {},
+        status=row["status"],
+        sort_order=row["sort_order"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def next_ref_code(section: Section) -> Optional[str]:
+    """Compute the next auto-assigned ref_code for a section, or None if the
+    section does not use ref_codes."""
+    prefix = REF_PREFIX.get(section)
+    if not prefix:
+        return None
+    sql = """
+        SELECT ref_code FROM telos_entries
+        WHERE section = %s AND ref_code LIKE %s
+    """
+    like = f"{prefix}%"
+    max_n = 0
+    with get_db_connection() as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(sql, (section.value, like))
+            for (code,) in cursor.fetchall():
+                if not code or not code.startswith(prefix):
+                    continue
+                tail = code[len(prefix):]
+                if tail.isdigit():
+                    max_n = max(max_n, int(tail))
+    return f"{prefix}{max_n + 1}"
+
+
+def add_entry(
+    section: Section,
+    content: str,
+    *,
+    ref_code: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    status: str = "active",
+    sort_order: int = 0,
+) -> Entry:
+    """Insert a new entry. If ref_code is None and the section uses ref_codes,
+    one is auto-assigned."""
+    if status not in STATUS_VALUES:
+        raise ValueError(f"invalid status {status!r}")
+    if ref_code is None and section in REF_PREFIX:
+        ref_code = next_ref_code(section)
+
+    sql = """
+        INSERT INTO telos_entries (section, ref_code, content, metadata, status, sort_order)
+        VALUES (%s, %s, %s, %s::jsonb, %s, %s)
+        RETURNING *;
+    """
+    params = (
+        section.value,
+        ref_code,
+        content,
+        json.dumps(metadata or {}),
+        status,
+        sort_order,
+    )
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, params)
+                conn.commit()
+                return _row_to_entry(cursor.fetchone())
+    except psycopg2.Error as e:
+        logger.error("Database error adding telos entry: %s", e)
+        raise
+
+
+def update_entry(
+    section: Section,
+    ref_code: str,
+    *,
+    content: Optional[str] = None,
+    metadata_merge: Optional[Dict[str, Any]] = None,
+    metadata_replace: Optional[Dict[str, Any]] = None,
+    status: Optional[str] = None,
+    sort_order: Optional[int] = None,
+) -> Optional[Entry]:
+    """Update one entry by (section, ref_code). Returns the updated Entry or
+    None if no row matched. `metadata_merge` does a shallow JSONB merge;
+    `metadata_replace` overwrites the whole metadata object. Pass at most
+    one of the two."""
+    if metadata_merge and metadata_replace is not None:
+        raise ValueError("pass at most one of metadata_merge / metadata_replace")
+    if status is not None and status not in STATUS_VALUES:
+        raise ValueError(f"invalid status {status!r}")
+
+    sets: List[str] = []
+    params: List[Any] = []
+    if content is not None:
+        sets.append("content = %s")
+        params.append(content)
+    if metadata_replace is not None:
+        sets.append("metadata = %s::jsonb")
+        params.append(json.dumps(metadata_replace))
+    elif metadata_merge:
+        sets.append("metadata = metadata || %s::jsonb")
+        params.append(json.dumps(metadata_merge))
+    if status is not None:
+        sets.append("status = %s")
+        params.append(status)
+    if sort_order is not None:
+        sets.append("sort_order = %s")
+        params.append(sort_order)
+
+    if not sets:
+        return get_entry(section, ref_code)
+
+    sets.append("updated_at = CURRENT_TIMESTAMP")
+    sql = f"""
+        UPDATE telos_entries SET {", ".join(sets)}
+        WHERE section = %s AND ref_code = %s
+        RETURNING *;
+    """
+    params.extend([section.value, ref_code])
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, tuple(params))
+                conn.commit()
+                row = cursor.fetchone()
+                return _row_to_entry(row) if row else None
+    except psycopg2.Error as e:
+        logger.error("Database error updating telos entry: %s", e)
+        raise
+
+
+def upsert_singleton(
+    section: Section,
+    ref_code: str,
+    content: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Entry:
+    """Upsert a single entry by (section, ref_code). Used for Identity."""
+    existing = get_entry(section, ref_code)
+    if existing:
+        updated = update_entry(
+            section,
+            ref_code,
+            content=content,
+            metadata_replace=metadata or {},
+        )
+        assert updated is not None
+        return updated
+    return add_entry(section, content, ref_code=ref_code, metadata=metadata)
+
+
+def get_entry(section: Section, ref_code: str) -> Optional[Entry]:
+    sql = "SELECT * FROM telos_entries WHERE section = %s AND ref_code = %s;"
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, (section.value, ref_code))
+                row = cursor.fetchone()
+                return _row_to_entry(row) if row else None
+    except psycopg2.Error as e:
+        logger.error("Database error fetching telos entry: %s", e)
+        raise
+
+
+def list_section(
+    section: Section,
+    *,
+    status: Optional[str] = "active",
+    limit: Optional[int] = None,
+    order_by: str = "sort_order_asc",
+) -> List[Entry]:
+    """List entries in a section.
+
+    `status=None` returns all statuses. Default "active".
+    `order_by` options: sort_order_asc (default), created_at_desc,
+    created_at_asc.
+    """
+    where = ["section = %s"]
+    params: List[Any] = [section.value]
+    if status is not None:
+        where.append("status = %s")
+        params.append(status)
+    order_clause = {
+        "sort_order_asc": "sort_order ASC, created_at ASC",
+        "created_at_desc": "created_at DESC",
+        "created_at_asc": "created_at ASC",
+    }.get(order_by, "sort_order ASC, created_at ASC")
+
+    sql = f"SELECT * FROM telos_entries WHERE {' AND '.join(where)} ORDER BY {order_clause}"
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    sql += ";"
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, tuple(params))
+                return [_row_to_entry(r) for r in cursor.fetchall()]
+    except psycopg2.Error as e:
+        logger.error("Database error listing telos section: %s", e)
+        raise
+
+
+def archive_entry(section: Section, ref_code: str, reason: Optional[str] = None) -> bool:
+    """Set status='archived' and stash the reason in metadata.archived_reason."""
+    meta = {"archived_reason": reason} if reason else {}
+    row = update_entry(
+        section, ref_code, status="archived",
+        metadata_merge=meta if meta else None,
+    )
+    return row is not None
+
+
+def search_journal(query: str, limit: int = 20) -> List[Entry]:
+    """ILIKE search over journal content. Returns newest first."""
+    like = f"%{query}%"
+    sql = """
+        SELECT * FROM telos_entries
+        WHERE section = 'journal' AND content ILIKE %s
+        ORDER BY created_at DESC
+        LIMIT %s;
+    """
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, (like, int(limit)))
+                return [_row_to_entry(r) for r in cursor.fetchall()]
+    except psycopg2.Error as e:
+        logger.error("Database error searching telos journal: %s", e)
+        raise
+
+
+def has_identity() -> bool:
+    """True iff at least one identity entry exists. Used as the onboarding
+    completion sentinel."""
+    sql = "SELECT 1 FROM telos_entries WHERE section = 'identity' LIMIT 1;"
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(sql)
+                return cursor.fetchone() is not None
+    except psycopg2.Error as e:
+        logger.error("Database error checking telos identity: %s", e)
+        raise
+
+
+def count_active(section: Section) -> int:
+    sql = "SELECT COUNT(*) FROM telos_entries WHERE section = %s AND status = 'active';"
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(sql, (section.value,))
+                return cursor.fetchone()[0]
+    except psycopg2.Error as e:
+        logger.error("Database error counting telos section: %s", e)
+        raise
+
+
+def bulk_upsert(entries: Iterable[Entry]) -> List[Entry]:
+    """Atomic multi-entry insert/update. Used by the onboarding wizard and
+    markdown import. Each Entry: if (section, ref_code) exists, update
+    content/metadata/status/sort_order; otherwise insert."""
+    out: List[Entry] = []
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                for e in entries:
+                    if e.ref_code:
+                        sql = """
+                            INSERT INTO telos_entries
+                                (section, ref_code, content, metadata, status, sort_order)
+                            VALUES (%s, %s, %s, %s::jsonb, %s, %s)
+                            ON CONFLICT (section, ref_code) DO UPDATE SET
+                                content = EXCLUDED.content,
+                                metadata = EXCLUDED.metadata,
+                                status = EXCLUDED.status,
+                                sort_order = EXCLUDED.sort_order,
+                                updated_at = CURRENT_TIMESTAMP
+                            RETURNING *;
+                        """
+                        cursor.execute(
+                            sql,
+                            (
+                                e.section.value,
+                                e.ref_code,
+                                e.content,
+                                json.dumps(e.metadata or {}),
+                                e.status,
+                                e.sort_order,
+                            ),
+                        )
+                    else:
+                        # No ref_code: always insert as new (journal-style).
+                        sql = """
+                            INSERT INTO telos_entries
+                                (section, content, metadata, status, sort_order)
+                            VALUES (%s, %s, %s::jsonb, %s, %s)
+                            RETURNING *;
+                        """
+                        cursor.execute(
+                            sql,
+                            (
+                                e.section.value,
+                                e.content,
+                                json.dumps(e.metadata or {}),
+                                e.status,
+                                e.sort_order,
+                            ),
+                        )
+                    out.append(_row_to_entry(cursor.fetchone()))
+                conn.commit()
+    except psycopg2.Error:
+        logger.exception("Database error in telos bulk_upsert")
+        raise
+    return out
+
+
+def reset_all(section: Optional[Section] = None) -> int:
+    """Delete all entries, or all entries in one section. Returns the number
+    of rows deleted. Used by the CLI reset command."""
+    if section is not None:
+        sql = "DELETE FROM telos_entries WHERE section = %s;"
+        params: Tuple[Any, ...] = (section.value,)
+    else:
+        sql = "DELETE FROM telos_entries;"
+        params = ()
+    try:
+        with get_db_connection() as conn:
+            with get_db_cursor(conn, commit=True) as cursor:
+                cursor.execute(sql, params)
+                return cursor.rowcount
+    except psycopg2.Error as e:
+        logger.error("Database error resetting telos entries: %s", e)
+        raise
+
+
+def list_all_active() -> Dict[Section, List[Entry]]:
+    """Return all active entries grouped by section. Used by the loader."""
+    sql = """
+        SELECT * FROM telos_entries
+        WHERE status = 'active'
+        ORDER BY section, sort_order ASC, created_at ASC;
+    """
+    out: Dict[Section, List[Entry]] = {s: [] for s in Section}
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql)
+                for row in cursor.fetchall():
+                    e = _row_to_entry(row)
+                    out[e.section].append(e)
+    except psycopg2.Error as e:
+        logger.error("Database error listing all telos entries: %s", e)
+        raise
+    return out
+
+
+def list_all() -> List[Entry]:
+    """Return every entry (any status, any section), ordered for export."""
+    sql = """
+        SELECT * FROM telos_entries
+        ORDER BY section, sort_order ASC, created_at ASC;
+    """
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql)
+                return [_row_to_entry(r) for r in cursor.fetchall()]
+    except psycopg2.Error as e:
+        logger.error("Database error listing all telos entries: %s", e)
+        raise
+
+
+def recent_journal(limit: int = 5) -> List[Entry]:
+    """Most recent active journal entries, newest first."""
+    return list_section(
+        Section.JOURNAL, status="active", limit=limit, order_by="created_at_desc"
+    )

--- a/radbot/tools/telos/loader.py
+++ b/radbot/tools/telos/loader.py
@@ -1,0 +1,209 @@
+"""Build the two-tier Telos context injection strings.
+
+`build_telos_tiers()` returns `(anchor, full_block)`:
+
+* Anchor (~300 bytes, capped at 500) — goes into beto's `system_instruction`
+  on every turn. Identity + Mission + counts + pointer to tools.
+* Full block (~2KB, capped at 2048 bytes) — goes into `system_instruction`
+  on the first turn of each session only. Identity + Mission + Problems +
+  Goals + active Projects + Challenges + Wisdom + last 5 journal entries.
+
+Both are empty strings on a fresh DB, in which case the callback is a
+no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Tuple
+
+from . import db as telos_db
+from .models import IDENTITY_REF, Entry, Section
+
+logger = logging.getLogger(__name__)
+
+ANCHOR_CAP_BYTES = 500
+FULL_BLOCK_CAP_BYTES = 2048
+
+
+def build_telos_tiers() -> Tuple[str, str]:
+    """Return (anchor_text, full_block_text)."""
+    try:
+        grouped = telos_db.list_all_active()
+        journal = telos_db.recent_journal(limit=5)
+    except Exception as e:
+        logger.warning("Telos loader DB read failed (non-fatal): %s", e)
+        return "", ""
+
+    # If totally empty, return empty strings — callback will be a no-op.
+    if not any(grouped[s] for s in grouped) and not journal:
+        return "", ""
+
+    identity = _first(grouped.get(Section.IDENTITY))
+    missions = grouped.get(Section.MISSION, [])
+    problems = grouped.get(Section.PROBLEMS, [])
+    goals = grouped.get(Section.GOALS, [])
+    projects = grouped.get(Section.PROJECTS, [])
+    challenges = grouped.get(Section.CHALLENGES, [])
+    wisdom = grouped.get(Section.WISDOM, [])
+
+    anchor = _render_anchor(
+        identity=identity,
+        missions=missions,
+        counts={
+            "goals": len(goals),
+            "projects": len(projects),
+            "problems": len(problems),
+            "challenges": len(challenges),
+            "wisdom": len(wisdom),
+            "journal": len(journal),
+        },
+    )
+    full_block = _render_full_block(
+        identity=identity,
+        missions=missions,
+        problems=problems,
+        goals=goals,
+        projects=projects,
+        challenges=challenges,
+        wisdom=wisdom,
+        journal=journal,
+    )
+    return anchor, full_block
+
+
+def _first(items):
+    return items[0] if items else None
+
+
+def _single_line(text: str, limit: int = 160) -> str:
+    """Collapse a content block to a single line with a soft length cap."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) > limit:
+        collapsed = collapsed[: limit - 1].rstrip() + "…"
+    return collapsed
+
+
+def _render_anchor(*, identity, missions, counts) -> str:
+    lines = ["TELOS ANCHOR"]
+    if identity:
+        lines.append(f"Identity: {_single_line(identity.content, 180)}")
+    if missions:
+        lines.append(f"Mission: {_single_line(missions[0].content, 180)}")
+    parts = []
+    for label, n in (
+        ("goals", counts["goals"]),
+        ("projects", counts["projects"]),
+        ("problems", counts["problems"]),
+        ("challenges", counts["challenges"]),
+    ):
+        if n:
+            parts.append(f"{n} {label}")
+    if parts:
+        lines.append("Active: " + ", ".join(parts) + ".")
+    lines.append(
+        "Use telos_get_section(name) or telos_get_full() for detail;"
+        " telos_get_section('traumas') only when relevant."
+    )
+    text = "\n".join(lines)
+    if len(text.encode("utf-8")) > ANCHOR_CAP_BYTES:
+        # Trim the final line first, then mission detail.
+        lines = lines[:-1]
+        text = "\n".join(lines)
+        if len(text.encode("utf-8")) > ANCHOR_CAP_BYTES:
+            text = text.encode("utf-8")[: ANCHOR_CAP_BYTES - 1].decode(
+                "utf-8", errors="ignore"
+            ) + "…"
+    return text
+
+
+def _render_full_block(
+    *,
+    identity,
+    missions: List[Entry],
+    problems: List[Entry],
+    goals: List[Entry],
+    projects: List[Entry],
+    challenges: List[Entry],
+    wisdom: List[Entry],
+    journal: List[Entry],
+) -> str:
+    sections: List[Tuple[str, List[str]]] = []
+
+    if identity:
+        sections.append(("IDENTITY", [identity.content.strip()]))
+    if missions:
+        sections.append(("MISSION", [_bullet(m) for m in missions]))
+    if problems:
+        sections.append(("PROBLEMS", [_bullet(p) for p in problems]))
+    if goals:
+        sections.append(("GOALS", [_bullet(g) for g in goals]))
+    if projects:
+        sections.append(("ACTIVE PROJECTS", [_bullet(p) for p in projects]))
+    if challenges:
+        sections.append(("CHALLENGES", [_bullet(c) for c in challenges]))
+    if wisdom:
+        sections.append(("WISDOM", [_bullet(w) for w in wisdom]))
+    if journal:
+        sections.append(
+            (
+                "RECENT JOURNAL",
+                [_journal_line(j) for j in journal],
+            )
+        )
+
+    if not sections:
+        return ""
+
+    header = "USER CONTEXT (Telos) — full profile. Use for grounding beto in the user's current mission, goals, and recent state. Do not repeat verbatim to the user."
+    body = _assemble(header, sections)
+
+    # If over budget, drop journal entries from the tail first.
+    if len(body.encode("utf-8")) > FULL_BLOCK_CAP_BYTES and sections and sections[-1][0] == "RECENT JOURNAL":
+        journal_lines = sections[-1][1]
+        while journal_lines and len(body.encode("utf-8")) > FULL_BLOCK_CAP_BYTES:
+            journal_lines.pop()
+            if journal_lines:
+                sections[-1] = ("RECENT JOURNAL", journal_lines)
+            else:
+                sections.pop()
+            body = _assemble(header, sections)
+
+    # Final safety: hard-truncate if still over.
+    if len(body.encode("utf-8")) > FULL_BLOCK_CAP_BYTES:
+        body = body.encode("utf-8")[: FULL_BLOCK_CAP_BYTES - 1].decode(
+            "utf-8", errors="ignore"
+        ) + "…"
+
+    return body
+
+
+def _assemble(header: str, sections: List[Tuple[str, List[str]]]) -> str:
+    parts = [header, ""]
+    for title, items in sections:
+        parts.append(f"{title}:")
+        parts.extend(items)
+        parts.append("")
+    return "\n".join(parts).rstrip()
+
+
+def _bullet(entry: Entry) -> str:
+    ref = f"{entry.ref_code}: " if entry.ref_code else ""
+    body = _single_line(entry.content, 200)
+    # Append metadata hints inline for goals/projects.
+    meta = entry.metadata or {}
+    hints = []
+    if "deadline" in meta and meta["deadline"]:
+        hints.append(f"by {meta['deadline']}")
+    if "kpi" in meta and meta["kpi"]:
+        hints.append(f"kpi={meta['kpi']}")
+    if "priority" in meta and meta["priority"]:
+        hints.append(f"priority={meta['priority']}")
+    suffix = f" ({', '.join(hints)})" if hints else ""
+    return f"- {ref}{body}{suffix}"
+
+
+def _journal_line(entry: Entry) -> str:
+    date = entry.created_at.date().isoformat() if entry.created_at else ""
+    prefix = f"[{date}] " if date else ""
+    return f"- {prefix}{_single_line(entry.content, 180)}"

--- a/radbot/tools/telos/markdown_io.py
+++ b/radbot/tools/telos/markdown_io.py
@@ -1,0 +1,177 @@
+"""Canonical Telos markdown parse + render.
+
+The format mirrors Daniel Miessler's Telos template:
+
+    # TELOS
+
+    ## SECTION HEADER
+
+    - REF: content line
+    - REF: content line
+
+Sections without ref_codes just use plain bullets. The IDENTITY section is
+rendered as free-form text (name, location, role). Unknown headers are
+preserved via `metadata.raw_section_name` so a round-trip is idempotent
+for unknown sections.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from .models import (
+    IDENTITY_REF,
+    REF_PREFIX,
+    SECTION_HEADERS,
+    Entry,
+    Section,
+    header_to_section,
+)
+
+_HEADER_RE = re.compile(r"^##\s+(.+?)\s*$")
+_BULLET_RE = re.compile(r"^-\s+(?:([A-Z][A-Z0-9]*\d+|ME):\s+)?(.*)$")
+
+
+def parse_telos_markdown(text: str) -> List[Entry]:
+    """Parse canonical Telos markdown into a list of Entry objects.
+
+    Unknown sections are dropped with a warning comment in
+    metadata.raw_section_name so a round-trip preserves the source.
+    Identity entries collapse to a single entry with ref_code='ME'.
+    """
+    entries: List[Entry] = []
+    current_section: Optional[Section] = None
+    current_unknown: Optional[str] = None
+    sort_index = 0
+    identity_lines: List[str] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+        if line.lstrip().startswith("#"):
+            # Flush pending identity block if we were in IDENTITY.
+            if current_section == Section.IDENTITY and identity_lines:
+                entries.append(
+                    Entry(
+                        section=Section.IDENTITY,
+                        ref_code=IDENTITY_REF,
+                        content="\n".join(identity_lines).strip(),
+                    )
+                )
+                identity_lines = []
+
+            header_match = _HEADER_RE.match(line.lstrip())
+            if not header_match:
+                continue
+            header_text = header_match.group(1)
+            sec = header_to_section(header_text)
+            if sec is not None:
+                current_section = sec
+                current_unknown = None
+                sort_index = 0
+            else:
+                current_section = None
+                current_unknown = header_text
+                sort_index = 0
+            continue
+
+        if current_section is None and current_unknown is None:
+            continue
+
+        # Inside IDENTITY, accumulate lines (bulleted or not) into one entry.
+        if current_section == Section.IDENTITY:
+            bullet = _BULLET_RE.match(line.strip())
+            if bullet:
+                _, content = bullet.group(1), bullet.group(2)
+                identity_lines.append(content)
+            else:
+                identity_lines.append(line.strip())
+            continue
+
+        bullet = _BULLET_RE.match(line.strip())
+        if not bullet:
+            continue
+        ref_code, content = bullet.group(1), bullet.group(2)
+        content = content.strip()
+        if not content:
+            continue
+
+        if current_unknown is not None:
+            entries.append(
+                Entry(
+                    section=Section.JOURNAL,  # lossy fallback
+                    ref_code=ref_code,
+                    content=content,
+                    metadata={"raw_section_name": current_unknown},
+                    sort_order=sort_index,
+                )
+            )
+        else:
+            assert current_section is not None
+            entries.append(
+                Entry(
+                    section=current_section,
+                    ref_code=ref_code,
+                    content=content,
+                    sort_order=sort_index,
+                )
+            )
+        sort_index += 1
+
+    # Flush trailing identity block.
+    if current_section == Section.IDENTITY and identity_lines:
+        entries.append(
+            Entry(
+                section=Section.IDENTITY,
+                ref_code=IDENTITY_REF,
+                content="\n".join(identity_lines).strip(),
+            )
+        )
+
+    return entries
+
+
+def render_telos_markdown(entries: List[Entry]) -> str:
+    """Render a list of Entry objects as canonical Telos markdown.
+
+    Sections appear in canonical order; empty sections are omitted.
+    Identity renders as a free-form paragraph, not a bullet list.
+    """
+    grouped: Dict[Section, List[Entry]] = {s: [] for s in Section}
+    unknown: Dict[str, List[Entry]] = {}
+    for e in entries:
+        raw_name = e.metadata.get("raw_section_name") if e.metadata else None
+        if raw_name:
+            unknown.setdefault(raw_name, []).append(e)
+        else:
+            grouped[e.section].append(e)
+
+    out: List[str] = ["# TELOS", ""]
+
+    for section in Section:
+        items = grouped.get(section) or []
+        if not items:
+            continue
+        items.sort(key=lambda e: (e.sort_order, e.created_at or 0))
+        header = SECTION_HEADERS[section]
+        out.append(f"## {header}")
+        out.append("")
+        if section == Section.IDENTITY:
+            # Emit content as prose (may be multi-line).
+            out.append(items[0].content)
+            out.append("")
+            continue
+        for e in items:
+            out.append(e.to_markdown_bullet())
+        out.append("")
+
+    for raw_name, items in unknown.items():
+        out.append(f"## {raw_name}")
+        out.append("")
+        for e in items:
+            out.append(e.to_markdown_bullet())
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"

--- a/radbot/tools/telos/models.py
+++ b/radbot/tools/telos/models.py
@@ -1,0 +1,134 @@
+"""Telos data model — Section enum, Entry dataclass, ref-code prefixes.
+
+Telos is a structured persona/context store for a single user. Each Entry
+belongs to a Section and optionally carries a human-readable ref_code
+(e.g. "G1", "P3") for stable reference in markdown round-trips.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class Section(str, Enum):
+    IDENTITY = "identity"
+    HISTORY = "history"
+    PROBLEMS = "problems"
+    MISSION = "mission"
+    NARRATIVES = "narratives"
+    GOALS = "goals"
+    CHALLENGES = "challenges"
+    STRATEGIES = "strategies"
+    PROJECTS = "projects"
+    WISDOM = "wisdom"
+    IDEAS = "ideas"
+    PREDICTIONS = "predictions"
+    WRONG_ABOUT = "wrong_about"
+    BEST_BOOKS = "best_books"
+    BEST_MOVIES = "best_movies"
+    BEST_MUSIC = "best_music"
+    TASTE = "taste"
+    TRAUMAS = "traumas"
+    METRICS = "metrics"
+    JOURNAL = "journal"
+
+
+# Canonical markdown header labels (used for parse/render).
+SECTION_HEADERS: Dict[Section, str] = {
+    Section.IDENTITY: "IDENTITY",
+    Section.HISTORY: "HISTORY",
+    Section.PROBLEMS: "PROBLEMS",
+    Section.MISSION: "MISSION",
+    Section.NARRATIVES: "NARRATIVES",
+    Section.GOALS: "GOALS",
+    Section.CHALLENGES: "CHALLENGES",
+    Section.STRATEGIES: "STRATEGIES",
+    Section.PROJECTS: "PROJECTS",
+    Section.WISDOM: "WISDOM",
+    Section.IDEAS: "IDEAS",
+    Section.PREDICTIONS: "PREDICTIONS",
+    Section.WRONG_ABOUT: "THINGS I'VE BEEN WRONG ABOUT",
+    Section.BEST_BOOKS: "BEST BOOKS",
+    Section.BEST_MOVIES: "BEST MOVIES",
+    Section.BEST_MUSIC: "BEST MUSIC",
+    Section.TASTE: "TASTE",
+    Section.TRAUMAS: "TRAUMAS",
+    Section.METRICS: "METRICS",
+    Section.JOURNAL: "LOG",
+}
+
+# Reverse map for markdown parsing (header text → Section). Case-insensitive.
+_HEADER_TO_SECTION: Dict[str, Section] = {
+    v.upper(): k for k, v in SECTION_HEADERS.items()
+}
+# Accept a few alternate headers from the canonical Telos template.
+_HEADER_TO_SECTION["LOG (JOURNAL)"] = Section.JOURNAL
+_HEADER_TO_SECTION["JOURNAL"] = Section.JOURNAL
+
+
+def header_to_section(header: str) -> Optional[Section]:
+    return _HEADER_TO_SECTION.get(header.strip().upper())
+
+
+# Prefix used when auto-assigning ref_codes. Sections not listed here do not
+# use ref_codes by default (identity uses "ME"; history, wisdom, ideas,
+# journal, taste, traumas, best_* rely on natural ordering).
+REF_PREFIX: Dict[Section, str] = {
+    Section.PROBLEMS: "P",
+    Section.MISSION: "M",
+    Section.NARRATIVES: "N",
+    Section.GOALS: "G",
+    Section.CHALLENGES: "C",
+    Section.STRATEGIES: "S",
+    Section.PROJECTS: "PRJ",
+    Section.PREDICTIONS: "PRED",
+    Section.METRICS: "K",
+}
+
+
+# Sections whose tools should fire without user confirmation. The tool layer
+# does not enforce this — main_agent.md does. This set exists as
+# documentation and for admin-panel UX hints.
+SILENT_SECTIONS: set[Section] = {
+    Section.JOURNAL,
+    Section.PREDICTIONS,
+    Section.WRONG_ABOUT,
+    Section.BEST_BOOKS,
+    Section.BEST_MOVIES,
+    Section.BEST_MUSIC,
+    Section.TASTE,
+    Section.WISDOM,
+    Section.IDEAS,
+}
+
+# Sections never always-loaded into beto's prompt (privacy / noise).
+NEVER_ALWAYS_LOADED: set[Section] = {
+    Section.TRAUMAS,
+}
+
+# Valid status values.
+STATUS_VALUES: set[str] = {"active", "completed", "archived", "superseded"}
+
+# Single identity ref_code (there's only one user).
+IDENTITY_REF = "ME"
+
+
+@dataclass
+class Entry:
+    entry_id: Optional[str] = None  # UUID string, None until DB-assigned
+    section: Section = Section.JOURNAL
+    ref_code: Optional[str] = None
+    content: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    status: str = "active"
+    sort_order: int = 0
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def to_markdown_bullet(self) -> str:
+        """Render one entry as a markdown bullet line."""
+        prefix = f"- {self.ref_code}: " if self.ref_code else "- "
+        return f"{prefix}{self.content}"

--- a/radbot/tools/telos/telos_tools.py
+++ b/radbot/tools/telos/telos_tools.py
@@ -1,0 +1,666 @@
+"""Agent tools for reading and updating the Telos user-context store.
+
+All tools return ``{"status": "success", ...}`` or
+``{"status": "error", "message": ...}`` per radbot convention.
+
+Silent vs. confirm-required distinctions are enforced by the agent's
+instructions (``main_agent.md``), not here. These functions just do what
+they're asked.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from typing import Any, Dict, List, Optional
+
+from google.adk.tools import FunctionTool
+
+from radbot.tools.shared.errors import truncate_error
+
+from . import db as telos_db
+from .markdown_io import parse_telos_markdown, render_telos_markdown
+from .models import IDENTITY_REF, STATUS_VALUES, Entry, Section
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _section_or_error(section: str):
+    try:
+        return Section(section), None
+    except ValueError:
+        valid = ", ".join(s.value for s in Section)
+        return None, {
+            "status": "error",
+            "message": f"Unknown section {section!r}. Valid: {valid}.",
+        }
+
+
+def _serialize_entry(entry: Entry) -> Dict[str, Any]:
+    return {
+        "entry_id": entry.entry_id,
+        "section": entry.section.value,
+        "ref_code": entry.ref_code,
+        "content": entry.content,
+        "metadata": entry.metadata,
+        "status": entry.status,
+        "sort_order": entry.sort_order,
+        "created_at": entry.created_at.isoformat() if entry.created_at else None,
+        "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+    }
+
+
+def _wrap(label: str, fn, *args, **kwargs) -> Dict[str, Any]:
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        msg = f"Failed to {label}: {e}"
+        logger.error(msg)
+        logger.debug(traceback.format_exc())
+        return {"status": "error", "message": truncate_error(msg)}
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+def telos_get_section(section: str, include_inactive: bool = False) -> Dict[str, Any]:
+    """
+    Return all entries in a Telos section.
+
+    Valid sections: identity, history, problems, mission, narratives, goals,
+    challenges, strategies, projects, wisdom, ideas, predictions,
+    wrong_about, best_books, best_movies, best_music, taste, traumas,
+    metrics, journal.
+
+    Args:
+        section: The Telos section name (lowercase).
+        include_inactive: If True, include completed/archived/superseded
+            entries. Default False (active only).
+
+    Returns:
+        {"status": "success", "section": str, "entries": [...]} on success.
+    """
+    sec, err = _section_or_error(section)
+    if err:
+        return err
+
+    def _do():
+        status = None if include_inactive else "active"
+        order = "created_at_desc" if sec == Section.JOURNAL else "sort_order_asc"
+        entries = telos_db.list_section(sec, status=status, order_by=order)
+        return {
+            "status": "success",
+            "section": sec.value,
+            "entries": [_serialize_entry(e) for e in entries],
+        }
+
+    return _wrap(f"list section {section}", _do)
+
+
+def telos_get_entry(section: str, ref_code: str) -> Dict[str, Any]:
+    """
+    Fetch one Telos entry by (section, ref_code). Use to look up the full
+    record of a goal, problem, etc. you already know the ref_code for
+    (e.g. "G1", "P2", "PRED3"). Identity uses ref_code "ME".
+    """
+    sec, err = _section_or_error(section)
+    if err:
+        return err
+
+    def _do():
+        entry = telos_db.get_entry(sec, ref_code)
+        if not entry:
+            return {"status": "error", "message": f"No entry {ref_code} in {sec.value}."}
+        return {"status": "success", "entry": _serialize_entry(entry)}
+
+    return _wrap(f"get entry {section}:{ref_code}", _do)
+
+
+def telos_get_full() -> Dict[str, Any]:
+    """
+    Return the full Telos as canonical markdown. Use sparingly — this can be
+    large. Prefer telos_get_section when you only need a specific section.
+    """
+
+    def _do():
+        entries = telos_db.list_all()
+        md = render_telos_markdown(entries)
+        return {"status": "success", "markdown": md, "entry_count": len(entries)}
+
+    return _wrap("render full telos", _do)
+
+
+def telos_search_journal(query: str, limit: int = 20) -> Dict[str, Any]:
+    """
+    ILIKE search over journal content. Returns newest entries first.
+    Useful for "have I ever mentioned X?" questions.
+
+    Args:
+        query: Substring to match (case-insensitive).
+        limit: Max results to return. Default 20.
+    """
+
+    def _do():
+        rows = telos_db.search_journal(query, limit=limit)
+        return {
+            "status": "success",
+            "entries": [_serialize_entry(e) for e in rows],
+        }
+
+    return _wrap("search journal", _do)
+
+
+# ---------------------------------------------------------------------------
+# Silent-update tools (agent may call without user confirmation per main_agent.md)
+# ---------------------------------------------------------------------------
+
+
+def telos_add_journal(
+    entry: str,
+    event_type: str = "",
+    related_refs: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Append a journal entry. Use for notable events, decisions, states, or
+    interactions worth remembering. No confirmation needed.
+
+    Args:
+        entry: Free-form text describing what happened.
+        event_type: Optional tag (e.g. "decision", "milestone", "mood",
+            "interaction"). Stored in metadata.
+        related_refs: Optional list of ref_codes this journal entry relates
+            to (e.g. ["G1", "PRJ3"]). Stored in metadata.
+    """
+
+    def _do():
+        metadata: Dict[str, Any] = {}
+        if event_type:
+            metadata["event_type"] = event_type
+        if related_refs:
+            metadata["related_refs"] = list(related_refs)
+        row = telos_db.add_entry(Section.JOURNAL, entry, metadata=metadata)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("add journal", _do)
+
+
+def telos_add_prediction(
+    claim: str,
+    probability: float,
+    deadline: str = "",
+) -> Dict[str, Any]:
+    """
+    Record a prediction the user made with an attached probability and
+    optional deadline. Use whenever the user voices a forecast with a
+    confidence ("I'd bet 80% X", "by June there's a 60% chance Y"). No
+    confirmation needed.
+
+    Args:
+        claim: The predicted outcome as a single sentence.
+        probability: 0.0 to 1.0.
+        deadline: Optional ISO date ("2026-12-31") for when this resolves.
+    """
+
+    def _do():
+        if not 0.0 <= probability <= 1.0:
+            return {
+                "status": "error",
+                "message": "probability must be between 0.0 and 1.0.",
+            }
+        metadata: Dict[str, Any] = {"probability": probability}
+        if deadline:
+            metadata["deadline"] = deadline
+        row = telos_db.add_entry(Section.PREDICTIONS, claim, metadata=metadata)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("add prediction", _do)
+
+
+def telos_resolve_prediction(
+    ref_code: str,
+    outcome: bool,
+    actual_value: str = "",
+) -> Dict[str, Any]:
+    """
+    Mark a prediction as resolved with the outcome. If the user was
+    miscalibrated (confident and wrong, OR dismissive and right), also
+    appends an entry to wrong_about silently.
+
+    Args:
+        ref_code: The PRED<N> ref_code to resolve.
+        outcome: True if the prediction came true, False otherwise.
+        actual_value: Optional description of what actually happened.
+    """
+
+    def _do():
+        existing = telos_db.get_entry(Section.PREDICTIONS, ref_code)
+        if not existing:
+            return {"status": "error", "message": f"No prediction {ref_code}."}
+        prob = (existing.metadata or {}).get("probability")
+        meta = {
+            "resolution": "true" if outcome else "false",
+            "resolved_at": _now_iso(),
+        }
+        if actual_value:
+            meta["actual_value"] = actual_value
+        updated = telos_db.update_entry(
+            Section.PREDICTIONS,
+            ref_code,
+            status="completed",
+            metadata_merge=meta,
+        )
+
+        # Miscalibration: confident-and-wrong OR dismissive-and-right.
+        miscalibrated = False
+        if isinstance(prob, (int, float)):
+            if (not outcome and prob >= 0.75) or (outcome and prob <= 0.25):
+                miscalibrated = True
+        if miscalibrated:
+            note = (
+                f"Miscalibrated on {ref_code}: predicted "
+                f"{prob:.0%} for {existing.content!r}; outcome was "
+                f"{'true' if outcome else 'false'}."
+            )
+            telos_db.add_entry(
+                Section.WRONG_ABOUT,
+                note,
+                metadata={"source_prediction": ref_code},
+            )
+
+        return {
+            "status": "success",
+            "entry": _serialize_entry(updated) if updated else None,
+            "miscalibrated": miscalibrated,
+        }
+
+    return _wrap("resolve prediction", _do)
+
+
+def telos_note_wrong(thing: str, why: str = "") -> Dict[str, Any]:
+    """
+    Record that the user was wrong about something. Use when the user
+    concedes "I was wrong about X" or corrects a prior belief. No
+    confirmation needed.
+
+    Args:
+        thing: What the user was wrong about, one sentence.
+        why: Optional explanation of what actually turned out to be true.
+    """
+
+    def _do():
+        content = thing if not why else f"{thing} — {why}"
+        row = telos_db.add_entry(Section.WRONG_ABOUT, content)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("note wrong", _do)
+
+
+def telos_note_taste(
+    category: str,
+    item: str,
+    sentiment: str,
+    note: str = "",
+) -> Dict[str, Any]:
+    """
+    Record a strong taste/preference. Use when the user expresses a clear
+    opinion about a book, movie, song, food, tool, game, etc. No
+    confirmation needed.
+
+    Args:
+        category: "book" | "movie" | "music" | "food" | "tool" | "game" | "other"
+        item: The name of the item (title, brand, etc.).
+        sentiment: "love" | "like" | "dislike" | "hate" | "neutral"
+        note: Optional short comment explaining the sentiment.
+    """
+
+    def _do():
+        metadata = {"category": category, "sentiment": sentiment}
+        if note:
+            metadata["note"] = note
+        target_section = {
+            "book": Section.BEST_BOOKS,
+            "movie": Section.BEST_MOVIES,
+            "music": Section.BEST_MUSIC,
+        }.get(category, Section.TASTE)
+        row = telos_db.add_entry(target_section, item, metadata=metadata)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("note taste", _do)
+
+
+def telos_add_wisdom(principle: str, origin: str = "") -> Dict[str, Any]:
+    """
+    Record a principle or rule the user lives by. Use when the user
+    voices something quotable they'd want remembered (e.g., "always X",
+    "never Y", "if in doubt, Z"). No confirmation needed.
+
+    Args:
+        principle: The principle as a single quotable sentence.
+        origin: Optional source/attribution.
+    """
+
+    def _do():
+        metadata = {"origin": origin} if origin else {}
+        row = telos_db.add_entry(Section.WISDOM, principle, metadata=metadata)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("add wisdom", _do)
+
+
+def telos_add_idea(idea: str) -> Dict[str, Any]:
+    """
+    Record a strong opinion, hot-take, or idea the user has voiced.
+    No confirmation needed.
+    """
+
+    def _do():
+        row = telos_db.add_entry(Section.IDEAS, idea)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("add idea", _do)
+
+
+# ---------------------------------------------------------------------------
+# Confirm-required tools (agent must propose and get user yes per main_agent.md)
+# ---------------------------------------------------------------------------
+
+
+def telos_upsert_identity(
+    content: str,
+    name: str = "",
+    location: str = "",
+    role: str = "",
+    pronouns: str = "",
+) -> Dict[str, Any]:
+    """
+    Upsert the user's Identity entry (single record). Use when the user
+    states or updates who they are. Confirmation REQUIRED — propose the
+    change in a plain sentence first.
+
+    Args:
+        content: The full identity description (can be multi-line prose).
+        name: Optional structured name field.
+        location: Optional structured location field.
+        role: Optional structured role/occupation field.
+        pronouns: Optional structured pronouns field.
+    """
+
+    def _do():
+        metadata = {
+            k: v
+            for k, v in {
+                "name": name,
+                "location": location,
+                "role": role,
+                "pronouns": pronouns,
+            }.items()
+            if v
+        }
+        row = telos_db.upsert_singleton(
+            Section.IDENTITY, IDENTITY_REF, content, metadata
+        )
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("upsert identity", _do)
+
+
+def telos_add_entry(
+    section: str,
+    content: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    ref_code: str = "",
+) -> Dict[str, Any]:
+    """
+    Generic add for structural sections (problems, mission, narratives,
+    goals, challenges, strategies, projects, metrics). Confirmation REQUIRED.
+
+    For goals pass metadata like {"deadline": "2026-12-31", "kpi": "100k users"}.
+    For projects pass {"priority": "high", "parent_goal": "G1"}.
+    For problems/missions/narratives metadata is usually empty.
+
+    Use the specialized tools (telos_add_goal, telos_add_problem, etc.)
+    when you want clearer semantics; this is the escape hatch.
+    """
+    sec, err = _section_or_error(section)
+    if err:
+        return err
+
+    def _do():
+        row = telos_db.add_entry(
+            sec,
+            content,
+            ref_code=ref_code or None,
+            metadata=metadata or {},
+        )
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap(f"add {section}", _do)
+
+
+def telos_update_entry(
+    section: str,
+    ref_code: str,
+    content: str = "",
+    metadata_merge: Optional[Dict[str, Any]] = None,
+    status: str = "",
+) -> Dict[str, Any]:
+    """
+    Update one entry's content/metadata/status. Confirmation REQUIRED for
+    structural sections; for journal/predictions/taste etc. you typically
+    use the specialized silent tools instead.
+
+    Args:
+        section: Target section.
+        ref_code: Entry to update.
+        content: New content (empty string = leave unchanged).
+        metadata_merge: Shallow JSONB merge into existing metadata.
+        status: "active" | "completed" | "archived" | "superseded" (empty = leave).
+    """
+    sec, err = _section_or_error(section)
+    if err:
+        return err
+
+    def _do():
+        kwargs: Dict[str, Any] = {}
+        if content:
+            kwargs["content"] = content
+        if metadata_merge:
+            kwargs["metadata_merge"] = metadata_merge
+        if status:
+            if status not in STATUS_VALUES:
+                return {
+                    "status": "error",
+                    "message": f"invalid status {status!r}. Valid: {sorted(STATUS_VALUES)}.",
+                }
+            kwargs["status"] = status
+        row = telos_db.update_entry(sec, ref_code, **kwargs)
+        if not row:
+            return {"status": "error", "message": f"No entry {ref_code} in {sec.value}."}
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap(f"update {section}:{ref_code}", _do)
+
+
+def telos_add_goal(
+    title: str,
+    deadline: str = "",
+    kpi: str = "",
+    parent_problem: str = "",
+) -> Dict[str, Any]:
+    """
+    Add a goal. Confirmation REQUIRED. Auto-assigns G<N> ref_code.
+    """
+
+    def _do():
+        metadata = {
+            k: v
+            for k, v in {
+                "deadline": deadline,
+                "kpi": kpi,
+                "parent_problem": parent_problem,
+            }.items()
+            if v
+        }
+        row = telos_db.add_entry(Section.GOALS, title, metadata=metadata)
+        return {"status": "success", "entry": _serialize_entry(row)}
+
+    return _wrap("add goal", _do)
+
+
+def telos_complete_goal(ref_code: str, resolution: str = "") -> Dict[str, Any]:
+    """
+    Mark a goal completed and write a journal entry noting the completion.
+    Confirmation REQUIRED.
+    """
+
+    def _do():
+        meta = {"completed_at": _now_iso()}
+        if resolution:
+            meta["resolution"] = resolution
+        updated = telos_db.update_entry(
+            Section.GOALS,
+            ref_code,
+            status="completed",
+            metadata_merge=meta,
+        )
+        if not updated:
+            return {"status": "error", "message": f"No goal {ref_code}."}
+        journal_body = (
+            f"Completed {ref_code}: {updated.content}"
+            + (f" — {resolution}" if resolution else "")
+        )
+        telos_db.add_entry(
+            Section.JOURNAL,
+            journal_body,
+            metadata={"event_type": "goal_completed", "related_refs": [ref_code]},
+        )
+        return {"status": "success", "entry": _serialize_entry(updated)}
+
+    return _wrap(f"complete goal {ref_code}", _do)
+
+
+def telos_archive(section: str, ref_code: str, reason: str = "") -> Dict[str, Any]:
+    """
+    Archive an entry (soft delete). Confirmation REQUIRED — never archive
+    without explicit user approval.
+    """
+    sec, err = _section_or_error(section)
+    if err:
+        return err
+
+    def _do():
+        ok = telos_db.archive_entry(sec, ref_code, reason=reason or None)
+        if not ok:
+            return {
+                "status": "error",
+                "message": f"No entry {ref_code} in {sec.value}.",
+            }
+        return {"status": "success", "archived": f"{sec.value}:{ref_code}"}
+
+    return _wrap(f"archive {section}:{ref_code}", _do)
+
+
+def telos_import_markdown(markdown_text: str, replace: bool = False) -> Dict[str, Any]:
+    """
+    Bulk-load a Telos markdown file. Parses canonical Telos format (## SECTION
+    headers with `- REF: content` bullets) and upserts into the DB.
+
+    Args:
+        markdown_text: The full markdown content.
+        replace: If True, wipe ALL existing entries first. Default False
+            (merge into existing; entries with the same ref_code are
+            updated, new ones are added).
+
+    Confirmation REQUIRED when replace=True. Merge mode can go silently if
+    the user provided the content.
+    """
+
+    def _do():
+        entries = parse_telos_markdown(markdown_text)
+        if not entries:
+            return {
+                "status": "error",
+                "message": "Parsed zero entries — input may not be canonical Telos markdown.",
+            }
+        if replace:
+            telos_db.reset_all()
+        rows = telos_db.bulk_upsert(entries)
+        return {
+            "status": "success",
+            "imported": len(rows),
+            "replaced": replace,
+        }
+
+    return _wrap("import markdown", _do)
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Tool wrappers
+# ---------------------------------------------------------------------------
+
+# Read tools
+telos_get_section_tool = FunctionTool(telos_get_section)
+telos_get_entry_tool = FunctionTool(telos_get_entry)
+telos_get_full_tool = FunctionTool(telos_get_full)
+telos_search_journal_tool = FunctionTool(telos_search_journal)
+
+# Silent-update tools
+telos_add_journal_tool = FunctionTool(telos_add_journal)
+telos_add_prediction_tool = FunctionTool(telos_add_prediction)
+telos_resolve_prediction_tool = FunctionTool(telos_resolve_prediction)
+telos_note_wrong_tool = FunctionTool(telos_note_wrong)
+telos_note_taste_tool = FunctionTool(telos_note_taste)
+telos_add_wisdom_tool = FunctionTool(telos_add_wisdom)
+telos_add_idea_tool = FunctionTool(telos_add_idea)
+
+# Confirm-required tools
+telos_upsert_identity_tool = FunctionTool(telos_upsert_identity)
+telos_add_entry_tool = FunctionTool(telos_add_entry)
+telos_update_entry_tool = FunctionTool(telos_update_entry)
+telos_add_goal_tool = FunctionTool(telos_add_goal)
+telos_complete_goal_tool = FunctionTool(telos_complete_goal)
+telos_archive_tool = FunctionTool(telos_archive)
+telos_import_markdown_tool = FunctionTool(telos_import_markdown)
+
+
+TELOS_TOOLS = [
+    # read
+    telos_get_section_tool,
+    telos_get_entry_tool,
+    telos_get_full_tool,
+    telos_search_journal_tool,
+    # silent
+    telos_add_journal_tool,
+    telos_add_prediction_tool,
+    telos_resolve_prediction_tool,
+    telos_note_wrong_tool,
+    telos_note_taste_tool,
+    telos_add_wisdom_tool,
+    telos_add_idea_tool,
+    # confirm-required
+    telos_upsert_identity_tool,
+    telos_add_entry_tool,
+    telos_update_entry_tool,
+    telos_add_goal_tool,
+    telos_complete_goal_tool,
+    telos_archive_tool,
+    telos_import_markdown_tool,
+]

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -189,6 +189,17 @@ async def initialize_app_startup():
                 f"Error initializing reminder database: {str(rem_err)}", exc_info=True
             )
 
+        logger.debug("Initializing telos database schema...")
+        try:
+            from radbot.tools.telos.db import init_telos_schema
+
+            init_telos_schema()
+            logger.debug("Telos database schema initialized")
+        except Exception as telos_err:
+            logger.error(
+                f"Error initializing telos database: {str(telos_err)}", exc_info=True
+            )
+
         logger.debug("Initializing coder workspaces database schema...")
         try:
             from radbot.tools.claude_code.db import init_coder_schema

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -30,7 +30,7 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 
 | Agent | Factory | Model | Tool Count | Purpose |
 |-------|---------|-------|------------|---------|
-| **beto** | `agent/agent_core.py` | `config_manager.get_main_model()` (default `gemini-2.5-pro`) | 2 | Orchestrator, routes to specialists |
+| **beto** | `agent/agent_core.py` | `config_manager.get_main_model()` (default `gemini-2.5-pro`) | 20 | Orchestrator, routes to specialists; owns Telos (persistent user context) |
 | **casa** | `agent/home_agent/factory.py` | `resolve_agent_model("casa_agent")` | ~38 | Smart home, media, music, grocery, card emission |
 | **planner** | `agent/planner_agent/factory.py` | `resolve_agent_model("planner_agent")` | 14 | Calendar, scheduling, reminders |
 | **tracker** | `agent/tracker_agent/factory.py` | `resolve_agent_model("tracker_agent")` | 13 | Tasks, projects, webhooks |
@@ -47,11 +47,12 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 
 - **Temperature**: 0.2
 - **Global instruction**: injects today's date
-- **Tools**: `search_agent_memory`, `store_agent_memory` (via `create_agent_memory_tools("beto")`)
-- **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder, notifications, alerts, telemetry), HA client check
-- **Before-model callbacks**: `[filter_tool_events_from_prompt, scrub_empty_content_before_model, sanitize_before_model_callback]`
+- **Tools**: `search_agent_memory`, `store_agent_memory` (via `create_agent_memory_tools("beto")`) + 18 Telos tools (`TELOS_TOOLS`, see `specs/tools.md`)
+- **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder, telos, notifications, alerts, telemetry), HA client check
+- **Before-model callbacks**: `[filter_tool_events_from_prompt, scrub_empty_content_before_model, sanitize_before_model_callback, inject_telos_context]`
 - **After-model callbacks**: `[handle_empty_response_after_model, telemetry_after_model_callback]`
 - **Instruction file**: `config/default_configs/instructions/main_agent.md`
+- **Telos persona injection** (beto only): `inject_telos_context` appends an anchor (~300B: identity + mission + counts + tool pointer) to `llm_request.config.system_instruction` on every turn. On the first turn of each session it also appends the full block (~2KB: mission, problems, goals, active projects, challenges, wisdom, last 5 journal entries), gated by `callback_context.state["telos_bootstrapped"]`. Sub-agents are tool executors and do **not** receive Telos context. See `docs/implementation/telos.md`.
 - **Full conversation history**: root keeps all prior user/assistant text turns. Sub-agent tool_call and function_response events are dropped from the LLM prompt by `filter_tool_events_from_prompt` (session state is retained) to keep the cacheable prefix stable — without this, churning tool-response blobs pushed beto's prompt-cache hit rate to ~1%.
 
 ## Domain Agents
@@ -197,6 +198,7 @@ From `config/default_configs/instructions/main_agent.md`:
 | `scrub_empty_content_before_model` | `callbacks/empty_content_callback.py` | all (before_model) | Drop Content entries with empty text parts (Gemini API errors) |
 | `scope_sub_agent_context_callback` | `callbacks/scope_to_current_turn.py` | sub-agents only (before_model) | Trim to current turn |
 | `filter_tool_events_from_prompt` | `callbacks/filter_tool_events.py` | beto only (before_model) | Drop tool-only Content (function_call / function_response) from the LLM prompt so beto's cacheable prefix stays stable across turns |
+| `inject_telos_context` | `tools/telos/callback.py` | beto only (before_model) | Inject Telos anchor every turn + full block on first turn of session into `system_instruction` |
 | `handle_empty_response_after_model` | `callbacks/empty_content_callback.py` | all (after_model) | Replace empty model responses with a "still thinking" marker |
 | `telemetry_after_model_callback` | `callbacks/telemetry_callback.py` | all (after_model) | Record token usage + cost in `llm_usage_log` with `session_id` |
 | `tool_call_repair_callback` | `callbacks/tool_call_repair_callback.py` | (available, not wired by default) | Repair malformed function calls |
@@ -215,4 +217,5 @@ From `config/default_configs/instructions/main_agent.md`:
 | `tools/adk_builtin/code_execution_tool.py` | `code_execution_agent` factory |
 | `callbacks/scope_to_current_turn.py` | Per-turn context scoping for sub-agents |
 | `callbacks/filter_tool_events.py` | Strip tool-only Content from beto's LLM prompt to keep cacheable prefix stable |
+| `tools/telos/callback.py` | Inject Telos user-context into beto's `system_instruction` (anchor every turn, full block session-start) |
 | `tools/shared/card_protocol.py` | `radbot:<kind>` fenced-block card emission |

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -13,6 +13,7 @@ Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
+| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section` (identity/mission/problems/goals/projects/challenges/wisdom/predictions/journal/…), `ref_code` (e.g. `G1`, `P2`, `ME`), `content`, `metadata` (JSONB — section-specific fields), `status` (active/completed/archived/superseded), `sort_order`, UNIQUE (section, ref_code) |
 | `webhook_definitions` | `tools/webhooks/db.py` | `webhook_id` (UUID), `name` (UNIQUE), `path_suffix` (UNIQUE), `prompt_template`, `secret` |
 | `radbot_credentials` | `credentials/store.py` | `name` (PK), `encrypted_value`, `salt`, `credential_type` |
 | `coder_workspaces` | `tools/claude_code/db.py` | `workspace_id` (UUID), `owner`, `repo`, `branch`, `local_path`, `status`, `last_session_id`, `name`, `description` |
@@ -38,12 +39,13 @@ Uses the `radbot_chathistory` database with its own pool in `web/db/connection.p
 |-------|-------|---------|
 | `notifications` | `idx_notifications_type`, `idx_notifications_unread` (partial on `read=FALSE`), `idx_notifications_created (DESC)` | Feed filtering |
 | `llm_usage_log` | `idx_llm_usage_log_created (created_at DESC)`, `idx_llm_usage_log_label` | Rolling cost queries + session filters |
+| `telos_entries` | `idx_telos_section_status`, `idx_telos_active` (partial on `status='active'`), `idx_telos_journal_recent (created_at DESC)` (partial on `section='journal'`) | Loader (always-loaded section queries) + journal recency |
 
 ### Schema Init
 
 All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS` (or the `init_table_schema()` helper in `tools/shared/db_schema.py`). Called from:
 
-- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, notifications, llm_usage_log, alerts)
+- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, telos, notifications, llm_usage_log, alerts)
 - `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history)
 - `worker/__main__.py` — worker-side schema init (calls directly, not via ADK callback)
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -19,6 +19,7 @@ Non-tool services (TTS, STT, ntfy) expose REST endpoints only — they are not r
 | `tools/homeassistant/` (Dashboard WS) | 6 | casa | `list_ha_dashboards`, `get_ha_dashboard_config`, `create_ha_dashboard`, `update_ha_dashboard`, `delete_ha_dashboard`, `save_ha_dashboard_config` |
 | `tools/scheduler/` | 3 | planner | `create_scheduled_task`, `list_scheduled_tasks`, `delete_scheduled_task` |
 | `tools/reminders/` | 3 | planner | `create_reminder`, `list_reminders`, `delete_reminder` |
+| `tools/telos/` | 18 | beto | `telos_get_section`, `telos_get_entry`, `telos_get_full`, `telos_search_journal`, `telos_add_journal`, `telos_add_prediction`, `telos_resolve_prediction`, `telos_note_wrong`, `telos_note_taste`, `telos_add_wisdom`, `telos_add_idea`, `telos_upsert_identity`, `telos_add_entry`, `telos_update_entry`, `telos_add_goal`, `telos_complete_goal`, `telos_archive`, `telos_import_markdown` |
 | `tools/webhooks/` | 3 | tracker | `create_webhook`, `list_webhooks`, `delete_webhook` |
 | `tools/overseerr/` | 4 | casa | `search_overseerr_media`, `get_overseerr_media_details`, `request_overseerr_media`, `list_overseerr_requests` |
 | `tools/lidarr/` | 5 | casa | `search_lidarr_artist`, `search_lidarr_album`, `add_lidarr_artist`, `add_lidarr_album`, `list_lidarr_quality_profiles` |
@@ -126,6 +127,45 @@ Uses WebSocket client (`ha_websocket_client.py`) for Lovelace CRUD.
 | `create_reminder` | `message`, `remind_at`, `delay_minutes`, `timezone_name` |
 | `list_reminders` | `status` (pending/completed/cancelled/all) |
 | `delete_reminder` | `reminder_id` |
+
+### telos — `tools/telos/telos_tools.py`
+
+Persistent user-context store (mission, goals, problems, projects, challenges, wisdom, predictions, taste, journal, etc.). Beto-only. An anchor (~300B) is injected into `system_instruction` every turn via `inject_telos_context`; the full block (~2KB) is injected on the first turn of each session (gated by `callback_context.state['telos_bootstrapped']`). One-time onboarding via `uv run python -m radbot.tools.telos.cli onboard`.
+
+See `docs/implementation/telos.md` for the design and update policy (silent vs. confirm-required tools).
+
+**Read tools**
+
+| Tool | Parameters |
+|------|-----------|
+| `telos_get_section` | `section`, `include_inactive` |
+| `telos_get_entry` | `section`, `ref_code` |
+| `telos_get_full` | — |
+| `telos_search_journal` | `query`, `limit` |
+
+**Silent-update tools** (agent calls without asking)
+
+| Tool | Parameters |
+|------|-----------|
+| `telos_add_journal` | `entry`, `event_type`, `related_refs` |
+| `telos_add_prediction` | `claim`, `probability`, `deadline` |
+| `telos_resolve_prediction` | `ref_code`, `outcome`, `actual_value` (auto-adds `wrong_about` on miscalibration) |
+| `telos_note_wrong` | `thing`, `why` |
+| `telos_note_taste` | `category`, `item`, `sentiment`, `note` |
+| `telos_add_wisdom` | `principle`, `origin` |
+| `telos_add_idea` | `idea` |
+
+**Confirm-required tools** (agent proposes, user approves)
+
+| Tool | Parameters |
+|------|-----------|
+| `telos_upsert_identity` | `content`, `name`, `location`, `role`, `pronouns` |
+| `telos_add_entry` | `section`, `content`, `metadata`, `ref_code` |
+| `telos_update_entry` | `section`, `ref_code`, `content`, `metadata_merge`, `status` |
+| `telos_add_goal` | `title`, `deadline`, `kpi`, `parent_problem` |
+| `telos_complete_goal` | `ref_code`, `resolution` (also writes a journal entry) |
+| `telos_archive` | `section`, `ref_code`, `reason` |
+| `telos_import_markdown` | `markdown_text`, `replace` |
 
 ### webhooks — `tools/webhooks/webhook_tools.py`
 

--- a/tests/unit/test_telos.py
+++ b/tests/unit/test_telos.py
@@ -1,0 +1,430 @@
+"""Unit tests for the telos module.
+
+Covers:
+  * markdown round-trip (parse → render → parse)
+  * loader anchor/full-block assembly + size caps
+  * inject_telos_context callback session-start gating
+  * callback no-op on empty DB
+  * tool layer writes (silent + confirm-required both work)
+  * has_identity sentinel derivation
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from radbot.tools.telos import loader as telos_loader
+from radbot.tools.telos.callback import (
+    _BOOTSTRAP_STATE_KEY,
+    inject_telos_context,
+)
+from radbot.tools.telos.markdown_io import parse_telos_markdown, render_telos_markdown
+from radbot.tools.telos.models import (
+    IDENTITY_REF,
+    Entry,
+    Section,
+)
+
+
+# ---------------------------------------------------------------------------
+# Markdown round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownRoundTrip:
+    def test_basic_round_trip(self):
+        src = (
+            "# TELOS\n\n"
+            "## IDENTITY\n\n"
+            "Perry, based in Austin, builds agents.\n\n"
+            "## PROBLEMS\n\n"
+            "- P1: people waste time on busywork\n\n"
+            "## GOALS\n\n"
+            "- G1: ship radbot v1\n"
+            "- G2: sleep more\n\n"
+            "## WISDOM\n\n"
+            "- the magic is in the work you're avoiding\n"
+        )
+        entries = parse_telos_markdown(src)
+        rendered = render_telos_markdown(entries)
+        entries2 = parse_telos_markdown(rendered)
+
+        # Stable counts + ref_codes survive the round-trip.
+        sections1 = sorted(e.section.value for e in entries)
+        sections2 = sorted(e.section.value for e in entries2)
+        assert sections1 == sections2
+
+        refs1 = sorted(e.ref_code or "" for e in entries)
+        refs2 = sorted(e.ref_code or "" for e in entries2)
+        assert refs1 == refs2
+
+        # Content preserved.
+        by_ref = {e.ref_code: e.content for e in entries if e.ref_code}
+        by_ref2 = {e.ref_code: e.content for e in entries2 if e.ref_code}
+        for ref, content in by_ref.items():
+            assert by_ref2.get(ref) == content
+
+    def test_identity_single_entry(self):
+        entries = parse_telos_markdown(
+            "## IDENTITY\n\nLine one.\nLine two.\n"
+        )
+        idents = [e for e in entries if e.section == Section.IDENTITY]
+        assert len(idents) == 1
+        assert idents[0].ref_code == IDENTITY_REF
+        assert "Line one." in idents[0].content
+        assert "Line two." in idents[0].content
+
+    def test_unknown_section_preserved(self):
+        entries = parse_telos_markdown("## CUSTOM THING\n\n- something weird\n")
+        assert len(entries) == 1
+        assert entries[0].metadata.get("raw_section_name") == "CUSTOM THING"
+
+        rendered = render_telos_markdown(entries)
+        assert "## CUSTOM THING" in rendered
+        assert "something weird" in rendered
+
+    def test_empty_input(self):
+        assert parse_telos_markdown("") == []
+
+    def test_render_empty(self):
+        assert render_telos_markdown([]).strip() == "# TELOS"
+
+
+# ---------------------------------------------------------------------------
+# Loader: build_telos_tiers()
+# ---------------------------------------------------------------------------
+
+
+def _fake_entry(
+    section: Section,
+    content: str,
+    ref_code: str | None = None,
+    metadata: dict | None = None,
+    created_at: datetime | None = None,
+) -> Entry:
+    return Entry(
+        entry_id="abcd",
+        section=section,
+        ref_code=ref_code,
+        content=content,
+        metadata=metadata or {},
+        status="active",
+        sort_order=0,
+        created_at=created_at or datetime(2026, 4, 18, tzinfo=timezone.utc),
+        updated_at=created_at or datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
+
+
+class TestLoader:
+    def test_empty_db_returns_empty_strings(self):
+        grouped = {s: [] for s in Section}
+        with patch.object(telos_loader.telos_db, "list_all_active", return_value=grouped), \
+             patch.object(telos_loader.telos_db, "recent_journal", return_value=[]):
+            anchor, full_block = telos_loader.build_telos_tiers()
+        assert anchor == ""
+        assert full_block == ""
+
+    def test_populated_db_builds_both_tiers(self):
+        grouped = {s: [] for s in Section}
+        grouped[Section.IDENTITY] = [
+            _fake_entry(Section.IDENTITY, "Perry, Austin, builds agents", "ME")
+        ]
+        grouped[Section.MISSION] = [
+            _fake_entry(Section.MISSION, "Make radbot self-aware", "M1")
+        ]
+        grouped[Section.PROBLEMS] = [
+            _fake_entry(Section.PROBLEMS, "agents forget who the user is", "P1"),
+        ]
+        grouped[Section.GOALS] = [
+            _fake_entry(Section.GOALS, "Ship telos", "G1"),
+            _fake_entry(Section.GOALS, "Sleep 8h", "G2"),
+        ]
+        journal = [
+            _fake_entry(Section.JOURNAL, "Wrote the Telos spec"),
+        ]
+        with patch.object(telos_loader.telos_db, "list_all_active", return_value=grouped), \
+             patch.object(telos_loader.telos_db, "recent_journal", return_value=journal):
+            anchor, full_block = telos_loader.build_telos_tiers()
+
+        assert anchor
+        assert full_block
+        assert "Perry" in anchor
+        assert "Make radbot self-aware" in anchor
+        assert "IDENTITY" in full_block
+        assert "G1" in full_block
+        assert "G2" in full_block
+        assert "Wrote the Telos spec" in full_block
+
+    def test_anchor_size_cap(self):
+        # Pathological: long identity + long mission → anchor still under cap.
+        grouped = {s: [] for s in Section}
+        grouped[Section.IDENTITY] = [
+            _fake_entry(Section.IDENTITY, "x" * 2000, "ME")
+        ]
+        grouped[Section.MISSION] = [
+            _fake_entry(Section.MISSION, "y" * 2000, "M1")
+        ]
+        grouped[Section.GOALS] = [
+            _fake_entry(Section.GOALS, f"goal {i}", f"G{i}") for i in range(20)
+        ]
+        with patch.object(telos_loader.telos_db, "list_all_active", return_value=grouped), \
+             patch.object(telos_loader.telos_db, "recent_journal", return_value=[]):
+            anchor, _ = telos_loader.build_telos_tiers()
+        assert len(anchor.encode("utf-8")) <= telos_loader.ANCHOR_CAP_BYTES
+
+    def test_full_block_size_cap(self):
+        grouped = {s: [] for s in Section}
+        grouped[Section.IDENTITY] = [_fake_entry(Section.IDENTITY, "Perry", "ME")]
+        grouped[Section.MISSION] = [_fake_entry(Section.MISSION, "Mission text", "M1")]
+        grouped[Section.GOALS] = [
+            _fake_entry(Section.GOALS, "A" * 200, f"G{i}") for i in range(30)
+        ]
+        journal = [
+            _fake_entry(Section.JOURNAL, "J" * 150) for _ in range(30)
+        ]
+        with patch.object(telos_loader.telos_db, "list_all_active", return_value=grouped), \
+             patch.object(telos_loader.telos_db, "recent_journal", return_value=journal):
+            _, full_block = telos_loader.build_telos_tiers()
+        assert len(full_block.encode("utf-8")) <= telos_loader.FULL_BLOCK_CAP_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Callback: session-start gating
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(state: dict | None = None):
+    ctx = MagicMock()
+    ctx.state = state if state is not None else {}
+    return ctx
+
+
+def _make_req(existing_system_instruction: str | None = None):
+    req = MagicMock()
+    req.config = MagicMock()
+    req.config.system_instruction = existing_system_instruction
+    return req
+
+
+class TestInjectTelosContext:
+    def test_noop_on_empty_db(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            return_value=("", ""),
+        ):
+            ctx = _make_ctx()
+            req = _make_req("original")
+            result = inject_telos_context(ctx, req)
+        assert result is None
+        assert req.config.system_instruction == "original"
+
+    def test_first_turn_injects_anchor_plus_full_block(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            return_value=("ANCHOR_TEXT", "FULL_BLOCK_TEXT"),
+        ):
+            ctx = _make_ctx(state={})
+            req = _make_req("base_instruction")
+            inject_telos_context(ctx, req)
+
+        si = req.config.system_instruction
+        assert "base_instruction" in si
+        assert "ANCHOR_TEXT" in si
+        assert "FULL_BLOCK_TEXT" in si
+        assert ctx.state[_BOOTSTRAP_STATE_KEY] is True
+
+    def test_subsequent_turn_injects_anchor_only(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            return_value=("ANCHOR_TEXT", "FULL_BLOCK_TEXT"),
+        ):
+            ctx = _make_ctx(state={_BOOTSTRAP_STATE_KEY: True})
+            req = _make_req("base_instruction")
+            inject_telos_context(ctx, req)
+
+        si = req.config.system_instruction
+        assert "ANCHOR_TEXT" in si
+        assert "FULL_BLOCK_TEXT" not in si
+
+    def test_first_turn_with_no_full_block_still_injects_anchor(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            return_value=("ANCHOR_TEXT", ""),
+        ):
+            ctx = _make_ctx(state={})
+            req = _make_req(None)
+            inject_telos_context(ctx, req)
+        assert "ANCHOR_TEXT" in req.config.system_instruction
+        # With no full block, we still don't flip the bootstrap flag (so next
+        # time a full block becomes available it'll inject).
+        assert not ctx.state.get(_BOOTSTRAP_STATE_KEY)
+
+    def test_handles_none_system_instruction(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            return_value=("ANCHOR_TEXT", ""),
+        ):
+            ctx = _make_ctx()
+            req = _make_req(None)
+            inject_telos_context(ctx, req)
+        assert req.config.system_instruction == "ANCHOR_TEXT"
+
+    def test_handles_db_failure_gracefully(self):
+        with patch(
+            "radbot.tools.telos.callback.build_telos_tiers",
+            side_effect=RuntimeError("db down"),
+        ):
+            ctx = _make_ctx()
+            req = _make_req("base")
+            result = inject_telos_context(ctx, req)
+        # Should not raise; system_instruction left unchanged.
+        assert result is None
+        assert req.config.system_instruction == "base"
+
+
+# ---------------------------------------------------------------------------
+# Agent wiring: callback attached to beto only, NOT to sub-agents
+# ---------------------------------------------------------------------------
+
+
+class TestAgentWiring:
+    def test_callback_on_beto_only(self):
+        """inject_telos_context should be in root agent's before_model_callback,
+        and absent from the shared sub-agent _before_cbs."""
+        import radbot.agent.agent_core as core
+
+        assert inject_telos_context in core.root_agent.before_model_callback
+
+        # Sub-agents use _before_cbs (name is module-private but stable).
+        # Each sub-agent's before_model_callback should not contain our callback.
+        for sa in core.root_agent.sub_agents:
+            before = sa.before_model_callback or []
+            assert inject_telos_context not in before, (
+                f"inject_telos_context leaked into sub-agent {sa.name}"
+            )
+
+    def test_telos_tools_on_beto(self):
+        """Telos tools should be registered on beto's tool list."""
+        import radbot.agent.agent_core as core
+        from radbot.tools.telos import TELOS_TOOLS
+
+        beto_tool_fns = set()
+        for t in core.root_agent.tools:
+            fn = getattr(t, "func", None)
+            if fn:
+                beto_tool_fns.add(fn.__name__)
+
+        for tool in TELOS_TOOLS:
+            fn = getattr(tool, "func", None)
+            if fn:
+                assert fn.__name__ in beto_tool_fns, (
+                    f"Telos tool {fn.__name__} missing from beto"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tool layer (with DB mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestToolsLayer:
+    def test_silent_add_journal(self):
+        from radbot.tools.telos import telos_tools
+
+        fake_row = _fake_entry(Section.JOURNAL, "Did a thing")
+        with patch.object(telos_tools.telos_db, "add_entry", return_value=fake_row) as mock_add:
+            out = telos_tools.telos_add_journal("Did a thing", event_type="decision")
+        assert out["status"] == "success"
+        assert out["entry"]["content"] == "Did a thing"
+        _, kwargs = mock_add.call_args
+        assert kwargs["metadata"]["event_type"] == "decision"
+
+    def test_confirm_required_add_goal(self):
+        from radbot.tools.telos import telos_tools
+
+        fake_row = _fake_entry(
+            Section.GOALS, "Ship telos", "G1",
+            metadata={"deadline": "2026-12-31"},
+        )
+        with patch.object(telos_tools.telos_db, "add_entry", return_value=fake_row):
+            out = telos_tools.telos_add_goal(
+                "Ship telos", deadline="2026-12-31", kpi="v1 tagged"
+            )
+        assert out["status"] == "success"
+        assert out["entry"]["ref_code"] == "G1"
+
+    def test_get_section_filters_inactive_by_default(self):
+        from radbot.tools.telos import telos_tools
+
+        fake = [_fake_entry(Section.GOALS, "x", "G1")]
+        with patch.object(telos_tools.telos_db, "list_section", return_value=fake) as mock_list:
+            out = telos_tools.telos_get_section("goals")
+        assert out["status"] == "success"
+        # list_section called with status='active' by default.
+        _, kwargs = mock_list.call_args
+        assert kwargs["status"] == "active"
+
+    def test_unknown_section_returns_error(self):
+        from radbot.tools.telos import telos_tools
+
+        out = telos_tools.telos_get_section("not_a_real_section")
+        assert out["status"] == "error"
+
+    def test_resolve_prediction_adds_wrong_about_on_miscalibration(self):
+        from radbot.tools.telos import telos_tools
+
+        pred = _fake_entry(
+            Section.PREDICTIONS, "X will happen", "PRED1",
+            metadata={"probability": 0.9},
+        )
+        resolved = _fake_entry(
+            Section.PREDICTIONS, "X will happen", "PRED1",
+            metadata={"probability": 0.9, "resolution": "false"},
+        )
+        wrong = _fake_entry(Section.WRONG_ABOUT, "Miscalibrated on PRED1")
+
+        add_entry_calls = []
+
+        def fake_add_entry(section, content, **kwargs):
+            add_entry_calls.append((section, content, kwargs))
+            return wrong
+
+        with patch.object(telos_tools.telos_db, "get_entry", return_value=pred), \
+             patch.object(telos_tools.telos_db, "update_entry", return_value=resolved), \
+             patch.object(telos_tools.telos_db, "add_entry", side_effect=fake_add_entry):
+            out = telos_tools.telos_resolve_prediction("PRED1", outcome=False)
+
+        assert out["status"] == "success"
+        assert out["miscalibrated"] is True
+        # One add_entry call for wrong_about.
+        assert any(sec == Section.WRONG_ABOUT for sec, _, _ in add_entry_calls)
+
+    def test_resolve_prediction_no_wrong_about_when_calibrated(self):
+        from radbot.tools.telos import telos_tools
+
+        pred = _fake_entry(
+            Section.PREDICTIONS, "X will happen", "PRED1",
+            metadata={"probability": 0.5},
+        )
+        resolved = _fake_entry(
+            Section.PREDICTIONS, "X will happen", "PRED1",
+            metadata={"probability": 0.5, "resolution": "true"},
+        )
+
+        add_entry_calls = []
+
+        def fake_add_entry(section, content, **kwargs):
+            add_entry_calls.append((section, content, kwargs))
+            return _fake_entry(section, content)
+
+        with patch.object(telos_tools.telos_db, "get_entry", return_value=pred), \
+             patch.object(telos_tools.telos_db, "update_entry", return_value=resolved), \
+             patch.object(telos_tools.telos_db, "add_entry", side_effect=fake_add_entry):
+            out = telos_tools.telos_resolve_prediction("PRED1", outcome=True)
+
+        assert out["status"] == "success"
+        assert out["miscalibrated"] is False
+        assert not any(sec == Section.WRONG_ABOUT for sec, _, _ in add_entry_calls)


### PR DESCRIPTION
## Summary

Adds a Telos-style structured persona/context store (adapted from [danielmiessler/Telos](https://github.com/danielmiessler/Telos)) that beto reads on every turn and writes to during interactions. Gives beto durable knowledge of mission, goals, projects, wisdom, journal, predictions, taste — and a calibrated write-path so it compounds from conversation instead of sitting frozen as a prompt append.

**One table, JSONB section metadata, canonical markdown import/export.** Sections: identity, mission, problems, narratives, goals, challenges, strategies, projects, wisdom, ideas, predictions, wrong_about, best_books/movies/music, taste, history, traumas, metrics, journal.

**Injection is beto-only.** Anchor (~300B) appends to `system_instruction` every turn; full block (~2KB) appends on the first turn of each session, gated by `callback_context.state['telos_bootstrapped']`. Sub-agents are tool executors and don't get persona context. See `docs/implementation/telos.md`.

**Update policy** (enforced by `main_agent.md`, not the tool layer): silent tools (journal, prediction, wrong-about, taste, wisdom, idea) fire without asking; structural tools (mission, problems, goals, projects, challenges, archive) require user confirmation.

**Onboarding is one-time and outside the agent loop.** No instructions baked into the LLM, no recurring nudges. Run once via `uv run python -m radbot.tools.telos.cli onboard`.

## What changed

- `radbot/tools/telos/` — new module: `models.py`, `db.py` (CRUD + bulk upsert), `markdown_io.py` (canonical Telos round-trip), `loader.py` (two-tier assembly with size caps), `callback.py` (`inject_telos_context`), `telos_tools.py` (18 FunctionTools), `cli.py` (`onboard`/`import`/`export`/`show`/`reset`).
- `radbot/agent/agent_core.py` — registers `TELOS_TOOLS` on beto; adds `inject_telos_context` to beto's `before_model_callback` only (not the shared `_before_cbs` that sub-agents use).
- `radbot/agent/agent_tools_setup.py` — `telos_init` added to `_SCHEMA_INITS`.
- `radbot/web/app.py` — `init_telos_schema()` added to startup chain.
- `radbot/config/default_configs/instructions/main_agent.md` — Telos update policy section (silent vs. confirm tools).
- `tests/unit/test_telos.py` — markdown round-trip, loader size caps, callback session-start gating, empty-DB no-op, sub-agent isolation, tool happy paths.
- Specs: `docs/implementation/telos.md` (full design), `SPEC.md`, `specs/tools.md`, `specs/agents.md`, `specs/storage.md`, `CLAUDE.md`.

## Spec updates

- `specs/tools.md` — new `tools/telos/` row (18 tools); full per-tool table.
- `specs/agents.md` — beto tool count 2 → 20; `inject_telos_context` added to callback registry and beto's callback list.
- `specs/storage.md` — new `telos_entries` table + indexes.
- `SPEC.md` / `CLAUDE.md` — Telos cross-cutting bullet and tool/table rows.

## Test plan

- [ ] `uv run pytest tests/unit/test_telos.py -v`
- [ ] `uv run python -m radbot.tools.telos.cli onboard` — walks through the 9-question interview; Identity commits first so the sentinel flips.
- [ ] After onboard, `uv run python -m radbot.tools.telos.cli show` — prints saved sections.
- [ ] `uv run python -m radbot.tools.telos.cli export > /tmp/telos.md && cat /tmp/telos.md` — round-trips to canonical Telos format.
- [ ] Start beto (`uv run python -m radbot.web`), ask a general question, check logs for `TELOS ANCHOR` / full block in first turn's `system_instruction`.
- [ ] Ask beto "what do you know about me?" — should pull from Telos via `telos_get_full` / `telos_get_section`.
- [ ] Mention a prediction with a probability ("I'd bet 70% X by June") — beto should silently call `telos_add_prediction`; confirm via `telos show`.
- [ ] Propose a new goal — beto should ask for confirmation before calling `telos_add_goal`.
- [ ] Verify sub-agents (casa, planner, etc.) do NOT receive Telos context: grep sub-agent logs or inspect `llm_request.config.system_instruction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)