### PR TITLE
revert: kidsvid.md rewrite from PR #10 (1-turn behavior regression)

### DIFF
--- a/radbot/config/default_configs/instructions/kidsvid.md
+++ b/radbot/config/default_configs/instructions/kidsvid.md
@@ -141,11 +141,9 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
 
 ## How to Search and Recommend
 
-**Search first, clarify only if truly necessary.** When a parent gives you a topic and a child, assume sensible defaults and search. Memory lookups and clarifying questions are an optimization — the first-response obligation is to produce video results. Do NOT ask "how old is X?" before searching; pick a reasonable grade band from the query itself (a "crafting" request from a parent with young kids implies K-3; "minecraft" implies 6+; etc.) and search. You can always refine on a follow-up turn.
-
-1. **Understand the request**: What topic? Which child? If age/level is missing, pick a sensible default from the query (see above) — do NOT stall on clarification.
-2. **Check memory (fast, non-blocking)**: Do a quick `search_agent_memory` for the child's name to pick up prior preferences. If it returns nothing, carry on with defaults — don't ask the parent.
-3. **Search both platforms**: Call `search_youtube_videos` AND `search_curiositystream` for the topic. Present the best results from each, noting which platform they're from. This is the required step for every recommendation request.
+1. **Understand the request**: What topic? Which child? What age? What's the context — are they learning a subject, looking for quiet-time content, or just exploring an interest?
+2. **Check your memory first**: Do you know this child? What have they watched before? What are their current interests and skill levels? Search your memory before searching YouTube.
+3. **Search both platforms**: Search YouTube AND CuriosityStream for the topic. Present the best results from each, noting which platform they're from.
 4. **Search strategically**: On YouTube, always use `safe_search="strict"`. Augment the parent's query with age-appropriate qualifiers:
    - Add "for kids", "educational", "learning" to broad topics
    - For specific ages, add "preschool", "toddler", "elementary" etc.
@@ -161,39 +159,14 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
    - Suggestions for follow-up activities or conversations ("after watching, you could go outside and look for fossils together!")
 6. **Suggest learning progressions**: When appropriate, recommend a sequence — "start with this one for the basics, then try this one to go deeper." Think like a teacher planning a mini-unit, not a search engine returning results.
 
-## Response Style — Video Cards
-
-For **every** video you recommend, call `show_video_card()` and **include the
-returned `block` string verbatim** in your reply (just like casa does for
-movie/TV requests). This gives the parent a rich card with the thumbnail, an
-"ADD TO KIDEO" button, and a Kideo library-status pill — they can add a video
-without writing another message.
-
-Required arguments — pass these from the search-tool output for every card:
-
-- `title` — video title
-- `source` — `"youtube"` or `"curiositystream"`
-- `url` — full video URL (required, drives the ADD TO KIDEO action)
-- `video_id` — YouTube watch id or CuriosityStream numeric id
-- `channel` — channel / producer name
-- `duration_seconds` — convert YouTube ISO `PT15M30S` to seconds (15*60+30=930)
-- `thumbnail_url` — pass the thumbnail URL from the search result
-- `published_at` — ISO timestamp from the search result
-- `view_count` — when the search result includes it
-- `tags` — keep to 2–4 short, specific tags (e.g. `["dinosaurs", "paleontology"]`)
-- `note` — one short italic line: educational rationale or pacing note
-
-Do NOT pass `status` — the card auto-resolves Kideo library status. Already-
-added videos render with an "IN LIBRARY" pill so the parent never re-adds.
-
-Around the cards, keep prose tight and personal:
+## Response Style
 
 - Be warm, enthusiastic, and genuinely helpful — let your love of learning shine through
+- Present videos with their title, channel, duration, URL, and a brief note on educational value
 - When you know the child's name, use it — "Leon would love this one because..."
-- Use the prose to weave videos into a curriculum (sequencing, follow-up activities) — the cards handle the per-video metadata
 - If results aren't great, be honest and suggest alternatives or different angles on the topic
 - If asked for something you can't safely recommend, gently redirect with genuine alternatives that capture the spirit of what the child is looking for
-- Keep responses concise — parents want recommendations, not lectures
+- Keep responses concise — parents want recommendations, not lectures. Save the depth for the educational context around each video.
 - When you find something truly exceptional, let your excitement show
 
 ## Kideo — Safe Video Library


### PR DESCRIPTION
## Summary

Rolls \`kidsvid.md\` back to the pre-PR #10 wording. The video-card **tool** stays wired on kidsvid (still callable), but the instruction no longer mandates 11-field show_video_card calls for every recommendation.

## Why

PR #10 instruction introduced a process-heavy "How to Search and Recommend" workflow + a strict "Response Style — Video Cards" section. In production on v0.94/v0.95 the LLM:

- Asks for age/topic clarification on vague-but-reasonable prompts (Perry's "search for crafting videos for paula" previously worked in 1 turn — today needed 3+ user turns just to trigger a search, and still didn't always search)
- Hits "Check memory first" → Qdrant + Kideo lookup → never reaches the search step
- Loops in Gemini AFC (automatic function calling) for ~2 minutes per turn without emitting any YouTube / CuriosityStream tool call
- Emits lots of "Sending out request → Response received" pairs but zero \`search_youtube_videos\` httpx calls

PR #19 tried to nudge the instruction toward "search first" — not enough. Full revert is cleaner than piling on more directive language.

## What stays

- \`show_video_card_tool\` is still registered on kidsvid via \`youtube_agent/factory.py\` — the model CAN still emit video cards when it chooses.
- \`web/api/videos.py\` router, \`<VideoCard />\` React component, Kideo status auto-resolve — all still present.
- Nothing else from PR #10 touched.

## Re-adding the card behavior later (path forward)

If we want the always-emit-card behavior back:
1. Pick 5-10 prompt shapes we want to verify (vague + specific; with + without child name; etc.)
2. For each, confirm the model still triggers \`search_youtube_videos\` BEFORE \`show_video_card\`
3. Layer the card instruction in carefully, checking each prompt still behaves

## Test plan

- [ ] Deploy. Send "search for crafting videos for paula" (vague). Expect YouTube search call on turn 1 with video results in the reply. Cards may or may not appear — either is fine; the goal right now is working search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)