### PR TITLE
migrate(deps): google-adk 2.0.0a3 → 1.31.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ env/
 Thumbs.db
 
 **/.claude/settings.local.json
+# Claude Code session worktrees (created by EnterWorktree; ephemeral)
+.claude/worktrees/
 .env*
 !.env.example
 !.env.docker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # RadBot - Claude Code Instructions
 
-RadBot is an AI agent framework built on Google ADK 2.0.0a3, PostgreSQL, Qdrant,
+RadBot is an AI agent framework built on Google ADK 1.31.0, PostgreSQL, Qdrant,
 and MCP. The main agent "beto" has a 90s SoCal personality. Multi-agent architecture
 with specialized sub-agents (casa, planner, tracker, comms, scout, axel, search, code execution).
 
@@ -289,11 +289,11 @@ FastAPI behind Traefik generates redirect URLs using the internal HTTP scheme un
 
 ## Known Gotchas
 
-- **google-adk 2.0.0a3** with V1 LlmAgent mode (default, permanently). We previously kept `mode='task'` on domain agents and adaptive V1/V2 instructions anticipating a flip to V2, but ADK is **removing** V2 `_Mesh` (see [google/adk-python#5283](https://github.com/google/adk-python/issues/5283), closed 2026-04-16: "we are removing v2_Mesh in our latest version of workflow. And will by default use the v1 llm agent."). Do NOT set `ADK_DISABLE_V1_LLM_AGENT=true` — it breaks `transfer_to_agent` because V2 `_Mesh.run_node_impl` exits the coordinator generator before `execute_tools` can fire. `mode='task'` on sub-agents is a no-op under V1 and kept only to avoid churn.
-- **google-genai 1.72.0** is installed — NOT `google-generativeai` (different package/API)
-- **ADK 2.0 sub-agent assembly**: ALL sub-agents MUST be passed to the root Agent constructor. Do NOT add agents to `sub_agents` after construction — the routing graph is built in `model_post_init`. See `agent_core.py`.
-- **ADK 2.0 app_name validation**: App names must be valid Python identifiers (letters, digits, underscores). No hyphens.
-- **ADK `@tool` decorator removed**: `google.adk.tools.decorators.tool` no longer exists in 2.0. Use `FunctionTool` wrapper instead. Existing code has try/except fallbacks.
+- **google-adk 1.31.0** — the currently supported line. We previously ran 2.0.0a3 but reverted after the upstream team committed to unwinding V2 (see [google/adk-python#5283](https://github.com/google/adk-python/issues/5283), closed 2026-04-16: "we are removing v2_Mesh in our latest version of workflow. And will by default use the v1 llm agent."). The `mode='task'` kwarg, `TASK_FINISH_INSTRUCTIONS`, and `FeatureName.V1_LLM_AGENT` branches that anticipated a V2 flip are gone.
+- **google-genai 1.72.0** is installed — NOT `google-generativeai` (different package/API). ADK 1.31 requires `>=1.72.0`.
+- **Sub-agent assembly**: pass every sub-agent to the root Agent constructor. Adding to `sub_agents` after construction leaves `parent_agent` unset on the child, breaking `transfer_to_agent` lookups. See `agent_core.py`.
+- **App names** must be valid Python identifiers (letters, digits, underscores). No hyphens.
+- **`@tool` decorator unavailable**: use the `FunctionTool` wrapper. Some older code has try/except fallbacks left over from the upgrade-transition period.
 - **BuiltInCodeExecutor**: Use `code_executor=BuiltInCodeExecutor()` on Agent, not as a tool
 - **ADK async**: `InMemorySessionService.get_session/create_session` are async — must be awaited
 - **Runner.run_async()** for async contexts; `Runner.run()` blocks the event loop

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,8 +1,8 @@
 # RadBot Spec
 
 ## Quick Ref
-- Stack: Google ADK 2.0.0a3 (V1 LlmAgent mode) | FastAPI | React 18 | PostgreSQL | Qdrant | MCP | A2A
-- Runtime: Python 3.14-slim, `google-adk>=2.0.0a3,<3.0.0`, `google-genai>=1.68.0`
+- Stack: Google ADK 1.31.0 | FastAPI | React 18 | PostgreSQL | Qdrant | MCP | A2A
+- Runtime: Python 3.14-slim, `google-adk>=1.31.0,<2.0.0`, `google-genai>=1.72.0`
 - Entry: `python -m radbot.web` (web) | `python -m radbot` (CLI) | `python -m radbot.worker --workspace-id <UUID>` (terminal worker)
 - Pkg: uv — always `uv run`
 - Main agent: beto (90s SoCal personality, pure orchestrator)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "google-adk>=2.0.0a3,<3.0.0",
-    "google-genai>=1.68.0",
+    "google-adk>=1.31.0,<2.0.0",
+    "google-genai>=1.72.0",
     "qdrant-client>=1.13.0",
     "modelcontextprotocol>=0.1.0",
     "tzdata",

--- a/radbot/agent/agent_core.py
+++ b/radbot/agent/agent_core.py
@@ -4,9 +4,10 @@ Core agent creation and configuration for RadBot.
 Beto is a pure orchestrator with only memory tools. All domain tools
 live on specialized sub-agents.
 
-ADK 2.0 NOTE: All sub-agents MUST be passed to the root Agent constructor.
-The new workflow-based LlmAgent builds its internal routing mesh in
-model_post_init — agents added after construction won't be routable.
+Sub-agent assembly order: pass every sub-agent to the root Agent
+constructor rather than mutating ``sub_agents`` after the fact — ADK
+sets ``parent_agent`` on each child at construction, which the tree
+relies on for routing lookup.
 """
 
 import logging
@@ -123,8 +124,9 @@ today = date.today()
 beto_tools = create_agent_memory_tools("beto") + list(TELOS_TOOLS)
 
 # ---------------------------------------------------------------------------
-# Create ALL sub-agents BEFORE the root Agent constructor.
-# ADK 2.0's _Mesh builds the routing graph in model_post_init.
+# Create ALL sub-agents BEFORE the root Agent constructor so ADK sets
+# parent_agent on each child at construction time. Mutating sub_agents
+# later leaves that link unset, breaking routing lookups.
 # ---------------------------------------------------------------------------
 
 # Builtin sub-agents (search, code execution, scout)

--- a/radbot/agent/comms_agent/factory.py
+++ b/radbot/agent/comms_agent/factory.py
@@ -29,7 +29,6 @@ def create_comms_agent() -> Optional[Agent]:
             "comms",
             "You are Comms, a communications specialist. "
             "Read emails via Gmail and manage Jira issues.",
-            use_task_mode=True,
         )
 
         # Build tools list
@@ -71,7 +70,6 @@ def create_comms_agent() -> Optional[Agent]:
             description="Email (Gmail read-only) and Jira issue management (list, view, transition, comment, search).",
             instruction=instruction,
             tools=tools,
-            mode="task",
         )
 
         logger.info(f"Created Comms agent with {len(tools)} tools")

--- a/radbot/agent/execution_agent/factory.py
+++ b/radbot/agent/execution_agent/factory.py
@@ -12,7 +12,7 @@ from google.adk.agents import Agent
 
 from radbot.agent.execution_agent.agent import AxelExecutionAgent, ExecutionAgent
 from radbot.agent.factory_utils import load_tools
-from radbot.agent.shared import TASK_FINISH_INSTRUCTIONS, TRANSFER_INSTRUCTIONS
+from radbot.agent.shared import TRANSFER_INSTRUCTIONS
 from radbot.config import config_manager
 
 # Set up logging
@@ -127,13 +127,9 @@ def create_execution_agent(
             logger.warning(f"Failed to add shell tool to Axel: {e}")
         logger.info("Code execution capability enabled for Axel agent")
 
-    # Add completion instructions (task or transfer depending on V1/V2 mode)
-    try:
-        from google.adk.features import FeatureName, is_feature_enabled
-        v2_active = not is_feature_enabled(FeatureName.V1_LLM_AGENT)
-    except Exception:
-        v2_active = False
-    full_instruction = instruction + (TASK_FINISH_INSTRUCTIONS if v2_active else TRANSFER_INSTRUCTIONS)
+    # Append transfer-back instructions so axel hands control to beto after
+    # completing its task.
+    full_instruction = instruction + TRANSFER_INSTRUCTIONS
 
     # Create the ExecutionAgent instance
     execution_agent = ExecutionAgent(

--- a/radbot/agent/execution_agent/factory.py
+++ b/radbot/agent/execution_agent/factory.py
@@ -156,7 +156,6 @@ def create_execution_agent(
             description="A specialized agent for implementing code, executing tasks, and managing project files.",
             instruction=full_instruction,
             tools=agent_tools,
-            mode="task",
         )
 
         # Store the execution_agent reference on the ADK agent for later access

--- a/radbot/agent/home_agent/factory.py
+++ b/radbot/agent/home_agent/factory.py
@@ -29,7 +29,6 @@ def create_home_agent() -> Optional[Agent]:
             "casa",
             "You are Casa, a smart home and media specialist. "
             "Control Home Assistant devices and manage Overseerr media requests.",
-            use_task_mode=True,
         )
 
         # Build tools list
@@ -122,7 +121,6 @@ def create_home_agent() -> Optional[Agent]:
             description="Smart home device control (lights, switches, sensors), dashboard management (Lovelace), media requests (movies, TV shows), music collection (Lidarr), and grocery ordering (Picnic).",
             instruction=instruction,
             tools=tools,
-            mode="task",
         )
 
         logger.info(f"Created Casa agent with {len(tools)} tools")

--- a/radbot/agent/planner_agent/factory.py
+++ b/radbot/agent/planner_agent/factory.py
@@ -29,7 +29,6 @@ def create_planner_agent() -> Optional[Agent]:
             "planner",
             "You are Planner, a time and scheduling specialist. "
             "Manage calendar events, scheduled tasks, and reminders.",
-            use_task_mode=True,
         )
 
         # Build tools list
@@ -85,7 +84,6 @@ def create_planner_agent() -> Optional[Agent]:
             description="Calendar events, scheduled recurring tasks, one-shot reminders, and time queries.",
             instruction=instruction,
             tools=tools,
-            mode="task",
         )
 
         logger.info(f"Created Planner agent with {len(tools)} tools")

--- a/radbot/agent/research_agent/agent.py
+++ b/radbot/agent/research_agent/agent.py
@@ -99,7 +99,6 @@ class ResearchAgent:
             description=description,
             tools=tools,
             output_key=output_key,
-            mode="task",
         )
 
         # Store app_name for reference (not used by LlmAgent but needed for Runner)

--- a/radbot/agent/research_agent/factory.py
+++ b/radbot/agent/research_agent/factory.py
@@ -14,7 +14,7 @@ from google.adk.tools import FunctionTool
 
 # Import project components
 from radbot.agent.research_agent.agent import ResearchAgent
-from radbot.agent.shared import TASK_FINISH_INSTRUCTIONS, TRANSFER_INSTRUCTIONS
+from radbot.agent.shared import TRANSFER_INSTRUCTIONS
 from radbot.config import config_manager
 
 
@@ -91,14 +91,10 @@ def create_research_agent(
     # No sub-agents needed here — search_agent, code_execution_agent, and axel
     # are siblings under beto, and ADK's transfer_to_agent can find them by name.
 
-    # Append completion instructions (task or transfer depending on V1/V2 mode)
+    # Append transfer-back instructions so scout hands control to beto after
+    # completing its research task.
     if hasattr(adk_agent, "instruction") and adk_agent.instruction:
-        try:
-            from google.adk.features import FeatureName, is_feature_enabled
-            v2_active = not is_feature_enabled(FeatureName.V1_LLM_AGENT)
-        except Exception:
-            v2_active = False
-        adk_agent.instruction += TASK_FINISH_INSTRUCTIONS if v2_active else TRANSFER_INSTRUCTIONS
+        adk_agent.instruction += TRANSFER_INSTRUCTIONS
 
     # Return either the ResearchAgent wrapper or the underlying ADK agent
     if as_subagent:

--- a/radbot/agent/runner.py
+++ b/radbot/agent/runner.py
@@ -1,14 +1,13 @@
 """Runner module for RadBot.
 
-Re-exports the stock ADK Runner as RadbotRunner. The stock Runner
-correctly handles V2 LlmAgent via _V1LlmAgentWrapper, which delegates
-to the _Mesh orchestration loop for proper multi-agent routing.
+Re-exports the stock ADK ``Runner`` as ``RadbotRunner``.
 
-All Runner imports in the codebase use:
+All Runner imports in the codebase use::
+
     from radbot.agent.runner import RadbotRunner as Runner
 
 This indirection keeps a single point of change if we ever need to
-customize Runner behavior.
+customize Runner behaviour.
 """
 
 from google.adk.runners import Runner as RadbotRunner  # noqa: F401

--- a/radbot/agent/shared.py
+++ b/radbot/agent/shared.py
@@ -17,13 +17,6 @@ TRANSFER_INSTRUCTIONS = (
     "You MUST always do BOTH steps — never return without text content, and never skip the transfer back."
 )
 
-TASK_FINISH_INSTRUCTIONS = (
-    "\n\nCRITICAL RULE — Completing your task:\n"
-    "1. Complete your task using your tools.\n"
-    "2. Call finish_task(result='<your full response with all results>') to return the results.\n"
-    "You MUST call finish_task when done — include ALL substantive data in the result string."
-)
-
 
 def resolve_agent_model(agent_name: str) -> str:
     """Resolve the model to use for an agent, falling back to sub_model.
@@ -40,17 +33,15 @@ def resolve_agent_model(agent_name: str) -> str:
     return model
 
 
-def load_agent_instruction(agent_name: str, fallback: str, *, use_task_mode: bool = False) -> str:
+def load_agent_instruction(agent_name: str, fallback: str) -> str:
     """Load agent instructions from config, falling back to a default string.
 
-    Automatically appends completion instructions (task or transfer) based
-    on the active ADK mode.
+    Appends :data:`TRANSFER_INSTRUCTIONS` so the sub-agent always returns
+    text and hands control back to beto via ``transfer_to_agent``.
 
     Args:
         agent_name: The instruction file name (e.g. "casa", "planner").
         fallback: Default instruction text if no file is found.
-        use_task_mode: If True AND V1_LLM_AGENT is disabled, append
-            TASK_FINISH_INSTRUCTIONS. Otherwise append TRANSFER_INSTRUCTIONS.
 
     Returns:
         The full instruction string with completion instructions appended.
@@ -59,15 +50,5 @@ def load_agent_instruction(agent_name: str, fallback: str, *, use_task_mode: boo
         instruction = config_manager.get_instruction(agent_name)
     except FileNotFoundError:
         instruction = fallback
-
-    # Only use task instructions when V2 is active
-    if use_task_mode:
-        try:
-            from google.adk.features import FeatureName, is_feature_enabled
-            if not is_feature_enabled(FeatureName.V1_LLM_AGENT):
-                instruction += TASK_FINISH_INSTRUCTIONS
-                return instruction
-        except Exception:
-            pass
     instruction += TRANSFER_INSTRUCTIONS
     return instruction

--- a/radbot/agent/specialized_agent_factory.py
+++ b/radbot/agent/specialized_agent_factory.py
@@ -5,10 +5,9 @@ Creates all domain-specific sub-agents (casa, planner, tracker, comms, axel,
 kidsvid) and returns them for inclusion in the root agent's sub_agents list
 at construction time.
 
-NOTE: ADK 2.0 builds the internal routing mesh in model_post_init, so all
-sub-agents MUST be passed to the root Agent constructor. Do NOT add agents
-to sub_agents after construction — they won't be part of the mesh and
-transfer_to_agent won't find them.
+NOTE: pass every sub-agent to the root Agent constructor. Adding to
+``sub_agents`` after construction leaves ``parent_agent`` unset on the
+child, which breaks ``transfer_to_agent`` lookups.
 """
 
 import logging

--- a/radbot/agent/tracker_agent/factory.py
+++ b/radbot/agent/tracker_agent/factory.py
@@ -29,7 +29,6 @@ def create_tracker_agent() -> Optional[Agent]:
             "tracker",
             "You are Tracker, a task and project management specialist. "
             "Manage todo items, projects, and webhook integrations.",
-            use_task_mode=True,
         )
 
         # Build tools list
@@ -53,7 +52,6 @@ def create_tracker_agent() -> Optional[Agent]:
             description="Todo lists, project management, task tracking, and webhook configuration.",
             instruction=instruction,
             tools=tools,
-            mode="task",
         )
 
         logger.info(f"Created Tracker agent with {len(tools)} tools")

--- a/radbot/agent/youtube_agent/factory.py
+++ b/radbot/agent/youtube_agent/factory.py
@@ -30,7 +30,6 @@ def create_youtube_agent() -> Optional[Agent]:
             "kidsvid",
             "You are KidsVid, a children's video curator. "
             "Search YouTube for safe, educational, age-appropriate videos for children.",
-            use_task_mode=True,
         )
 
         # Build tools list
@@ -88,7 +87,6 @@ def create_youtube_agent() -> Optional[Agent]:
             ),
             instruction=instruction,
             tools=tools,
