### PR TITLE
fix(kidsvid): search first, clarify only when necessary

### DIFF
--- a/radbot/config/default_configs/instructions/kidsvid.md
+++ b/radbot/config/default_configs/instructions/kidsvid.md
@@ -141,9 +141,11 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
 
 ## How to Search and Recommend
 
-1. **Understand the request**: What topic? Which child? What age? What's the context — are they learning a subject, looking for quiet-time content, or just exploring an interest?
-2. **Check your memory first**: Do you know this child? What have they watched before? What are their current interests and skill levels? Search your memory before searching YouTube.
-3. **Search both platforms**: Search YouTube AND CuriosityStream for the topic. Present the best results from each, noting which platform they're from.
+**Search first, clarify only if truly necessary.** When a parent gives you a topic and a child, assume sensible defaults and search. Memory lookups and clarifying questions are an optimization — the first-response obligation is to produce video results. Do NOT ask "how old is X?" before searching; pick a reasonable grade band from the query itself (a "crafting" request from a parent with young kids implies K-3; "minecraft" implies 6+; etc.) and search. You can always refine on a follow-up turn.
+
+1. **Understand the request**: What topic? Which child? If age/level is missing, pick a sensible default from the query (see above) — do NOT stall on clarification.
+2. **Check memory (fast, non-blocking)**: Do a quick `search_agent_memory` for the child's name to pick up prior preferences. If it returns nothing, carry on with defaults — don't ask the parent.
+3. **Search both platforms**: Call `search_youtube_videos` AND `search_curiositystream` for the topic. Present the best results from each, noting which platform they're from. This is the required step for every recommendation request.
 4. **Search strategically**: On YouTube, always use `safe_search="strict"`. Augment the parent's query with age-appropriate qualifiers:
    - Add "for kids", "educational", "learning" to broad topics
    - For specific ages, add "preschool", "toddler", "elementary" etc.


### PR DESCRIPTION
## Summary

Tweaks \`kidsvid.md\`'s "How to Search and Recommend" section so kidsvid actually calls \`search_youtube_videos\` / \`search_curiositystream\` on vague-but-reasonable prompts, rather than stalling in memory + Kideo-library lookups.

## Evidence

Prod conversation on v0.94 (context-cache fix in place) with \`gemini-pro-latest\`:

\`\`\`
16:12:39  User: "can you search for some crafting videos for paula?"
16:13:33  httpx POST gemini-embedding-001 (memory embed)          ← step 2
16:13:33  httpx POST qdrant/points/query  (memory search)           ← step 2
16:13:44  httpx GET kideo.demonsafe.com/api/collections             ← step 2
           (no YouTube API calls)                                    ← step 3 skipped
\`\`\`

Same pattern across two fresh sessions. The LLM executes steps 1-2 and never reaches step 3.

## Root cause

PR #10's new kidsvid.md leads with a process-heavy "How to Search and Recommend" section whose step 1 demands "topic, child, age, context" and step 2 is a memory sweep. For ambiguous prompts the model treats those as blockers — it asks follow-up clarifying questions or gets stuck in gathering mode instead of searching.

Yesterday (pre PR #10) the instruction didn't front-load this process, and the same prompt resolved in 1 turn.

## Fix

Adds an explicit "Search first, clarify only if truly necessary" directive at the top of the section. The three steps are re-framed so:

- Step 1 says pick a sensible default from the query (crafting → K-3; minecraft → 6+) rather than asking about age.
- Step 2 is fast + non-blocking — memory call runs, empty result does NOT justify a clarifying question back to the parent.
- Step 3 is marked "required for every recommendation request" so search isn't skippable.

Untouched: video-card spec, educational philosophy, content safety, Kideo integration.

## Test plan

- [ ] Deploy. Send "crafting videos for paula". Expect YouTube + CuriosityStream search calls in the log on turn 1, with video cards rendered in the reply.
- [ ] No clarifying question about age on first turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)