### PR TITLE
feat(casa): migrate HA tool surface to native mcp_server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Beto routes requests via ADK's `transfer_to_agent` — no wrapper tools needed.
 | Agent | Factory location | Tools | Purpose |
 |---|---|---|---|
 | **beto** (root) | `agent/agent_core.py` | 2 memory | Orchestrator, routes to specialists |
-| **casa** | `agent/home_agent/factory.py` | 6 HA + 4 Overseerr + 5 Lidarr + 8 Picnic + 2 memory | Smart home, media requests, music collection, grocery ordering |
+| **casa** | `agent/home_agent/factory.py` | HA MCP (~19 built-in + user scripts, dynamic) + 6 HA Dashboard + 4 Overseerr + 5 Lidarr + 8 Picnic + 2 memory | Smart home (native HA Assist intent tools via `mcp_server`), media requests, music, grocery. Set `integrations.home_assistant.use_mcp=false` to fall back to the 6 REST tools. |
 | **planner** | `agent/planner_agent/factory.py` | 1 time + 5 calendar + 3 scheduler + 3 reminder + 2 memory | Calendar, scheduling, reminders |
 | **tracker** | `agent/tracker_agent/factory.py` | 8 todo + 3 webhook + 2 memory | Task/project management |
 | **comms** | `agent/comms_agent/factory.py` | 4 gmail + 6 jira + 2 memory | Email, issue tracking |