-            mode="task",
         )
 
         logger.info(f"Created KidsVid agent with {len(tools)} tools")

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -158,9 +158,9 @@ All assembly happens in `radbot/agent/agent_core.py` at module import time:
 5. **Before construction**, callbacks are attached to each sub-agent:
    - `before_model_callback = [scope_sub_agent_context_callback, scrub_empty_content_before_model, sanitize_tool_schemas_before_model]`
    - `after_model_callback = [handle_empty_response_after_model, telemetry_after_model_callback]`
-6. Root `Agent(...)` is constructed — ADK's `model_post_init()` builds the `_Mesh` routing graph once, setting `parent_agent` on every sub-agent
+6. Root `Agent(...)` is constructed — ADK sets `parent_agent` on every sub-agent at construction, which `transfer_to_agent` relies on for routing lookup
 
-**Critical**: agents added to `sub_agents` after construction are NOT part of the mesh — `transfer_to_agent` will not find them. See `docs/implementation/session_id_tracking.md` for history.
+**Critical**: agents added to `sub_agents` after construction leave `parent_agent` unset on the child — `transfer_to_agent` will not find them. See `docs/implementation/session_id_tracking.md` for history.
 
 ## Per-Turn Context Scoping
 

--- a/specs/deployment.md
+++ b/specs/deployment.md
@@ -13,8 +13,8 @@
 
 - **Python**: 3.14-slim base image for both main app and worker (upgraded in `85a258e`)
 - **Package manager**: `uv` — both containers use multi-stage builds with `uv` + GHA layer caching (`c20e8b2`, `c1cbdd8`)
