### PR TITLE
fix(callbacks): scrub_empty_content must never reduce contents to []

### DIFF
--- a/radbot/callbacks/empty_content_callback.py
+++ b/radbot/callbacks/empty_content_callback.py
@@ -34,6 +34,15 @@ def scrub_empty_content_before_model(
     cascading failures where subsequent model calls also return empty.
     This scrubs them out before each model call.
 
+    **Safety guard**: never leaves ``contents`` empty. If every entry
+    looks empty (happens in ADK V1 right after ``transfer_to_agent`` —
+    the sub-agent's first LLM request can carry scaffolding-only
+    Content objects), we leave the request untouched and let ADK / the
+    model handle it. Reducing ``contents`` to ``[]`` triggers the
+    google-genai transformer's ``ValueError('contents are required.')``
+    and kills the request outright, which is a worse failure mode than
+    passing through.
+
     Returns None so the request proceeds normally.
     """
     if not llm_request.contents:
@@ -50,11 +59,18 @@ def scrub_empty_content_before_model(
         else:
             removed += 1
 
-    if removed > 0:
+    if removed > 0 and cleaned:
         llm_request.contents = cleaned
         logger.info(
             "empty_content_scrub: removed %d/%d empty Content objects from request history",
             removed,
+            original_count,
+        )
+    elif removed > 0 and not cleaned:
+        # Would have emptied contents entirely — pass through instead.
+        logger.warning(
+            "empty_content_scrub: %d Content objects all had empty parts; "
+            "passing through untouched to avoid 'contents are required' 400",
             original_count,
         )
 


### PR DESCRIPTION
## Summary

Adds a guard in \`scrub_empty_content_before_model\` so it never leaves \`llm_request.contents\` as an empty list. When every entry has empty/None parts, pass the request through untouched instead — google-genai's transformer otherwise raises \`ValueError('contents are required.')\` and the request dies before it reaches the model.

## Symptom

Post-PR #14 prod was routing transfers correctly (beto → kidsvid) but then dying with:

\`\`\`
ERROR radbot.web.api.session.session_runner  Error in process_message: contents are required.
  google/genai/_transformers.py:482  ValueError: contents are required.
\`\`\`

Only surfaces after a \`transfer_to_agent\`: traceback lands inside the sub-agent's first LLM call (\`base_llm_flow.py:_call_llm_async\` nested inside \`_postprocess_handle_function_calls_async\`).

## Root cause

ADK V1 appears to frame the sub-agent's first LLM request with Content objects that have \`parts=None\` or \`parts=[]\` — scaffolding that carries state without payload. Our scrub (written to defend against the Gemini \`parts=None\` cascade, docstring refs adk-python#3525 and python-genai#1289) saw those as "empty" and dropped every entry, leaving \`contents=[]\`, which google-genai rejects outright.

## Fix

One-line logic change + a \`WARNING\` log when the guard fires, so we can watch how often ADK actually sends all-empty contents:

\`\`\`python
if removed > 0 and cleaned:
    llm_request.contents = cleaned
elif removed > 0 and not cleaned:
    # Would have emptied contents entirely — pass through.
    logger.warning(...)
\`\`\`

Passing an empty-framing request through is a strictly better outcome than a guaranteed 400. ADK or the model can choose what to do; the 400 kills it immediately and then cascades through \`session_runner.py\`'s retry loop, poisoning the session.

## Test plan

- [ ] Deploy; send a message that used to fail on turn 2 (e.g. "find crafting videos for paula" then "paper mostly"). Expect a real response from kidsvid rather than the \`contents are required\` error.
- [ ] Watch for the new WARNING \`empty_content_scrub: N Content objects all had empty parts\` in \`radbot.callbacks.empty_content_callback\`. Its presence at reasonable frequency is fine; if it fires on every turn we should dig deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)