--- a/docs/implementation/integrations/ha_mcp_migration.md
+++ b/docs/implementation/integrations/ha_mcp_migration.md
@@ -1,0 +1,108 @@
+# Home Assistant MCP Migration
+
+<!-- Status: shipped | See also: docs/plans/ha_alias_learning.md (follow-up) -->
+
+## What changed
+
+Casa's Home Assistant tool surface moved from 6 hand-rolled REST FunctionTools to the tools HA itself exposes through its built-in `mcp_server` core integration (HA 2025.2+). The REST tools stay in the tree as a fallback path, gated by `integrations.home_assistant.use_mcp` (default `true`).
+
+## Why
+
+### Capability
+
+The REST tool set only supported `turn_on` / `turn_off` / `toggle` per entity. Everything else — brightness, color, climate temperature, media search, volume, vacuum, fan speed, timers, broadcast TTS, scenes, user scripts — was unreachable from radbot.
+
+HA's `mcp_server` exposes the full **Assist LLM API** as MCP tools. On Perry's HA (probed live at `http://192.168.50.104:8123`, HA 2026.4.1): 19 built-in intent tools plus 18 user-exposed scripts, 37 total. Concrete intents now reachable include `HassLightSet` (brightness/color/temperature), `HassClimateSetTemperature`, `HassMediaSearchAndPlay`, `HassSetVolume`, `HassVacuumStart`, `HassFanSetSpeed`, `HassBroadcast`, `HassStartTimer`, `GetLiveContext`, plus every user script (`morning_heat`, `water_plants`, `start_plex`, `executa_hisense_*`, …) with zero radbot-side code.
+
+### Search / resolution
+
+Previously: LLM called `search_ha_entities(search_term)` → radbot string-matched on an in-memory snapshot of all entities → returned candidate list → LLM picked one → called `turn_*_ha_entity(entity_id)`. Two LLM roundtrips every time.
+
+With MCP: HA's intent resolver (`MatchTargets`) is invoked by the action tool itself. The LLM emits `HassTurnOff(name="basement plant", domain=["light","switch"])` and HA's resolver handles name, area, floor, domain-array, device-class, and alias matching natively. One roundtrip typical; on ambiguity HA returns a structured `MatchFailedError` the LLM can retry with a narrower filter.
+
+The `domain: string[]` parameter is the critical feature: a phrase like "basement plant lights" that could resolve to `light.*` or `switch.*` (common when growlights are actually smart outlets with bulbs) is handled in one call by expanding the domain array.
+
+### Exposure model
+
+HA gates the MCP tool surface by "Expose to Assist" (Settings → Voice assistants → Expose). Only exposed entities appear in `GetLiveContext`; only exposed entities are resolvable via action intents. On Perry's HA: 99 exposed entities out of ~500 total, 13 areas. The exposure list is the authoritative "what the LLM is allowed to see," which radbot defers to rather than re-implementing.
+
+### Measured token cost
+
+Live probe against the same HA that casa talks to in production:
+
+| | Before (REST) | After (MCP) |
+|---|---|---|
+| Tool schema footprint on casa's prompt | 6 tools × ~250B each ≈ 1.5 KB | 37 tools, 9.8 KB total (~2.45K tokens) |
+| Entity state "snapshot" call | `list_ha_entities` unbounded, 500+ entities, ~30-50 KB per call | `GetLiveContext`, 99 exposed entities, ~3.25 KB per call (~10× smaller) |
+| Startup `list_entities()` in `setup_before_agent_call` | Always fired, full dump | Removed — health check is now just `GET /api/` |
+
+Tool schemas are larger (we're paying for the capability we gained). Per-call state-lookup cost is far smaller. Net effect on typical casa turns is lower prompt size, and much higher capability per turn.
+
+## Architecture
+
+### Transport
+
+HA's `mcp_server` exposes two transports:
+
+- `GET /mcp_server/sse` — SSE transport (original)
+- `POST /api/mcp` — **streamable-HTTP** transport (added in 2025.11 line, current MCP spec)
+
+We use streamable-HTTP. It's stateless (no session id, no keepalive, no exit stack) — each JSON-RPC request is independent. That matches both the agent-factory sync bootstrap and the per-call async runtime cleanly.
+
+Why not ADK's bundled `McpToolset`: it targets SSE and returns an `AsyncExitStack` the caller must keep alive across the tool's lifetime. That fits badly with the agent factory (sync context at construction, then ADK's loop runs tools later) and created lifetime bugs in the existing scaffold (`radbot/tools/mcp/mcp_homeassistant.py` runs a throwaway event loop and drops the exit stack — the transport wouldn't survive real use). A 170-line streamable-HTTP client with httpx sidesteps all of it.
+
+### Modules
+
+| File | Purpose |
+|---|---|
+| `radbot/tools/homeassistant/ha_mcp_client.py` | `HAMcpClient` — streamable-HTTP JSON-RPC client. `list_tools_sync()` for factory-time discovery, `call_tool(name, arguments)` async for runtime invocation. Singleton via `get_ha_mcp_client()` / `reset_ha_mcp_client()`, same config/credential chain as the REST client. |
+| `radbot/tools/homeassistant/ha_mcp_tools.py` | `build_ha_mcp_function_tools(client)` — wraps each MCP tool as an ADK `FunctionTool` with `function_schema` translated from MCP's `inputSchema`. Sanitizes HA tool names to valid Python identifiers (user scripts can have leading digits / non-ASCII). Unwraps HA's `{"success": bool, "result": ...}` envelope before returning to the LLM. |
+| `radbot/agent/home_agent/factory.py` | Wired — prefers MCP tools, falls back to the REST six if `use_mcp=false` or MCP discovery fails. |
+| `radbot/agent/agent_tools_setup.py` | `list_entities()` startup dump removed. HA health check is now just `GET /api/`. |
+| `radbot/web/api/admin.py` | `/api/test/home-assistant` now probes REST + MCP and reports tool count. `_INTEGRATION_RESET_REGISTRY` includes `reset_ha_mcp_client` so admin hot-reload clears the singleton. |
+| `radbot/web/frontend/src/components/admin/panels/ConnectionPanels.tsx` | Dropped the `mcp_sse_url` input; added a "Use MCP" toggle. URL is derived from the existing `url` field. |
+
+### Config
+
+```yaml
+integrations:
+  home_assistant:
+    enabled: true
+    url: http://192.168.50.104:8123/       # same as REST
+    # token stored in credential store as `ha_token`
+    use_mcp: true                          # default true; false falls back to REST tools
+```
+
+The `mcp_sse_url` field is gone — the MCP endpoint is `urljoin(url, "api/mcp")`.
+
+### Tool discovery and naming
+
+`HAMcpClient.list_tools_sync()` runs an `initialize` → `notifications/initialized` → `tools/list` trio at factory time and returns the raw MCP tool list. `build_ha_mcp_function_tools` then:
+
+1. Reads each entry's `name`, `description`, `inputSchema`.
+2. Sanitizes `name` to a valid Python identifier (ADK requirement). Original name is kept in the closure used for `tools/call` so the mapping survives sanitization.
+3. Produces `FunctionTool(function=<async closure>, function_schema=<JSON schema>)`. ADK sees exactly what it expects — a callable and a schema.
+4. On invocation, drops `None` values from the arguments (ADK occasionally passes explicit nulls that HA rejects).
+5. Returns the unwrapped `result` on success, or `{"status": "error", "error": ...}` on failure.
+
+### Fallback behaviour
+
+`create_home_agent()` attempts MCP first. If `use_mcp=false`, HA is unconfigured, or `list_tools_sync()` raises (MCP server not loaded in HA, token rejected, etc.), it falls back to importing the REST tool set. There is no mixed mode — a casa agent is all-MCP or all-REST — to avoid doubling the tool surface when both paths work.
+
+## Probed behaviour (live, 2026-04-18)
+
+```
+POST /api/mcp  →  {"protocolVersion":"2024-11-05", ... serverInfo:{name:"home-assistant", version:"1.26.0"}, ...}
+tools/list     →  37 tools
+GetLiveContext →  99 entities across 13 areas, 55% currently unavailable
+                  domains: sensor(33) switch(26) binary_sensor(18) light(7) scene(7) fan(4) media_player(2) lock(1) vacuum(1)
+HassTurnOff(name="nonexistent zxqw widget", domain=["light","switch"])
+               →  isError=true, MatchFailedError{is_match=False, no_match_reason=NAME, ...}
+GetDateTime    →  {"date":"2026-04-18","time":"15:58:39","timezone":"CEST","weekday":"Saturday"}
+```
+
+## Follow-ups
+
+- **HA alias learning loop** — `docs/plans/ha_alias_learning.md`. Turn recurring fuzzy resolutions ("grow" → area `all grow lights`) into persistent HA entity/area aliases via the WebSocket registry API, with a candidate queue in postgres and human-in-the-loop promotion. Deliberately deferred until we have usage data from the MCP migration in production.
+- **Dashboard tools on MCP?** — HA's `mcp_server` doesn't expose Lovelace CRUD. The WS-based dashboard tools stay as-is.
+- **Push state updates** — MCP Resources / Notifications aren't implemented in HA yet (tools+prompts only). State changes still need to be polled via `GetLiveContext` or the REST `GET /api/states` path.

--- a/docs/implementation/integrations/index.md
+++ b/docs/implementation/integrations/index.md
@@ -8,6 +8,7 @@ This directory contains documentation for RadBot's integrations with external se
 ## Contents
 
 - [Google Calendar](google_calendar.md) - Google Calendar API integration
+- [Home Assistant MCP migration](ha_mcp_migration.md) - Casa's HA tool surface via HA's `mcp_server` (HA 2025.2+), replacing the hand-rolled REST FunctionTools
 
 ## Overview
 

--- a/docs/plans/ha_alias_learning.md
+++ b/docs/plans/ha_alias_learning.md
@@ -1,0 +1,266 @@
+# HA Alias Learning Loop (Plan)
+
+<!-- Status: planned, not yet implemented | Depends on: HA MCP migration -->
+
+## Context
+
+Home Assistant's intent resolver (`MatchTargets`, reached via the `mcp_server` integration) matches user phrasing to entities using:
+
+- entity `friendly_name`
+- entity `aliases` list (entity registry)
+- area `name` + area `aliases` list (area registry)
+- floor `name` + floor `aliases` list (floor registry)
+- `domain[]` / `device_class[]` filters passed in the tool call
+
+The HA MCP migration (see `docs/implementation/integrations/ha_mcp_migration.md` once shipped) dropped radbot's `search_ha_entities` tool because HA now does the matching natively. But HA's matcher only knows what HA's registries have been *told* about — friendly names and any aliases the user manually added in the HA UI.
+
+In production we routinely see queries like "turn off the basement grow" where:
+
+- "grow" is not a friendly name of any entity
+- "grow" is not an alias on anything in HA
+- But the entities *are* all grouped under an area called `all grow lights`
+
+On such a query the LLM's first `HassTurnOff(name="basement grow", domain=["light","switch"])` returns `MatchFailedError`. The LLM's recovery today: call `GetLiveContext`, search client-side, re-call `HassTurnOff` with the right area or name. Works, but it's two LLM roundtrips on every such phrase — forever.
+
+**This plan is about capturing those recoveries as persistent aliases so the second+ time the user says "grow" it resolves in one roundtrip.**
+
+## Goal
+
+Let radbot learn entity and area aliases from successful fuzzy-resolution episodes, promote them into HA's registry after enough corroboration, and expose the pipeline so a human can audit / override before or after promotion.
+
+**Non-goals:**
+
+- Do not maintain a parallel "radbot-side" alias map. HA's matcher is the authority; any alias radbot cares about ultimately lives in HA. See "Why not pure-postgres" below.
+- Do not auto-learn from first encounter. The learning loop is deliberately conservative — corroboration-gated and user-visible.
+- Do not touch exposure config (`homeassistant/expose_entity`). Exposure is the user's policy surface; aliases are a naming surface. They stay separate.
+
+## Why hybrid (postgres candidate queue + HA for production aliases)
+
+**HA is the production store** for two decisive reasons:
+
+1. **HA's resolver has features we'd otherwise rebuild.** `MatchTargets` handles floor > area > entity hierarchy, `domain[]` expansion, `device_class` narrowing, `allow_duplicate_names` toggling, fuzzy matching with aliases. Reproducing this in radbot would be a real project with long-tail edge cases.
+2. **Area aliases cover groups of entities for free.** Adding "grow" as an alias on the `all grow lights` area is one write that covers 8 switches. A radbot-side phrase map would have to either re-implement area resolution or rewrite one phrase into N individual entity calls.
+
+**radbot postgres is the learning queue + audit trail** because HA has no concept of:
+
+- "we saw this phrase N times"
+- "user confirmed / rejected this mapping"
+- "this alias was promoted by radbot on date X, rollback-able via this row"
+
+Pure-HA loses all provenance. Pure-postgres loses HA's native resolver and multi-client benefit. Hybrid keeps both.
+
+## Architecture
+
+```
+User message
+  └─ casa LLM emits HassTurnOff(name="basement grow", domain=[...])
+       └─ HA MCP returns MatchFailedError
+            └─ casa LLM calls GetLiveContext
+                 └─ LLM picks area "all grow lights" + retries
+                      └─ HA MCP succeeds
+                           └─ candidate_recorder hook writes a row to
+                              ha_alias_candidates
+                                (user_phrase, resolved_target_id, session_id, ...)
+
+  (later, async)
+  └─ candidate_promoter job
+       └─ any candidate with usage_count >= N and user_rejected = false?
+            ├─ send notification to user: "I keep seeing 'grow'
+            │   — add as an alias for area 'all grow lights'? [yes/no/never]"
+            └─ on yes → config/area_registry/update via WS client
+                 └─ mark candidate row promoted_at = now()
+```
+
+Two independent flows: **candidate recording** runs on every successful fuzzy resolution (synchronous, lightweight); **promotion** is async and human-in-the-loop.
+
+## Components
+
+### 1. DB schema — `ha_alias_candidates`
+
+```sql
+CREATE TABLE IF NOT EXISTS ha_alias_candidates (
+    candidate_id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    target_kind          TEXT NOT NULL CHECK (target_kind IN ('entity', 'area', 'floor')),
+    target_id            TEXT NOT NULL,           -- entity_id / area_id / floor_id
+    target_display_name  TEXT NOT NULL,           -- for humans in admin UI
+    user_phrase          TEXT NOT NULL,           -- normalized lowercase, stripped
+    resolution_path      TEXT NOT NULL,           -- 'getlivecontext' | 'domain_expand' | 'fuzzy_alias' | 'manual'
+    usage_count          INT NOT NULL DEFAULT 1,
+    session_ids          TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],  -- distinct sessions it's been seen in
+    user_confirmed       BOOL NOT NULL DEFAULT FALSE,
+    user_rejected        BOOL NOT NULL DEFAULT FALSE,
+    promoted_at          TIMESTAMPTZ,             -- when we wrote to HA; NULL if not yet
+    promoted_alias_text  TEXT,                    -- exact string we wrote (for rollback)
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes                TEXT,
+
+    UNIQUE (target_kind, target_id, user_phrase)
+);
+
+CREATE INDEX ha_alias_candidates_unpromoted
+  ON ha_alias_candidates (usage_count DESC, last_seen_at DESC)
+  WHERE promoted_at IS NULL AND user_rejected = FALSE;
+```
+
+Schema init hook: `init_ha_alias_schema()` in `radbot/tools/homeassistant/alias_db.py`, wired into `setup_before_agent_call` alongside the existing schema registry (see `radbot/agent/agent_tools_setup.py`).
+
+### 2. WebSocket alias methods
+
+Extend `radbot/tools/homeassistant/ha_websocket_client.py`:
+
+```python
+async def list_entity_registry(self) -> list[dict]:
+    return await self.send_command("config/entity_registry/list")
+
+async def update_entity_aliases(self, entity_id: str, aliases: list[str]) -> dict:
+    return await self.send_command(
+        "config/entity_registry/update",
+        entity_id=entity_id,
+        aliases=aliases,
+    )
+
+async def list_area_registry(self) -> list[dict]:
+    return await self.send_command("config/area_registry/list")
+
+async def update_area_aliases(self, area_id: str, aliases: list[str]) -> dict:
+    return await self.send_command(
+        "config/area_registry/update",
+        area_id=area_id,
+        aliases=aliases,
+    )
+
+async def list_floor_registry(self) -> list[dict]:
+    return await self.send_command("config/floor_registry/list")
+
+async def update_floor_aliases(self, floor_id: str, aliases: list[str]) -> dict:
+    return await self.send_command(
+        "config/floor_registry/update",
+        floor_id=floor_id,
+        aliases=aliases,
+    )
+```
+
+The existing transport (`send_command`) already handles auth, reconnect, and message-ID correlation — these are thin convenience wrappers.
+
+**Important detail for `update_*_aliases`:** HA's registry update is a full replace of the `aliases` list, not an append. Implementations must read current aliases first, union/remove, then write back. Do this in an atomic helper.
+
+### 3. Candidate recording hook
+
+Add `record_alias_candidate` in `radbot/tools/homeassistant/alias_learner.py`:
+
+```python
+def record_alias_candidate(
+    *,
+    user_phrase: str,
+    target_kind: str,         # 'entity' | 'area' | 'floor'
+    target_id: str,
+    target_display_name: str,
+    resolution_path: str,     # what led us here
+    session_id: str | None = None,
+) -> None:
+    """Upsert a candidate row. Lightweight, never raises into hot path."""
+```
+
+Called by casa's `HassTurnOn`/`HassTurnOff`/etc. retry path when:
+- the first call returned `MatchFailedError`, AND
+- a follow-up call succeeded on the same user phrase with a different resolution strategy
+
+Implementation note: the MCP tool adapter (the ADK `FunctionTool` wrapper around each HA MCP tool) is the natural seam. On success, it inspects whether the preceding call for this LLM turn failed with `MatchFailedError` and if so records a candidate.
+
+**Normalization rules for `user_phrase`:**
+
+- lowercase
+- strip surrounding whitespace + punctuation
+- collapse internal whitespace
+- strip common stop phrases: "the ", "my ", "please ", leading / trailing articles
+- keep a `raw_phrase` in `notes` JSON for debugging
+
+### 4. Promotion rules
+
+A nightly (or on-demand) job scans `ha_alias_candidates WHERE promoted_at IS NULL AND user_rejected = FALSE`. Proposed thresholds (tunable via `config:agent.alias_learning`):
+
+```yaml
+alias_learning:
+  enabled: true
+  min_usage_count: 3              # how many successful resolutions before proposing
+  min_distinct_sessions: 2        # across multiple user sessions (not one bad session)
+  cooldown_days: 7                # don't re-propose a rejected candidate within N days
+  auto_promote: false             # if true, skip user notification and promote directly
+  max_aliases_per_target: 10      # safety cap on alias list length
+```
+
+Three paths a candidate can take:
+
+1. **Proposed → confirmed** — user clicks "yes" on the notification. Alias written to HA, `user_confirmed=true`, `promoted_at=now()`, `promoted_alias_text` recorded.
+2. **Proposed → rejected** — user clicks "no". `user_rejected=true`. The candidate is kept so we don't propose it again; future identical resolutions still bump `usage_count` (for telemetry) but no re-proposal until `cooldown_days`.
+3. **Proposed → ignored** — no click. The notification expires; the candidate stays in the queue for the next run.
+
+Path (4) — **auto-promote** — is supported but off by default. Behind a config flag for users who want radbot to manage aliases aggressively.
+
+### 5. Tools on casa (manual alias management)
+
+Independently of the learning loop, expose explicit tools the user can invoke:
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `ha_list_aliases` | `target_kind`, `target_id` | Read current aliases for an entity/area/floor |
+| `ha_add_alias` | `target_kind`, `target_id`, `alias`, `reason?` | Union-add one alias; record in candidates as `user_confirmed=true` already |
+| `ha_remove_alias` | `target_kind`, `target_id`, `alias` | Remove one alias; update the candidate row `promoted_at=NULL` |
+| `ha_list_candidates` | `promoted?`, `limit?` | Read the candidate queue for admin/debug |
+| `ha_promote_candidate` | `candidate_id` | Force-promote a candidate (skip threshold) |
+| `ha_reject_candidate` | `candidate_id` | Mark rejected |
+
+These cover cases like "Perry: 'add an alias grow to the all grow lights area'" — direct, no learning loop needed.
+
+### 6. Admin panel
+
+New section in `/admin/` → "HA Alias Learning":
+
+- Summary: candidates queued, promoted this month, rejected, top-phrases-by-usage
+- Table of unpromoted candidates sorted by `usage_count DESC`, with inline promote/reject buttons
+- Table of promoted aliases with rollback
+- Pricing-panel style test button: "Preview HA registry state for `<entity_id>`"
+
+Frontend path follows the existing pattern: `radbot/web/frontend/src/components/admin/panels/HaAliasPanel.tsx`, registered in `AdminPage.tsx` NAV_ITEMS + PANEL_MAP.
+
+## Safety guards (design decisions, not afterthoughts)
+
+1. **Never auto-learn from a failed recovery.** Candidates are only written after a full round-trip success. If the LLM bounced between resolutions without ever succeeding, nothing is learned.
+2. **Alias collision check before write.** Before calling `update_*_aliases`, list the current registry and refuse if the proposed alias string is already attached to a *different* target. Surface the conflict as a notification and leave the candidate in the queue.
+3. **Domain sanity check.** Don't learn a phrase as an entity alias if the matched entities span >2 domains — that means the phrase is really an area-or-group concept, not an entity concept. Re-target the candidate to the area.
+4. **Prefer area-level over entity-level.** If multiple entity matches share a single area, propose an area alias. One alias, one write, benefits every entity in the area forever.
+5. **Cap alias count per target** (`max_aliases_per_target`, default 10). Prevents alias bloat from tail queries. If hit, surface a "you may want to prune" notification rather than silently dropping.
+6. **Provenance in our table, not HA's.** HA's alias list has no "who added this" concept. We keep that in `ha_alias_candidates`. When rolling back, we read `promoted_alias_text` from our row and issue a remove via WS.
+7. **User opt-out entirely.** `config:agent.alias_learning.enabled = false` disables the recording hook and the promoter job. Existing aliases stay in HA untouched. This is the escape hatch if someone objects philosophically to "an agent modifying HA config."
+
+## What this adds to casa's base prompt
+
+- 0-6 new FunctionTools (0 if learning is disabled, 3 for read-only learning, 6 for manual + learning). Each small-schema — estimate ~50-80 tokens each. Worst case ~500 tokens on casa's permanent prompt.
+- Worth weighing at review time: are these on *casa* or on a separate `admin` sub-agent beto routes to? The learning tools get used rarely; offloading to a dedicated agent would keep casa's permanent prompt tighter. Argues for a new `admin` sub-agent or for putting them on axel (which already has system-admin tools).
+
+## Rollout plan (when picking this up)
+
+1. Migration: `init_ha_alias_schema()` + wire into startup. One commit.
+2. WS client methods. One commit.
+3. `record_alias_candidate` + hook in the HA MCP tool adapter. One commit.
+4. Manual management tools (`ha_add_alias`, `ha_remove_alias`, `ha_list_aliases`). One commit. Ship this as its own PR for manual use before learning loop is enabled.
+5. Promoter job + notifications. Behind `alias_learning.enabled` flag (default false). One commit.
+6. Admin panel. One commit.
+7. Flip `alias_learning.enabled = true` in a final config change after a few days of manual use.
+
+## References
+
+- HA entity registry WebSocket API: https://developers.home-assistant.io/docs/api/websocket/#entity-registry
+- HA area registry WebSocket API: https://developers.home-assistant.io/docs/api/websocket/#area-registry
+- HA floor registry WebSocket API: https://developers.home-assistant.io/docs/api/websocket/#floor-registry
+- HA exposing entities to Assist: https://www.home-assistant.io/voice_control/voice_remote_expose_devices/
+- HA MCP server integration: https://www.home-assistant.io/integrations/mcp_server/
+- The MCP migration plan this depends on: `docs/implementation/integrations/ha_mcp_migration.md` (once shipped)
+
+## Open questions to resolve on pickup
+
+- **Notification delivery** — we don't currently push interactive prompts to the user outside the chat UI. Candidate options: reuse the existing notifications table + admin badge (simplest), or pop a chat-UI toast with action buttons. Decide before shipping the promoter job.
+- **Where do the tools live?** — casa (higher prompt cost, lower friction) vs a dedicated admin sub-agent (extra routing hop, lower prompt cost). Test in prod after manual-tools ship.
+- **Normalization corpus** — which stop phrases / common openers are actually in our usage? Revisit after 1 week of candidate data.
+- **Floor registry adoption** — HA floors are a relatively new concept (2024+). Check whether Perry's setup uses them before committing UI space.

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -1,0 +1,11 @@
+# Plans
+
+Design documents for work that has been researched and scoped but is **not yet implemented**.
+
+Separate from `docs/implementation/` — that directory describes what's already shipped. Files here are preserved research so we don't have to redo it when we pick the work up later.
+
+When a plan ships: move the final doc into the matching `docs/implementation/` subdirectory and delete (or redirect) the file here.
+
+## Open plans
+
+- [HA alias learning loop](ha_alias_learning.md) — use-based learning of HA entity/area aliases, with candidate queue in postgres and promotion into HA's registry. Deferred follow-up to the HA MCP migration.

--- a/radbot/agent/agent_tools_setup.py
+++ b/radbot/agent/agent_tools_setup.py
@@ -54,30 +54,22 @@ def setup_before_agent_call(callback_context: CallbackContext):
                 logger.error(f"Failed to initialize {key}: {e}")
                 callback_context.state[key] = False
 
-    # Initialize Home Assistant client if not already done
+    # Initialize Home Assistant client with a lightweight health check.
+    # We deliberately do NOT call list_entities() here — that was an
+    # unbounded dump (~500 entities, tens of KB) paid once per process
+    # for no tool-path benefit. The MCP migration made it redundant:
+    # GetLiveContext returns only exposed entities (~99) and is called
+    # on-demand by the LLM when it actually needs state.
     if "ha_client_init" not in callback_context.state:
         try:
             from radbot.tools.homeassistant import get_ha_client
 
             ha_client = get_ha_client()
-            if ha_client:
-                try:
-                    entities = ha_client.list_entities()
-                    if entities:
-                        logger.info(
-                            f"Successfully connected to Home Assistant. Found {len(entities)} entities."
-                        )
-                        callback_context.state["ha_client_init"] = True
-                    else:
-                        logger.warning(
-                            "Connected to Home Assistant but no entities were returned"
-                        )
-                        callback_context.state["ha_client_init"] = False
-                except Exception as e:
-                    logger.error(f"Error testing Home Assistant connection: {e}")
-                    callback_context.state["ha_client_init"] = False
+            if ha_client and ha_client.get_api_status():
+                logger.info("Connected to Home Assistant REST API")
+                callback_context.state["ha_client_init"] = True
             else:
-                logger.warning("Home Assistant client could not be initialized")
+                logger.warning("Home Assistant client not available or unhealthy")
                 callback_context.state["ha_client_init"] = False
         except Exception as e:
             logger.error(f"Error initializing Home Assistant client: {e}")

--- a/radbot/agent/home_agent/factory.py
+++ b/radbot/agent/home_agent/factory.py
@@ -35,30 +35,65 @@ def create_home_agent() -> Optional[Agent]:
         # Build tools list
         tools = []
 
-        # Home Assistant tools
-        try:
-            from radbot.tools.homeassistant import (
-                get_ha_entity_state,
-                list_ha_entities,
-                search_ha_entities,
-                toggle_ha_entity,
-                turn_off_ha_entity,
-                turn_on_ha_entity,
-            )
+        # Home Assistant tools — prefer the native `mcp_server` integration
+        # (HA 2025.2+): one streamable-HTTP client, all 19 built-in Assist
+        # intents plus every user-exposed script, native fuzzy resolution
+        # via name/area/floor/domain[]/device_class[]. Falls back to the
+        # REST tool set only if MCP is disabled or unreachable.
+        from radbot.config.config_loader import config_loader
 
-            tools.extend(
-                [
-                    search_ha_entities,
-                    list_ha_entities,
+        ha_config = config_loader.get_home_assistant_config()
+        use_mcp = ha_config.get("use_mcp", True)
+
+        ha_tools_loaded = False
+        if use_mcp:
+            try:
+                from radbot.tools.homeassistant.ha_mcp_client import (
+                    get_ha_mcp_client,
+                )
+                from radbot.tools.homeassistant.ha_mcp_tools import (
+                    build_ha_mcp_function_tools,
+                )
+
+                mcp_client = get_ha_mcp_client()
+                if mcp_client is not None:
+                    mcp_tools = build_ha_mcp_function_tools(mcp_client)
+                    if mcp_tools:
+                        tools.extend(mcp_tools)
+                        logger.info(
+                            "Added %d Home Assistant MCP tools to Casa",
+                            len(mcp_tools),
+                        )
+                        ha_tools_loaded = True
+            except Exception as e:
+                logger.warning(
+                    "Failed to load HA MCP tools, will try REST fallback: %s", e
+                )
+
+        if not ha_tools_loaded:
+            try:
+                from radbot.tools.homeassistant import (
                     get_ha_entity_state,
-                    turn_on_ha_entity,
-                    turn_off_ha_entity,
+                    list_ha_entities,
+                    search_ha_entities,
                     toggle_ha_entity,
-                ]
-            )
-            logger.info("Added 6 Home Assistant tools to Casa")
-        except Exception as e:
-            logger.warning(f"Failed to add HA tools to Casa: {e}")
+                    turn_off_ha_entity,
+                    turn_on_ha_entity,
+                )
+
+                tools.extend(
+                    [
+                        search_ha_entities,
+                        list_ha_entities,
+                        get_ha_entity_state,
+                        turn_on_ha_entity,
+                        turn_off_ha_entity,
+                        toggle_ha_entity,
+                    ]
+                )
+                logger.info("Added 6 Home Assistant REST tools to Casa (fallback)")
+            except Exception as e:
+                logger.warning(f"Failed to add HA REST tools to Casa: {e}")
 
         # Dashboard tools (WebSocket-based)
         tools.extend(load_tools("radbot.tools.homeassistant", "HA_DASHBOARD_TOOLS", "Casa", "HA dashboard"))

--- a/radbot/tools/homeassistant/ha_mcp_client.py
+++ b/radbot/tools/homeassistant/ha_mcp_client.py
@@ -1,0 +1,237 @@
+"""Minimal Streamable-HTTP Model Context Protocol client for Home Assistant.
+
+HA ships an `mcp_server` core integration (since 2025.2) that exposes the
+Assist LLM API — every built-in intent (`HassTurnOn`, `HassLightSet`,
+`HassClimateSetTemperature`, `HassMediaSearchAndPlay`, etc.) plus every
+user-exposed script — as MCP tools. Radbot talks to it over MCP's
+streamable-HTTP transport at ``POST /api/mcp``.
+
+### Why a custom client instead of ADK's ``McpToolset``
+
+ADK's bundled ``McpToolset`` targets SSE transport and returns an
+``AsyncExitStack`` the caller must keep alive for the lifetime of the
+tools. That's awkward from the sync factory path used at agent
+construction and creates lifetime-management traps (the throwaway
+event-loop pattern in ``radbot/tools/mcp/mcp_homeassistant.py`` closes
+the stack before tools are called).
+
+HA's streamable-HTTP endpoint is **stateless** — each JSON-RPC request is
+independent, no session id, no persistent stream. httpx (already a
+project dep) is the right client, and each tool invocation is a plain
+POST. Tool discovery is done once at factory time via the sync client;
+per-call invocation uses the async client so it runs inside ADK's event
+loop without extra plumbing.
+
+### Auth
+
+Bearer token — the same long-lived access token (LLAT) used for the
+REST API. Configured in ``integrations.home_assistant.token`` or the
+``ha_token`` credential-store entry (see
+``radbot/tools/homeassistant/ha_client_singleton.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import httpx
+
+from radbot.config.config_loader import config_loader
+
+logger = logging.getLogger(__name__)
+
+
+# MCP protocol version — latest HA server (1.26.0) advertises 2024-11-05.
+# Sending this version keeps the negotiated protocol stable.
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+
+
+def _normalize_mcp_url(base_url: str) -> str:
+    """Derive the streamable-HTTP MCP endpoint from HA's REST base URL."""
+    return urljoin(base_url.rstrip("/") + "/", "api/mcp")
+
+
+class HAMcpClient:
+    """Stateless streamable-HTTP MCP client for a single HA instance.
+
+    The client is thread-safe for concurrent async calls — each request
+    is independent and httpx's AsyncClient is safe to share.
+    """
+
+    def __init__(self, base_url: str, token: str, timeout: float = 15.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.endpoint = _normalize_mcp_url(self.base_url)
+        self._token = token
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        self._timeout = timeout
+        self._next_id = 0
+        self._initialized = False
+
+    def _alloc_id(self) -> int:
+        self._next_id += 1
+        return self._next_id
+
+    # ------------------------------------------------------------------
+    # Protocol helpers
+    # ------------------------------------------------------------------
+
+    def _init_request(self) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": self._alloc_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "clientInfo": {"name": "radbot", "version": "1.0"},
+                "capabilities": {},
+            },
+        }
+
+    @staticmethod
+    def _initialized_notification() -> Dict[str, Any]:
+        return {"jsonrpc": "2.0", "method": "notifications/initialized"}
+
+    def _tools_list_request(self) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": self._alloc_id(),
+            "method": "tools/list",
+        }
+
+    def _tools_call_request(
+        self, name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": self._alloc_id(),
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+
+    @staticmethod
+    def _raise_on_error(payload: Dict[str, Any]) -> Dict[str, Any]:
+        err = payload.get("error")
+        if err:
+            raise RuntimeError(
+                f"MCP error {err.get('code', '?')}: {err.get('message', 'unknown')}"
+            )
+        result = payload.get("result", {})
+        # tools/call wraps results with isError=true on runtime errors
+        if isinstance(result, dict) and result.get("isError"):
+            content = result.get("content") or []
+            text = content[0].get("text") if content else "unknown tool error"
+            raise RuntimeError(f"MCP tool error: {text}")
+        return result
+
+    # ------------------------------------------------------------------
+    # Sync path — used at factory time for tool discovery
+    # ------------------------------------------------------------------
+
+    def list_tools_sync(self) -> List[Dict[str, Any]]:
+        """Fetch the tool catalog via a short-lived sync httpx.Client.
+
+        Used during agent construction where spinning an event loop is
+        awkward. Also serves as a connectivity probe for the admin test
+        endpoint.
+        """
+        with httpx.Client(timeout=self._timeout) as client:
+            init_resp = client.post(
+                self.endpoint, headers=self._headers, json=self._init_request()
+            )
+            init_resp.raise_for_status()
+            self._raise_on_error(init_resp.json())
+
+            # Fire-and-forget the initialized notification; HA returns 202.
+            client.post(
+                self.endpoint,
+                headers=self._headers,
+                json=self._initialized_notification(),
+            )
+
+            list_resp = client.post(
+                self.endpoint, headers=self._headers, json=self._tools_list_request()
+            )
+            list_resp.raise_for_status()
+            result = self._raise_on_error(list_resp.json())
+            tools = result.get("tools", [])
+        self._initialized = True
+        return tools
+
+    # ------------------------------------------------------------------
+    # Async path — used for tool invocation at LLM runtime
+    # ------------------------------------------------------------------
+
+    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
+        """Invoke an MCP tool. Returns the text payload of the first content
+        part (HA always responds with a single text block whose body is a
+        JSON-encoded ``{"success": bool, "result": ...}`` envelope).
+        """
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.post(
+                self.endpoint,
+                headers=self._headers,
+                json=self._tools_call_request(name, arguments),
+            )
+            resp.raise_for_status()
+            result = self._raise_on_error(resp.json())
+        content = result.get("content") or []
+        if not content:
+            return None
+        return content[0].get("text")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Singleton + config resolution
+# ──────────────────────────────────────────────────────────────────────
+
+
+_mcp_client: Optional[HAMcpClient] = None
+
+
+def reset_ha_mcp_client() -> None:
+    """Reset the singleton so the next call re-reads config (admin hot-reload)."""
+    global _mcp_client
+    _mcp_client = None
+
+
+def get_ha_mcp_client() -> Optional[HAMcpClient]:
+    """Return a cached HA MCP client, or None if HA isn't configured.
+
+    Resolves URL + token via the same priority chain as the REST client:
+    merged config → credential store → env vars. Token lookup mirrors
+    ``ha_client_singleton.get_ha_client``.
+    """
+    global _mcp_client
+    if _mcp_client is not None:
+        return _mcp_client
+
+    ha_config = config_loader.get_home_assistant_config()
+    ha_url = ha_config.get("url") or os.getenv("HA_URL")
+    ha_token = ha_config.get("token")
+
+    if not ha_token:
+        try:
+            from radbot.credentials.store import get_credential_store
+
+            store = get_credential_store()
+            if store.available:
+                ha_token = store.get("ha_token") or ""
+        except Exception as e:
+            logger.debug("Could not read ha_token from credential store: %s", e)
+
+    if not ha_token:
+        ha_token = os.getenv("HA_TOKEN")
+
+    if not ha_url or not ha_token:
+        logger.debug("HA MCP client: URL or token not configured")
+        return None
+
+    _mcp_client = HAMcpClient(ha_url, ha_token)
+    return _mcp_client

--- a/radbot/tools/homeassistant/ha_mcp_tools.py
+++ b/radbot/tools/homeassistant/ha_mcp_tools.py
@@ -1,0 +1,161 @@
+"""Adapt Home Assistant MCP tools into ADK ``FunctionTool`` instances.
+
+Fetches the tool catalog from HA's ``mcp_server`` at agent-construction
+time, wraps each tool as a FunctionTool whose implementation forwards
+the call through ``HAMcpClient.call_tool``. The set of available tools
+depends on what the HA admin has exposed to Assist — 19 built-in intents
+plus every user-exposed script. See the reference in
+``docs/plans/ha_alias_learning.md`` for context on the exposure model.
+
+Tool response shape: HA wraps every MCP response in a single text
+content block whose body is a JSON-encoded ``{"success": bool, "result":
+...}`` envelope. This module unwraps that before returning to the LLM
+so the agent sees structured data, not a string.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+from google.adk.tools import FunctionTool
+
+from radbot.tools.homeassistant.ha_mcp_client import HAMcpClient
+
+logger = logging.getLogger(__name__)
+
+
+# ADK tool names must be a valid Python identifier. Users can name HA
+# scripts almost anything (we've seen leading digits, spaces, non-ASCII),
+# so sanitize on the radbot side while preserving the original name for
+# the MCP ``tools/call`` request.
+_VALID_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _sanitize_tool_name(name: str) -> str:
+    if _VALID_IDENT.match(name):
+        return name
+    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", name)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "ha_" + sanitized
+    return sanitized or "ha_tool"
+
+
+def _unwrap_ha_envelope(text: Optional[str]) -> Any:
+    """Decode HA's ``{"success": bool, "result": ...}`` wrapper.
+
+    Returns the ``result`` value on success, a structured error dict on
+    failure, or the raw text if it doesn't match the expected shape.
+    """
+    if text is None:
+        return None
+    try:
+        envelope = json.loads(text)
+    except (TypeError, ValueError):
+        return text
+    if not isinstance(envelope, dict):
+        return envelope
+    if "success" in envelope:
+        if envelope["success"]:
+            return envelope.get("result")
+        return {
+            "status": "error",
+            "error": envelope.get("error") or envelope.get("result"),
+        }
+    return envelope
+
+
+def _make_tool_caller(
+    client: HAMcpClient, original_name: str
+) -> Callable[..., Any]:
+    """Build the async callable that ADK will invoke for this tool.
+
+    The closure captures the HA-side tool name so the sanitized ADK tool
+    name still maps to the right MCP tool.
+    """
+
+    async def _call(**kwargs: Any) -> Any:
+        # Drop None values — JSON schemas default missing optional fields,
+        # but ADK sometimes passes them as None which HA then rejects.
+        payload = {k: v for k, v in kwargs.items() if v is not None}
+        try:
+            text = await client.call_tool(original_name, payload)
+        except Exception as e:
+            logger.warning(
+                "HA MCP call %s failed: %s (args=%s)",
+                original_name,
+                e,
+                list(payload.keys()),
+            )
+            return {"status": "error", "error": str(e)}
+        return _unwrap_ha_envelope(text)
+
+    return _call
+
+
+def _build_function_schema(
+    tool_name: str, description: str, input_schema: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Translate an MCP tool entry into ADK FunctionTool.function_schema."""
+    params = input_schema if isinstance(input_schema, dict) else {}
+    # MCP uses ``inputSchema`` with standard JSON-schema shape;
+    # FunctionTool's function_schema expects ``parameters`` of the same
+    # shape. Pass through. Ensure ``type`` is present for safety.
+    if "type" not in params:
+        params = {"type": "object", **params}
+    return {
+        "name": tool_name,
+        "description": description or f"Home Assistant MCP tool: {tool_name}",
+        "parameters": params,
+    }
+
+
+def build_ha_mcp_function_tools(client: HAMcpClient) -> List[FunctionTool]:
+    """Fetch HA's MCP tool list and wrap each as an ADK FunctionTool.
+
+    Runs a sync tool-discovery call at factory time. Each wrapped tool
+    executes asynchronously at LLM runtime, inside ADK's event loop.
+    """
+    try:
+        raw_tools = client.list_tools_sync()
+    except Exception as e:
+        logger.error("Failed to list HA MCP tools: %s", e)
+        return []
+
+    tools: List[FunctionTool] = []
+    seen_names: set[str] = set()
+
+    for entry in raw_tools:
+        original_name = entry.get("name", "")
+        if not original_name:
+            continue
+
+        adk_name = _sanitize_tool_name(original_name)
+        if adk_name in seen_names:
+            # Sanitization collision (e.g. two scripts with punctuation
+            # that collapses to the same identifier). Disambiguate with
+            # a suffix so both remain callable.
+            suffix = 2
+            while f"{adk_name}_{suffix}" in seen_names:
+                suffix += 1
+            adk_name = f"{adk_name}_{suffix}"
+        seen_names.add(adk_name)
+
+        schema = _build_function_schema(
+            adk_name,
+            entry.get("description", "") or "",
+            entry.get("inputSchema") or {},
+        )
+        func = _make_tool_caller(client, original_name)
+        func.__name__ = adk_name  # improves ADK/telemetry log clarity
+
+        tools.append(FunctionTool(function=func, function_schema=schema))
+
+    logger.info(
+        "Loaded %d Home Assistant MCP tools (from %d raw entries)",
+        len(tools),
+        len(raw_tools),
+    )
+    return tools

--- a/radbot/web/api/admin.py
+++ b/radbot/web/api/admin.py
@@ -26,6 +26,7 @@ _ADMIN_TOKEN_ENV = "RADBOT_ADMIN_TOKEN"
 _INTEGRATION_RESET_REGISTRY: list[tuple[str, str]] = [
     ("radbot.tools.homeassistant.ha_client_singleton", "reset_ha_client"),
     ("radbot.tools.homeassistant.ha_ws_singleton", "reset_ha_ws_client"),
+    ("radbot.tools.homeassistant.ha_mcp_client", "reset_ha_mcp_client"),
     ("radbot.tools.overseerr.overseerr_client", "reset_overseerr_client"),
     ("radbot.tools.ntfy.ntfy_client", "reset_ntfy_client"),
     ("radbot.tools.picnic.picnic_client", "reset_picnic_client"),
@@ -867,9 +868,23 @@ async def test_home_assistant(request: Request, _: None = Depends(_verify_admin)
                 f"{ha_url.rstrip('/')}/api/",
                 headers={"Authorization": f"Bearer {ha_token}"},
             )
-            if resp.status_code == 200:
-                return _ok("Connected to Home Assistant")
-            return _err(f"Home Assistant returned HTTP {resp.status_code}")
+            if resp.status_code != 200:
+                return _err(f"Home Assistant returned HTTP {resp.status_code}")
+
+        # Also probe the MCP endpoint so the admin gets a single go/no-go
+        # signal. We don't fail the whole test if MCP is absent — some HA
+        # installs may not have the mcp_server integration enabled.
+        mcp_status: Optional[str] = None
+        try:
+            from radbot.tools.homeassistant.ha_mcp_client import HAMcpClient
+
+            mcp_client = HAMcpClient(ha_url, ha_token, timeout=8.0)
+            tools = mcp_client.list_tools_sync()
+            mcp_status = f"{len(tools)} MCP tools available"
+        except Exception as e:
+            mcp_status = f"MCP unavailable: {e}"
+
+        return _ok(f"Connected to Home Assistant. {mcp_status}")
     except Exception as e:
         return _err(f"Home Assistant connection failed: {e}")
 

--- a/radbot/web/frontend/src/components/admin/panels/ConnectionPanels.tsx
+++ b/radbot/web/frontend/src/components/admin/panels/ConnectionPanels.tsx
@@ -660,7 +660,7 @@ export function HomeAssistantPanel() {
   const [enabled, setEnabled] = useState(false);
   const [haUrl, setHaUrl] = useState("");
   const [accessToken, setAccessToken] = useState("");
-  const [mcpSseUrl, setMcpSseUrl] = useState("");
+  const [useMcp, setUseMcp] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testResult, setTestResult] = useState<{ status: string; message: string } | null>(null);
   const [testing, setTesting] = useState(false);
@@ -670,7 +670,7 @@ export function HomeAssistantPanel() {
       const ha = dig(cfg, "integrations.home_assistant", {});
       setEnabled(!!ha.enabled);
       setHaUrl(ha.url || "");
-      setMcpSseUrl(ha.mcp_sse_url || "");
+      setUseMcp(ha.use_mcp !== false); // default true when unset
       if (ha.token) setAccessToken(MASKED);
     });
   }, [loadLiveConfig]);
