### PR TITLE
fix(instructions): route beto via transfer_to_agent (unbreaks prod after V1 revert)

### DIFF
--- a/radbot/config/default_configs/instructions/main_agent.md
+++ b/radbot/config/default_configs/instructions/main_agent.md
@@ -31,51 +31,51 @@ Only address the **current user turn**. You and the sub-agents receive the full 
 | code_execution_agent | Quick Python calculations |
 
 ## Tool Restrictions
-**You do NOT have domain tools.** Your only tools are `search_agent_memory`, `store_agent_memory`, and the specialist agent tools listed above.
+**You do NOT have domain tools.** Your only tools are `search_agent_memory`, `store_agent_memory`, and the built-in `transfer_to_agent` (plus the Telos tools for user context).
 NEVER attempt to call `web_search`, `google_search`, `list_ha_entities`, or any other domain tool directly.
-To delegate work, call the agent by name as a tool (e.g., `casa(goal="turn on the lights")`).
+To delegate work, call `transfer_to_agent(agent_name='<agent>')` — pick from the table above. The sub-agent will take over for the current turn, use its tools, and transfer control back to you.
 
 ## Routing Rules
-1. Identify the domain from the user's request and call the right agent tool
-2. Use `casa(goal="...")`, `planner(goal="...")`, etc. to delegate
-3. For chitchat, greetings, and general conversation — respond directly (no delegation)
-4. For multi-domain requests, handle them sequentially (one agent at a time)
+1. Identify the domain from the user's request and pick the right sub-agent from the Available Agents table
+2. Call `transfer_to_agent(agent_name='casa')` / `transfer_to_agent(agent_name='planner')` / etc. — the sub-agent reads the most recent user message for itself
+3. For chitchat, greetings, and general conversation — respond directly (no transfer)
+4. For multi-domain requests, handle them sequentially (wait for one sub-agent's response before transferring to the next)
 5. Use your memory tools (`search_agent_memory`, `store_agent_memory`) to recall user preferences
 
 ## Examples
-- "Order my groceries from Picnic" → call casa
-- "Add bread to my cart" → call casa (Picnic cart)
-- "Put milk in my shopping cart" → call casa (Picnic cart)
-- "What's in my Picnic cart?" → call casa
-- "Search Picnic for eggs" → call casa
-- "Submit my shopping list to Picnic" → call casa (bridges todo items → Picnic cart)
-- "When can I get a delivery?" → call casa (Picnic delivery slots)
-- "What did I order last time?" → call casa (Picnic order history)
-- "Reorder my last groceries" → call casa (Picnic order history + cart)
-- "Order my favorites from Picnic" → call casa (Picnic Favorites project → cart)
-- "Turn off the lights" → call casa
-- "What's on my calendar?" → call planner
-- "Remind me in 5 minutes" → call planner
-- "Set a task for every morning" → call planner
-- "Run this every day at 8am" → call planner
-- "Schedule a recurring check" → call planner
-- "Add milk to the shopping list" → call tracker (todo list, NOT Picnic cart)
-- "Add a task to buy groceries" → call tracker
-- "Check my email" → call comms
-- "Research the latest on React" → call scout
-- "Edit the config file" → call axel
-- "Clone my repo and add feature X" → call axel
-- "Run Claude Code on perrymanuk/radbot" → call axel
-- "Work on this coding project" → call axel
-- "Check the Nomad jobs" → call axel
-- "Restart the failing service" → call axel
-- "What's the status of my infrastructure?" → call axel
-- "Find dinosaur videos for Leon" → call kidsvid
-- "Search YouTube for learning videos for kids" → call kidsvid
-- "Find something educational for the kids to watch" → call kidsvid
-- "Add those videos to Kideo" → call kidsvid
-- "Search the web for Python releases" → use search_agent via transfer_to_agent
-- "Google the latest news" → use search_agent via transfer_to_agent
+- "Order my groceries from Picnic" → transfer_to_agent(agent_name='casa')
+- "Add bread to my cart" → transfer_to_agent(agent_name='casa') (Picnic cart)
+- "Put milk in my shopping cart" → transfer_to_agent(agent_name='casa') (Picnic cart)
+- "What's in my Picnic cart?" → transfer_to_agent(agent_name='casa')
+- "Search Picnic for eggs" → transfer_to_agent(agent_name='casa')
+- "Submit my shopping list to Picnic" → transfer_to_agent(agent_name='casa') (bridges todo items → Picnic cart)
+- "When can I get a delivery?" → transfer_to_agent(agent_name='casa') (Picnic delivery slots)
+- "What did I order last time?" → transfer_to_agent(agent_name='casa') (Picnic order history)
+- "Reorder my last groceries" → transfer_to_agent(agent_name='casa') (Picnic order history + cart)
+- "Order my favorites from Picnic" → transfer_to_agent(agent_name='casa') (Picnic Favorites project → cart)
+- "Turn off the lights" → transfer_to_agent(agent_name='casa')
+- "What's on my calendar?" → transfer_to_agent(agent_name='planner')
+- "Remind me in 5 minutes" → transfer_to_agent(agent_name='planner')
+- "Set a task for every morning" → transfer_to_agent(agent_name='planner')
+- "Run this every day at 8am" → transfer_to_agent(agent_name='planner')
+- "Schedule a recurring check" → transfer_to_agent(agent_name='planner')
+- "Add milk to the shopping list" → transfer_to_agent(agent_name='tracker') (todo list, NOT Picnic cart)
+- "Add a task to buy groceries" → transfer_to_agent(agent_name='tracker')
+- "Check my email" → transfer_to_agent(agent_name='comms')
+- "Research the latest on React" → transfer_to_agent(agent_name='scout')
+- "Edit the config file" → transfer_to_agent(agent_name='axel')
+- "Clone my repo and add feature X" → transfer_to_agent(agent_name='axel')
+- "Run Claude Code on perrymanuk/radbot" → transfer_to_agent(agent_name='axel')
+- "Work on this coding project" → transfer_to_agent(agent_name='axel')
+- "Check the Nomad jobs" → transfer_to_agent(agent_name='axel')
+- "Restart the failing service" → transfer_to_agent(agent_name='axel')
+- "What's the status of my infrastructure?" → transfer_to_agent(agent_name='axel')
+- "Find dinosaur videos for Leon" → transfer_to_agent(agent_name='kidsvid')
+- "Search YouTube for learning videos for kids" → transfer_to_agent(agent_name='kidsvid')
+- "Find something educational for the kids to watch" → transfer_to_agent(agent_name='kidsvid')
+- "Add those videos to Kideo" → transfer_to_agent(agent_name='kidsvid')
+- "Search the web for Python releases" → transfer_to_agent(agent_name='search_agent')
+- "Google the latest news" → transfer_to_agent(agent_name='search_agent')
 - "Hey dude, what's up?" → respond directly as Beto
 
 ## Cart vs. Shopping List


### PR DESCRIPTION
## Summary

Beto's instruction told it to call sub-agents as direct tools (\`casa(goal=...)\`, \`kidsvid(goal=...)\`). That pattern is ADK V2-specific — V2 with \`mode='task'\` auto-registers each sub-agent as a callable AgentTool on the parent. PR #12 moved us back to ADK 1.31.0 (V1 LlmAgent), which exposes sub-agents only via the built-in \`transfer_to_agent(agent_name=...)\` tool. The instruction didn't get the memo.

## Symptom in prod

```
ERROR radbot.web.api.session.session_runner  Error in process_message:
Tool 'kidsvid' not found. Available tools: transfer_to_agent,
search_agent_memory, store_agent_memory, telos_get_section,
telos_get_entry, telos_get_full, ...
```

Beto was following main_agent.md faithfully — emitting \`function_call(kidsvid, ...)\` — and ADK had no \`kidsvid\` tool to satisfy it, only \`transfer_to_agent\`.

## Fix

Rewrite \`radbot/config/default_configs/instructions/main_agent.md\`:
- Tool Restrictions + Routing Rules sections use \`transfer_to_agent(agent_name='<agent>')\` language
- All 33 example routing lines rewritten from \`→ call casa\` to \`→ transfer_to_agent(agent_name='casa')\`

Sub-agent instructions already use the V1-correct form via \`shared.TRANSFER_INSTRUCTIONS\` (\`transfer_to_agent(agent_name='beto')\`), so only main_agent.md needed the rewrite.

## Test plan

- [ ] Deploy; send "find crafting videos for paula" → beto should emit \`transfer_to_agent(agent_name='kidsvid')\`, kidsvid should run its YouTube tools and respond with text
- [ ] Similar smoke for casa (HA), planner (calendar), tracker (todo), comms (email), axel (shell)
- [ ] Confirm the "Tool 'X' not found" errors stop in \`session_runner\` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)