-- **ADK**: `google-adk>=2.0.0a3,<3.0.0` with V1 LlmAgent mode (V2 `_Mesh` is being removed upstream — see CLAUDE.md gotchas)
-- **genai**: `google-genai>=1.68.0` (NOT the older `google-generativeai` package)
+- **ADK**: `google-adk>=1.31.0,<2.0.0` — the currently supported line after upstream unwound the v2 alpha (see CLAUDE.md gotchas)
+- **genai**: `google-genai>=1.72.0` (ADK 1.31.0 floor; NOT the older `google-generativeai` package)
 
 ## Bootstrap Config
 


### PR DESCRIPTION
## Summary

Move off the `2.0.0a3` alpha back onto the currently supported **v1.31.0** (released 2026-04-17, *newer* than our v2 alpha). The upstream team has committed to unwinding v2_Mesh — [adk-python#5283 comment](https://github.com/google/adk-python/issues/5283#issuecomment-3097193826):

> we are removing v2_Mesh in our latest version of workflow. And will by default use the v1 llm agent.

## Why

v2.0.0a3 shipped two production-breaking bugs that we've been hitting today:

1. **Schema leak** — `Optional[Dict]` / `Optional[List]` tool params emit the snake_case `additional_properties` key; gemini-2.5/3.1-flash reject it with HTTP 400. Worked around in PR #11 via a `before_model_callback`, but the bug is still upstream.
2. **Transfer flakiness** — V2 `_Mesh` intermittently yields function_call-only responses (no text), exhausting the runner's 3-retry budget and poisoning the session. Currently the dominant failure mode in prod.

v1.31.0 has neither issue at the routing layer. PR #11's schema scrubber stays useful because v1.31 still has the same `_parse_schema_from_parameter` + `TypeAdapter` fallback path, so we leave that callback in place as defensive coverage.

## What v1.31.0 gives us unchanged

- Python ≥3.10 (we stay on 3.14)
- google-genai ≥1.72.0 (we're already there)
- `ContextCacheConfig`, all callbacks, `FunctionTool`, `Runner`, `transfer_to_agent` semantics

## What changed (five commits, all mechanical)

| Commit | Summary |
|---|---|
| `858f0fe` | `pyproject.toml`: pin `google-adk>=1.31.0,<2.0.0`; bump genai floor to match ADK's `>=1.72.0` |
| `016c14e` | Drop `mode='task'` kwarg from 7 factory files; simplify `shared.load_agent_instruction` (drop `use_task_mode`, drop `TASK_FINISH_INSTRUCTIONS`, always append `TRANSFER_INSTRUCTIONS`) |
| `857b012` | `.gitignore` for `.claude/worktrees/` + drop two stray gitlinks added in the previous commit |
| `b363a2a` | Remove `FeatureName.V1_LLM_AGENT` feature-check branches from `research_agent/factory.py` and `execution_agent/factory.py` — always V1 |
| `963871b` | Specs + CLAUDE.md + code-comment cleanup: version pins, `_Mesh` references, the V1/V2 duality note |

No callbacks touched. No tool code touched. No session/runner surgery. Nothing in `agent_core.py` beyond comment edits.

## Which specs did this PR update

- `SPEC.md` — stack + runtime lines
- `specs/deployment.md` — ADK/genai version pins
- `specs/agents.md` — routing-graph description
- `CLAUDE.md` — `Known Gotchas` ADK entry rewritten with a short historical note

## Test plan

- [ ] `uv sync` pulls ADK 1.31.0 cleanly; no pip backtracking
- [ ] `make test-unit` passes locally
- [ ] Deploy to a dev Nomad allocation first; confirm:
  - [ ] Beto → casa round-trip succeeds with text response (current failure mode on v2)
  - [ ] No new `additional_properties` 400s (we still have the PR #11 scrubber as belt-and-braces)
  - [ ] `/admin/api/telemetry/costs` shows normal traffic shape within 24h
- [ ] Then deploy to prod

## Rollback

Revert the PR. Nothing in the migration depends on v1-specific APIs that aren't in v2; a rollback is the same file diff reversed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)