@@ -700,7 +700,11 @@ export function HomeAssistantPanel() {
         home_assistant: {
           enabled,
           url: haUrl || undefined,
-          mcp_sse_url: mcpSseUrl || undefined,
+          use_mcp: useMcp,
+          // mcp_sse_url dropped — HA MCP endpoint is derived from `url`
+          // (POST <url>/api/mcp); SSE transport is superseded by
+          // streamable-HTTP on HA 2025.2+.
+          mcp_sse_url: null,
         },
       });
       toast("Home Assistant settings saved", "success");
@@ -735,10 +739,10 @@ export function HomeAssistantPanel() {
           onChange={setAccessToken}
           type="password"
         />
-        <FormInput
-          label="MCP SSE URL"
-          value={mcpSseUrl}
-          onChange={setMcpSseUrl}
+        <FormToggle
+          label="Use MCP (HA 2025.2+ native tool surface)"
+          checked={useMcp}
+          onChange={setUseMcp}
         />
       </Card>
 

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -60,7 +60,8 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 
 | Tool Group | Count | Source |
 |------------|-------|--------|
-| Home Assistant REST | 6 | `radbot.tools.homeassistant` (`search_ha_entities`, `list_ha_entities`, `get_ha_entity_state`, `turn_on/off/toggle_ha_entity`) |
+| Home Assistant (MCP, primary) | dynamic (~19 built-in + user-exposed scripts) | `radbot.tools.homeassistant.ha_mcp_tools.build_ha_mcp_function_tools` — discovered at factory time from HA's `mcp_server` (HA 2025.2+). Falls back to the REST row below if `use_mcp=false` or discovery fails. |
+| Home Assistant REST (fallback) | 6 | `radbot.tools.homeassistant` (`search_ha_entities`, `list_ha_entities`, `get_ha_entity_state`, `turn_on/off/toggle_ha_entity`) — used when MCP disabled/unavailable |
 | HA Dashboard (WS) | 6 | `radbot.tools.homeassistant.ha_dashboard_tools.HA_DASHBOARD_TOOLS` |
 | Overseerr | 4 | `radbot.tools.overseerr.OVERSEERR_TOOLS` |
 | Lidarr | 5 | `radbot.tools.lidarr.LIDARR_TOOLS` (`search_lidarr_artist`, `search_lidarr_album`, `add_lidarr_artist`, `add_lidarr_album`, `list_lidarr_quality_profiles`) |

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -16,7 +16,7 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py`. Prefer `get_int
 
 | Service | Client Class | Connection | Config Keys | Admin Panel | Test Endpoint |
 |---------|-------------|------------|-------------|-------------|---------------|
-| Home Assistant | `HomeAssistantRESTClient` + WS client | HTTP REST + WebSocket | `integrations.home_assistant.url`, credential: `ha_token` | `HomeAssistantPanel` | `/admin/api/test/home-assistant` |
+| Home Assistant | `HAMcpClient` (primary) + `HomeAssistantRESTClient` (fallback) + WS client | MCP streamable-HTTP + HTTP REST + WebSocket | `integrations.home_assistant.url`, `integrations.home_assistant.use_mcp` (default true), credential: `ha_token` | `HomeAssistantPanel` | `/admin/api/test/home-assistant` (probes REST + MCP) |
 | Overseerr | `OverseerrClient` | HTTP REST | `integrations.overseerr.url`, credential: `overseerr_api_key` | `OverseerrPanel` | `/admin/api/test/overseerr` |
 | Lidarr | `LidarrClient` | HTTP REST | `integrations.lidarr.url`, credential: `lidarr_api_key` | `LidarrPanel` | `/admin/api/test/lidarr` |
 | Picnic | `PicnicClientWrapper` | HTTP REST (python_picnic_api2) | credentials: `picnic_username`, `picnic_password`, `picnic_country_code`, `picnic_auth_token` (cached) | `PicnicPanel` | `/admin/api/test/picnic` |
@@ -43,14 +43,16 @@ Canonical example: `radbot/tools/overseerr/overseerr_client.py`. Prefer `get_int
 
 ### Home Assistant
 
-- **Client**: `tools/homeassistant/ha_rest_client.py` — `HomeAssistantRESTClient`
-- **WebSocket**: `tools/homeassistant/ha_websocket_client.py` — async WS at `wss://host/api/websocket`
-- **State cache**: `tools/homeassistant/ha_state_cache.py` — in-memory snapshot for `search_ha_entities`
-- **Auth**: Long-lived access token in `Authorization: Bearer` header
-- **Singletons**: Separate for REST (`ha_client_singleton.py`) and WS (`ha_ws_singleton.py`)
-- **Health check**: `GET /api/` → expects "API running." message
-- **Dashboard CRUD**: WebSocket only (Lovelace API not available via REST)
-- **Direct REST endpoints**: `web/api/ha.py` exposes `GET /api/ha/state/{entity_id}` + `POST /api/ha/service` for frontend device buttons (bypasses agent)
+- **MCP client (primary tool surface)**: `tools/homeassistant/ha_mcp_client.py` — `HAMcpClient`, stateless streamable-HTTP against `POST <ha_url>/api/mcp`. Discovery via `list_tools_sync()` at factory time; invocation via async `call_tool(name, arguments)`. Singleton via `get_ha_mcp_client()` / `reset_ha_mcp_client()`. FunctionTool adapter: `tools/homeassistant/ha_mcp_tools.py` → `build_ha_mcp_function_tools(client)` wraps each MCP tool as an ADK FunctionTool, sanitizes names to valid identifiers, and unwraps HA's `{"success": bool, "result": ...}` envelope before returning to the LLM. Tool set includes ~19 built-in Assist intents (`HassTurnOn`, `HassTurnOff`, `HassLightSet`, `HassClimateSetTemperature`, `HassMediaSearchAndPlay`, `HassSetVolume`, `HassVacuumStart`, `HassFanSetSpeed`, `HassBroadcast`, `HassStartTimer`, `GetLiveContext`, `GetDateTime`, ...) plus every user-exposed HA script.
+- **REST client (fallback + direct web endpoints)**: `tools/homeassistant/ha_rest_client.py` — `HomeAssistantRESTClient`. Used by `web/api/ha.py` for frontend device buttons; loaded onto casa only when `integrations.home_assistant.use_mcp = false` or MCP discovery fails at startup.
+- **WebSocket**: `tools/homeassistant/ha_websocket_client.py` — async WS at `wss://host/api/websocket`. Used for dashboard (Lovelace) CRUD and — planned — entity/area/floor registry alias management (see `docs/plans/ha_alias_learning.md`).
+- **State cache**: `tools/homeassistant/ha_state_cache.py` — legacy in-memory snapshot for the REST-based `search_ha_entities`. Unused when MCP path is active (MCP's `GetLiveContext` returns only Assist-exposed entities on demand).
+- **Auth**: Long-lived access token in `Authorization: Bearer` header for all three transports (REST, MCP streamable-HTTP, WS).
+- **Singletons**: Separate for REST (`ha_client_singleton.py`), WS (`ha_ws_singleton.py`), and MCP (`ha_mcp_client.py`). All three reset together on admin config change via `_INTEGRATION_RESET_REGISTRY`.
+- **Health check**: `GET /api/` → expects "API running." message. The `/admin/api/test/home-assistant` endpoint probes REST + MCP `tools/list` and reports tool count.
+- **Dashboard CRUD**: WebSocket only (Lovelace API not available via REST or MCP).
+- **Direct REST endpoints**: `web/api/ha.py` exposes `GET /api/ha/state/{entity_id}` + `POST /api/ha/service` for frontend device buttons (bypasses agent).
+- **HA-side prerequisite**: the `mcp_server` core integration must be enabled in HA (2025.2+). Tool availability is gated by Assist entity exposure (Settings → Voice assistants → Expose).
 
 ### Overseerr
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -15,7 +15,8 @@ Non-tool services (TTS, STT, ntfy) expose REST endpoints only — they are not r
 | `tools/todo/` | 8 | tracker | `add_task`, `complete_task`, `remove_task`, `list_projects`, `list_project_tasks`, `list_all_tasks`, `update_task`, `update_project` |
 | `tools/calendar/` | 5 | planner | `list_calendar_events`, `create_calendar_event`, `update_calendar_event`, `delete_calendar_event`, `check_calendar_availability` |
 | `tools/gmail/` | 4 | comms | `list_emails`, `search_emails`, `get_email`, `list_gmail_accounts` |
-| `tools/homeassistant/` (REST) | 6 | casa | `list_ha_entities`, `get_ha_entity_state`, `turn_on_ha_entity`, `turn_off_ha_entity`, `toggle_ha_entity`, `search_ha_entities` |
+| `tools/homeassistant/` (MCP, primary) | dynamic (~19 built-in + user-exposed scripts) | casa | `HassTurnOn`, `HassTurnOff`, `HassLightSet`, `HassClimateSetTemperature`, `HassMediaSearchAndPlay`, `HassSetVolume`, `HassVacuumStart`, `HassFanSetSpeed`, `HassBroadcast`, `HassStartTimer`, `GetLiveContext`, `GetDateTime`, … (schemas discovered at factory time from `<ha_url>/api/mcp` via `HAMcpClient.list_tools_sync()`, wrapped by `ha_mcp_tools.build_ha_mcp_function_tools`). Disable by setting `integrations.home_assistant.use_mcp = false` to fall back to the REST row below. |
+| `tools/homeassistant/` (REST, fallback) | 6 | casa (only when MCP disabled/unavailable) | `list_ha_entities`, `get_ha_entity_state`, `turn_on_ha_entity`, `turn_off_ha_entity`, `toggle_ha_entity`, `search_ha_entities` |
 | `tools/homeassistant/` (Dashboard WS) | 6 | casa | `list_ha_dashboards`, `get_ha_dashboard_config`, `create_ha_dashboard`, `update_ha_dashboard`, `delete_ha_dashboard`, `save_ha_dashboard_config` |
 | `tools/scheduler/` | 3 | planner | `create_scheduled_task`, `list_scheduled_tasks`, `delete_scheduled_task` |
 | `tools/reminders/` | 3 | planner | `create_reminder`, `list_reminders`, `delete_reminder` |
@@ -87,7 +88,30 @@ Global variants (`search_past_conversations`, `store_important_information`) exi
 | `get_email` | `message_id`, `account` |
 | `list_gmail_accounts` | — |
 
-### homeassistant (REST) — `tools/homeassistant/ha_tools_impl.py`
+### homeassistant (MCP, primary) — `tools/homeassistant/ha_mcp_client.py` + `ha_mcp_tools.py`
+
+Casa's default HA tool surface. Discovered dynamically from HA's `mcp_server` integration (HA 2025.2+) at agent-construction time via `HAMcpClient.list_tools_sync()`; each tool wrapped as an ADK FunctionTool whose implementation forwards to `HAMcpClient.call_tool(name, arguments)` via streamable-HTTP JSON-RPC. Tool set depends on Assist exposure in HA — typical shape:
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `HassTurnOn` / `HassTurnOff` | `name?`, `area?`, `floor?`, `domain[]?`, `device_class[]?` | HA's `MatchTargets` resolves — no `entity_id` required. `domain` as array (e.g. `["light","switch"]`) spans multiple domains in one call. |
+| `HassLightSet` | `name?`, `area?`, `floor?`, `domain[]?`, `color?`, `temperature?`, `brightness?` | Brightness 0-100, color as CSS color name, temperature Kelvin. |
+| `HassClimateSetTemperature` / `HassClimateGetTemperature` | `name?`, `area?`, `temperature?` | (exposed only if HA has climate entities on the Assist allowlist) |
+| `HassMediaSearchAndPlay` | `search_query`, `media_class?`, `name?`, `area?`, `floor?` | `media_class` enum: album, app, artist, channel, ... |
+| `HassMediaPause` / `HassMediaUnpause` / `HassMediaNext` / `HassMediaPrevious` / `HassSetVolume` / `HassSetVolumeRelative` / `HassMediaPlayerMute` / `HassMediaPlayerUnmute` | `name?`, `area?` (+ `volume_level` for `HassSetVolume`) | |
+| `HassVacuumStart` / `HassVacuumReturnToBase` / `HassVacuumCleanArea` | `name?`, `area?` | |
+| `HassFanSetSpeed` | `name?`, `area?`, `speed` (0-100) | |
+| `HassBroadcast` | `message` | TTS broadcast through whole home. |
+| `HassCancelAllTimers` / `HassStartTimer` | timer-specific | (exposure-dependent) |
+| `GetLiveContext` | — | Returns YAML-formatted snapshot of all Assist-exposed entities. Replaces the legacy `list_ha_entities` / `search_ha_entities`. |
+| `GetDateTime` | — | HA's system date/time. |
+| `<user_script_name>` | user-defined | Every HA script the user has exposed to Assist appears as its own tool. Names are sanitized to valid Python identifiers on the radbot side. |
+
+HA wraps each response in `{"success": bool, "result": ...}`; `ha_mcp_tools._unwrap_ha_envelope` unwraps before returning to the LLM.
+
+### homeassistant (REST, fallback) — `tools/homeassistant/ha_tools_impl.py`
+
+Loaded only when `integrations.home_assistant.use_mcp = false` or MCP tool discovery fails at startup. Kept as an escape hatch for non-exposed entities and for `web/api/ha.py`'s frontend device buttons.
 
 | Tool | Parameters |
 |------|-----------|


### PR DESCRIPTION
## Summary

- Casa now talks to Home Assistant through HA's native `mcp_server` core integration (HA 2025.2+) at `POST <url>/api/mcp`. The 6 hand-rolled REST entity tools stay behind an `integrations.home_assistant.use_mcp` flag as a fallback.
- New streamable-HTTP MCP client (`ha_mcp_client.py`) + FunctionTool adapter (`ha_mcp_tools.py`). Stateless httpx, no session id, no exit-stack bookkeeping.
- Removed the unbounded `list_entities()` startup call from `setup_before_agent_call`. On-demand `GetLiveContext` handles state needs at ~10× smaller payload.
- Design for the follow-up "alias learning" work preserved at `docs/plans/ha_alias_learning.md` (deliberately deferred — see below).

## Why

Live probe against the production HA (v2026.4.1) shows the MCP surface as a clear upgrade:

| | Before (REST) | After (MCP) |
|---|---|---|
| Tool count on casa | 6 (plus `search_ha_entities`) | 37 (19 built-in Assist intents + 18 user-exposed scripts, discovered dynamically) |
| Tool schema bytes | ~1.5 KB | 9.8 KB (~2.45K tokens) |
| State "snapshot" call | `list_ha_entities` — unbounded, 500+ entities, ~30–50 KB | `GetLiveContext` — 99 Assist-exposed entities, ~3.25 KB (~10× smaller) |
| Startup `list_entities()` dump in `setup_before_agent_call` | Fires once per process | **Removed** |
| Action capability | `turn_on` / `turn_off` / `toggle` only | `HassLightSet` (brightness/color/temperature), `HassClimateSetTemperature`, `HassMediaSearchAndPlay`, `HassSetVolume`, `HassVacuumStart`, `HassFanSetSpeed`, `HassBroadcast`, `HassStartTimer`, every user-exposed HA script, more |
| Search / resolution | Two LLM roundtrips: `search_ha_entities` → pick → `turn_off_ha_entity` | One roundtrip typical — HA's `MatchTargets` resolver inside each action tool handles name/area/floor/domain[]/device_class |
| Light-vs-switch (e.g. growlights as smart outlets) | Manual, we filter client-side | Native via `domain: string[]` array in one call |

## Transport: streamable-HTTP, not SSE

MCP's streamable-HTTP (`POST /api/mcp`) is stateless — each JSON-RPC request is independent. That matches both the sync agent factory (discovery) and ADK's async runtime (per-call invocation) cleanly. A ~170-line httpx client avoids ADK's `McpToolset`/SSE `AsyncExitStack` lifetime bugs — the existing scaffold in `radbot/tools/mcp/mcp_homeassistant.py` closed its event loop before the transport was used, which is why it was never wired into casa.

## Which specs did this PR update

- `specs/integrations.md` — HA row reflects new 3-client surface (MCP primary, REST fallback, WS for dashboards). New section describes `HAMcpClient`, the FunctionTool adapter, hot-reload wiring, and the Assist exposure prerequisite.
- `specs/tools.md` — Tool count on casa is now dynamic. Added the MCP row, kept REST as fallback row. New subsection enumerates the built-in Assist intents and their parameter shapes.
- `specs/agents.md` — Casa's tool group table updated.
- `CLAUDE.md` — Casa row in the sub-agents table updated.
- `docs/implementation/integrations/ha_mcp_migration.md` — New implementation doc covering design, module layout, transport choice, fallback behaviour, measured probe results.
- `docs/implementation/integrations/index.md` — Linked the new doc.

## Follow-up (deferred, not in this PR)

Preserved as `docs/plans/ha_alias_learning.md`: use-based learning of HA entity/area/floor aliases, with a candidate queue in postgres and human-in-the-loop promotion into HA's registry via WebSocket (`config/{entity,area,floor}_registry/update`). Deliberately split out so we land MCP first and let real usage data inform the learning-loop thresholds.

## Test plan

- [ ] After deploy, visit `/admin/` → Home Assistant → "Test". Expect `"Connected to Home Assistant. N MCP tools available"` where N ≥ 20 for a typical install with Assist exposure.
- [ ] Ask casa "what's exposed?" and confirm it calls `GetLiveContext` rather than a list-entities tool. Check token count per turn at `/admin/api/telemetry/costs` — expect casa's average `prompt_tokens/call` to drop vs. the pre-merge baseline.
- [ ] "Turn off the basement plant lights" — should resolve in one roundtrip via `HassTurnOff(domain=["light","switch"], ...)`. On an ambiguity, the LLM should see a `MatchFailedError` and retry with an area filter.
- [ ] Exercise a capability that only MCP supports: "set the kitchen light to 40%" (brightness), "play <X> on the kitchen speaker" (MediaSearchAndPlay). Confirm each executes without radbot adding new tool code.
- [ ] Fallback path: temporarily `PUT /admin/api/config/integrations` with `home_assistant.use_mcp=false`. Confirm the REST tools reappear and casa still works.
- [ ] Regression: existing Lovelace dashboard CRUD tools still function (WS path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)