### PR TITLE
restore: put sanitize_tool_schemas scrubber back (PR #16 went too far)

### DIFF
--- a/radbot/agent/agent_core.py
+++ b/radbot/agent/agent_core.py
@@ -34,6 +34,7 @@ from radbot.callbacks.telemetry_callback import telemetry_after_model_callback
 from radbot.callbacks.scope_to_current_turn import (
     scope_sub_agent_context_callback,
 )
+from radbot.callbacks.sanitize_tool_schemas import sanitize_tool_schemas_before_model
 from radbot.config.config_loader import config_loader
 
 # Import memory tools and services
@@ -151,7 +152,11 @@ all_sub_agents.extend(specialized_agents)
 # current user turn (prevents cross-turn context bleed). Root Beto keeps
 # full history — only sub-agents are scoped.
 _after_cbs = [handle_empty_response_after_model, telemetry_after_model_callback]
-_before_cbs = [scope_sub_agent_context_callback, scrub_empty_content_before_model]
+_before_cbs = [
+    scope_sub_agent_context_callback,
+    scrub_empty_content_before_model,
+    sanitize_tool_schemas_before_model,
+]
 for sa in all_sub_agents:
     if not sa.after_model_callback:
         sa.after_model_callback = _after_cbs
@@ -171,6 +176,7 @@ root_agent = Agent(
     before_model_callback=[
         scrub_empty_content_before_model,
         sanitize_before_model_callback,
+        sanitize_tool_schemas_before_model,
         # Telos: inject user persona/context into beto's system_instruction.
         # Anchor every turn, full block session-start only (state-gated).
         # Attached to beto ONLY — sub-agents don't need user persona context.

--- a/radbot/callbacks/sanitize_tool_schemas.py
+++ b/radbot/callbacks/sanitize_tool_schemas.py
@@ -1,0 +1,156 @@
+"""Before-model callback that removes non-standard JSON-Schema keys from
+outgoing tool declarations.
+
+### Why
+
+Gemini's model API (as of 2026-04) rejects requests whose
+``tools[*].function_declarations[*].parameters`` contain the snake_case
+key ``additional_properties``::
+
+    Invalid JSON payload received. Unknown name "additional_properties"
+    at 'tools[0].function_declarations[1].parameters.properties[5]
+                .value.any_of[0]': Cannot find field.
+
+The standard JSON-Schema keyword is ``additionalProperties`` (camelCase).
+Pydantic v2 emits that correctly, but somewhere in the
+Pydantic→Schema-proto→JSON pipeline (google-genai side), the field gets
+copied into the proto as its snake_case python attribute name and leaks
+back into the REST body. The gemini-2.5 / gemini-3.1-flash validators
+surface this strictly; gemini-3.1-pro used to tolerate it silently, so
+the failure began after the recent main-agent model downgrade (see
+``docs/implementation/integrations/ha_mcp_migration.md`` and beto's
+flash move in commit ``784e398``).
+
+### What
+
+This callback walks ``llm_request.config.tools`` and recursively strips
+the offending keys from every ``parameters`` schema. ``additionalProperties``
+(camelCase, standards-compliant) is left alone; only the non-standard
+snake_case version is removed. Applied on every agent's
+``before_model_callback`` so the scrub runs for every LLM call,
+regardless of which tool module introduced the leak.
+
+Idempotent and failure-safe: if anything about the Schema structure is
+different from what we expect, the callback swallows the exception and
+returns — telemetry will still capture the upstream error.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Keys that Gemini rejects when it sees them in a parameters schema.
+# Extend this set conservatively if similar schema-drift bugs surface.
+_NON_STANDARD_SCHEMA_KEYS = ("additional_properties",)
+
+
+def _scrub_obj(obj: Any) -> None:
+    """Recursively remove non-standard keys from a Schema-like object.
+
+    Handles two representations interchangeably:
+      * Python dicts (JSON-schema style)
+      * google-genai Schema proto messages (attribute access)
+
+    In both cases we walk common schema-tree fields: ``properties``,
+    ``items``, ``any_of`` / ``anyOf``, ``one_of`` / ``oneOf``,
+    ``all_of`` / ``allOf``.
+    """
+    if obj is None:
+        return
+
+    # Dict form
+    if isinstance(obj, dict):
+        for key in _NON_STANDARD_SCHEMA_KEYS:
+            obj.pop(key, None)
+        for child_key in (
+            "properties",
+            "items",
+            "any_of",
+            "anyOf",
+            "one_of",
+            "oneOf",
+            "all_of",
+            "allOf",
+        ):
+            child = obj.get(child_key)
+            if isinstance(child, dict):
+                for v in child.values():
+                    _scrub_obj(v)
+            elif isinstance(child, list):
+                for v in child:
+                    _scrub_obj(v)
+        return
+
+    # Proto / object form — remove attributes by setting them to None so
+    # the serializer drops them. Try/except because proto field sets can
+    # be strict about types.
+    for key in _NON_STANDARD_SCHEMA_KEYS:
+        if hasattr(obj, key):
+            try:
+                setattr(obj, key, None)
+            except Exception:
+                pass
+    for child_key in ("properties", "items", "any_of", "one_of", "all_of"):
+        child = getattr(obj, child_key, None)
+        if child is None:
+            continue
+        # Properties can be a dict-like or repeated field of entries
+        if isinstance(child, dict):
+            for v in child.values():
+                _scrub_obj(v)
+        elif hasattr(child, "values"):
+            try:
+                for v in child.values():
+                    _scrub_obj(v)
+            except Exception:
+                pass
+        elif isinstance(child, (list, tuple)):
+            for v in child:
+                _scrub_obj(v)
+        else:
+            # Single nested schema
+            _scrub_obj(child)
+
+
+def sanitize_tool_schemas_before_model(
+    callback_context: Any,
+    llm_request: Any,
+) -> Optional[Any]:
+    """Strip ``additional_properties`` from every tool parameter schema.
+
+    Returns ``None`` so the sanitized request proceeds unmodified in all
+    other respects.
+    """
+    try:
+        config = getattr(llm_request, "config", None)
+        tools = getattr(config, "tools", None) if config is not None else None
+        if not tools:
+            return None
+
+        scrubbed = 0
+        for tool in tools:
+            decls = getattr(tool, "function_declarations", None)
+            if not decls:
+                continue
+            for decl in decls:
+                params = getattr(decl, "parameters", None)
+                if params is None:
+                    continue
+                _scrub_obj(params)
+                scrubbed += 1
+
+        if scrubbed:
+            logger.debug(
+                "sanitize-tool-schemas: processed %d function declarations",
+                scrubbed,
+            )
+    except Exception as e:
+        # Never take the request down for a schema-scrub failure — the
+        # upstream call will surface any real problem with its own
+        # diagnostics.
+        logger.debug("sanitize-tool-schemas error (non-fatal): %s", e)
+    return None

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -49,7 +49,7 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 - **Global instruction**: injects today's date
 - **Tools**: `search_agent_memory`, `store_agent_memory` (via `create_agent_memory_tools("beto")`) + 18 Telos tools (`TELOS_TOOLS`, see `specs/tools.md`)
 - **Before-agent callback**: `setup_before_agent_call` — DB schema init (todo, scheduler, webhook, reminder, telos, notifications, alerts, telemetry), HA client check
-- **Before-model callbacks**: `[scrub_empty_content_before_model, sanitize_before_model_callback, inject_telos_context]`
+- **Before-model callbacks**: `[scrub_empty_content_before_model, sanitize_before_model_callback, sanitize_tool_schemas_before_model, inject_telos_context]`
 - **After-model callbacks**: `[handle_empty_response_after_model, telemetry_after_model_callback]`
 - **Instruction file**: `config/default_configs/instructions/main_agent.md`
 - **Telos persona injection** (beto only): `inject_telos_context` appends an anchor (~300B: identity + mission + counts + tool pointer) to `llm_request.config.system_instruction` on every turn. On the first turn of each session it also appends the full block (~2KB: mission, problems, goals, active projects, challenges, wisdom, last 5 journal entries), gated by `callback_context.state["telos_bootstrapped"]`. Sub-agents are tool executors and do **not** receive Telos context. See `docs/implementation/telos.md`.
@@ -156,7 +156,7 @@ All assembly happens in `radbot/agent/agent_core.py` at module import time:
 3. `create_specialized_agents()` builds the domain agents in order: casa → planner → tracker → comms → axel → kidsvid. None-returning factories are filtered out.
 4. `all_sub_agents` = builtin sub-agents + specialized — passed to the root `Agent(...)` constructor
 5. **Before construction**, callbacks are attached to each sub-agent:
-   - `before_model_callback = [scope_sub_agent_context_callback, scrub_empty_content_before_model]`
+   - `before_model_callback = [scope_sub_agent_context_callback, scrub_empty_content_before_model, sanitize_tool_schemas_before_model]`
    - `after_model_callback = [handle_empty_response_after_model, telemetry_after_model_callback]`
 6. Root `Agent(...)` is constructed — ADK sets `parent_agent` on every sub-agent at construction, which `transfer_to_agent` relies on for routing lookup
 
@@ -199,6 +199,7 @@ From `config/default_configs/instructions/main_agent.md`:
 | `sanitize_before_model_callback` | `callbacks/sanitize_callback.py` | beto (before_model) | Strip PII / sensitive tokens |
 | `scrub_empty_content_before_model` | `callbacks/empty_content_callback.py` | all (before_model) | Drop Content entries with empty text parts (Gemini API errors) |
 | `scope_sub_agent_context_callback` | `callbacks/scope_to_current_turn.py` | sub-agents only (before_model) | Trim to current turn |
+| `sanitize_tool_schemas_before_model` | `callbacks/sanitize_tool_schemas.py` | all (before_model) | Strip the non-standard `additional_properties` key from every tool's parameters schema before it hits Gemini. Works around the Pydantic→Schema-proto snake-case leak introduced by google-genai 1.72.0. |
 | `inject_telos_context` | `tools/telos/callback.py` | beto only (before_model) | Inject Telos anchor every turn + full block on first turn of session into `system_instruction` |
 | `handle_empty_response_after_model` | `callbacks/empty_content_callback.py` | all (after_model) | Replace empty model responses with a "still thinking" marker |
 | `telemetry_after_model_callback` | `callbacks/telemetry_callback.py` | all (after_model) | Record token usage + cost in `llm_usage_log` with `session_id` |
@@ -217,5 +218,6 @@ From `config/default_configs/instructions/main_agent.md`:
 | `tools/adk_builtin/search_tool.py` | `search_agent` factory |
 | `tools/adk_builtin/code_execution_tool.py` | `code_execution_agent` factory |
 | `callbacks/scope_to_current_turn.py` | Per-turn context scoping for sub-agents |
+| `callbacks/sanitize_tool_schemas.py` | Strip the non-standard `additional_properties` key from tool parameter schemas before Gemini rejects them (google-genai 1.72.0 leak) |
 | `tools/telos/callback.py` | Inject Telos user-context into beto's `system_instruction` (anchor every turn, full block session-start) |
 | `tools/shared/card_protocol.py` | `radbot:<kind>` fenced-block card emission |


### PR DESCRIPTION
## Summary

Restores the schema scrubber that PR #16 removed. v0.92 proved it wasn't the source of the "contents are required" issue — on deploy without it, production immediately starts 400-ing with the original \`additional_properties\` schema-leak error again. The scrubber is load-bearing.

## What the deploy of PR #16 showed

\`\`\`
15:56:29  Running agent with message: I want to search for crafting videos for paula
15:56:29  Error in process_message: 400 INVALID_ARGUMENT.
          Unknown name "additional_properties" at
          'tools[0].function_declarations[15].parameters...
\`\`\`

That's the exact error PR #11 was designed to suppress. The scrubber was working correctly; the \`contents are required\` cascade is a separate, still-open issue likely in ADK 1.31's transfer-to-sub-agent path.

## Restored

- \`radbot/callbacks/sanitize_tool_schemas.py\`
- Import + registration in \`agent_core.py\` (beto's \`before_model_callback\` + sub-agent shared \`_before_cbs\`)
- \`specs/agents.md\` Callback Inventory + Key Files rows

## Not restored (still reverted from PR #16)

- \`gemini-flash-latest\`/\`gemini-pro-latest\`/\`gemini-2.5-flash-lite\` pricing aliases. Billing-visibility only; default fallback is pro pricing. Can come back once we're stable.

## Next step

Isolate the "contents are required" issue as a separate investigation — per the earlier ADK upgrade commit (85a258e), the old V1 pattern used post-construction sub-agent mutation + explicit \`parent_agent\` setting. Worth testing whether the constructor-time assembly we kept from V2 has a subtle interaction with V1's \`transfer_to_agent\` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)