### PR TITLE
feat(kidsvid): video cards + ADD TO KIDEO button — re-ship of PR #10 without the kidsvid.md rewrite

### DIFF
--- a/radbot/agent/youtube_agent/factory.py
+++ b/radbot/agent/youtube_agent/factory.py
@@ -72,6 +72,12 @@ def create_youtube_agent() -> Optional[Agent]:
         memory_tools = create_agent_memory_tools("kidsvid")
         tools.extend(memory_tools)
 
+        # Card-rendering tool — emits a fenced ```radbot:video block the
+        # frontend renders as <VideoCard /> with an ADD TO KIDEO button.
+        from radbot.tools.shared.card_protocol import show_video_card_tool
+
+        tools.append(show_video_card_tool)
+
         agent = Agent(
             name="kidsvid",
             model=model,

--- a/radbot/config/default_configs/instructions/kidsvid.md
+++ b/radbot/config/default_configs/instructions/kidsvid.md
@@ -159,39 +159,14 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
    - Suggestions for follow-up activities or conversations ("after watching, you could go outside and look for fossils together!")
 6. **Suggest learning progressions**: When appropriate, recommend a sequence — "start with this one for the basics, then try this one to go deeper." Think like a teacher planning a mini-unit, not a search engine returning results.
 
-## Response Style — Video Cards
-
-For **every** video you recommend, call `show_video_card()` and **include the
-returned `block` string verbatim** in your reply (just like casa does for
-movie/TV requests). This gives the parent a rich card with the thumbnail, an
-"ADD TO KIDEO" button, and a Kideo library-status pill — they can add a video
-without writing another message.
-
-Required arguments — pass these from the search-tool output for every card:
-
-- `title` — video title
-- `source` — `"youtube"` or `"curiositystream"`
-- `url` — full video URL (required, drives the ADD TO KIDEO action)
-- `video_id` — YouTube watch id or CuriosityStream numeric id
-- `channel` — channel / producer name
-- `duration_seconds` — convert YouTube ISO `PT15M30S` to seconds (15*60+30=930)
-- `thumbnail_url` — pass the thumbnail URL from the search result
-- `published_at` — ISO timestamp from the search result
-- `view_count` — when the search result includes it
-- `tags` — keep to 2–4 short, specific tags (e.g. `["dinosaurs", "paleontology"]`)
-- `note` — one short italic line: educational rationale or pacing note
-
-Do NOT pass `status` — the card auto-resolves Kideo library status. Already-
-added videos render with an "IN LIBRARY" pill so the parent never re-adds.
-
-Around the cards, keep prose tight and personal:
+## Response Style
 
 - Be warm, enthusiastic, and genuinely helpful — let your love of learning shine through
+- Present videos with their title, channel, duration, URL, and a brief note on educational value
 - When you know the child's name, use it — "Leon would love this one because..."
-- Use the prose to weave videos into a curriculum (sequencing, follow-up activities) — the cards handle the per-video metadata
 - If results aren't great, be honest and suggest alternatives or different angles on the topic
 - If asked for something you can't safely recommend, gently redirect with genuine alternatives that capture the spirit of what the child is looking for
-- Keep responses concise — parents want recommendations, not lectures
+- Keep responses concise — parents want recommendations, not lectures. Save the depth for the educational context around each video.
 - When you find something truly exceptional, let your excitement show
 
 ## Kideo — Safe Video Library

--- a/radbot/config/default_configs/instructions/kidsvid.md
+++ b/radbot/config/default_configs/instructions/kidsvid.md
@@ -159,14 +159,39 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
    - Suggestions for follow-up activities or conversations ("after watching, you could go outside and look for fossils together!")
 6. **Suggest learning progressions**: When appropriate, recommend a sequence — "start with this one for the basics, then try this one to go deeper." Think like a teacher planning a mini-unit, not a search engine returning results.
 
-## Response Style
+## Response Style — Video Cards
+
+For **every** video you recommend, call `show_video_card()` and **include the
+returned `block` string verbatim** in your reply (just like casa does for
+movie/TV requests). This gives the parent a rich card with the thumbnail, an
+"ADD TO KIDEO" button, and a Kideo library-status pill — they can add a video
+without writing another message.
+
+Required arguments — pass these from the search-tool output for every card:
+
+- `title` — video title
+- `source` — `"youtube"` or `"curiositystream"`
+- `url` — full video URL (required, drives the ADD TO KIDEO action)
+- `video_id` — YouTube watch id or CuriosityStream numeric id
+- `channel` — channel / producer name
+- `duration_seconds` — convert YouTube ISO `PT15M30S` to seconds (15*60+30=930)
+- `thumbnail_url` — pass the thumbnail URL from the search result
+- `published_at` — ISO timestamp from the search result
+- `view_count` — when the search result includes it
+- `tags` — keep to 2–4 short, specific tags (e.g. `["dinosaurs", "paleontology"]`)
+- `note` — one short italic line: educational rationale or pacing note
+
+Do NOT pass `status` — the card auto-resolves Kideo library status. Already-
+added videos render with an "IN LIBRARY" pill so the parent never re-adds.
+
+Around the cards, keep prose tight and personal:
 
 - Be warm, enthusiastic, and genuinely helpful — let your love of learning shine through
-- Present videos with their title, channel, duration, URL, and a brief note on educational value
 - When you know the child's name, use it — "Leon would love this one because..."
+- Use the prose to weave videos into a curriculum (sequencing, follow-up activities) — the cards handle the per-video metadata
 - If results aren't great, be honest and suggest alternatives or different angles on the topic
 - If asked for something you can't safely recommend, gently redirect with genuine alternatives that capture the spirit of what the child is looking for
-- Keep responses concise — parents want recommendations, not lectures. Save the depth for the educational context around each video.
+- Keep responses concise — parents want recommendations, not lectures
 - When you find something truly exceptional, let your excitement show
 
 ## Kideo — Safe Video Library

--- a/radbot/tools/shared/card_protocol.py
+++ b/radbot/tools/shared/card_protocol.py
@@ -30,7 +30,7 @@ from radbot.tools.shared.tool_decorator import tool_error_handler
 
 logger = logging.getLogger(__name__)
 
-_VALID_KINDS = {"media", "seasons", "ha-device", "handoff"}
+_VALID_KINDS = {"media", "seasons", "ha-device", "handoff", "video"}
 
 
 def _lookup_poster_url(tmdb_id: int, media_type: str) -> Optional[str]:
@@ -54,6 +54,42 @@ def _lookup_poster_url(tmdb_id: int, media_type: str) -> Optional[str]:
     except Exception as e:
         logger.debug("Poster URL lookup failed for %s/%s: %s", media_type, tmdb_id, e)
         return None
+
+
+_KIDEO_STATUS_MAP = {
+    "ready": "in_library",
+    "available": "in_library",
+    "downloaded": "in_library",
+    "queued": "queued",
+    "pending": "queued",
+    "downloading": "processing",
+    "transcoding": "processing",
+    "error": "error",
+    "failed": "error",
+}
+
+
+def _lookup_kideo_status(url: Optional[str]) -> tuple:
+    """Best-effort Kideo library lookup.
+
+    Returns ``(card_status, kideo_video_id)`` where ``card_status`` is one of
+    ``"in_library" | "queued" | "processing" | "error"`` or ``None`` when the
+    video is not in Kideo / lookup failed. Mirrors :func:`_lookup_poster_url`
+    — never raises.
+    """
+    if not url:
+        return None, None
+    try:
+        from radbot.tools.youtube.kideo_client import find_video_by_url
+
+        match = find_video_by_url(url)
+    except Exception as e:
+        logger.debug("Kideo lookup failed for %s: %s", url, e)
+        return None, None
+    if not match:
+        return None, None
+    raw_status = (match.get("status") or "").lower()
+    return _KIDEO_STATUS_MAP.get(raw_status, "in_library"), match.get("id")
 
 
 def format_card_block(kind: str, data: Any) -> str:
@@ -292,12 +328,123 @@ def show_ha_device_card(
     }
 
 
+_VIDEO_SOURCES = {"youtube", "curiositystream"}
+_VIDEO_STATUSES = {"in_library", "queued", "processing", "error", "not_added"}
+
+
+@tool_error_handler("render kid video card")
+def show_video_card(
+    title: str,
+    source: str,
+    url: str,
+    video_id: Optional[str] = None,
+    channel: Optional[str] = None,
+    duration_seconds: Optional[int] = None,
+    published_at: Optional[str] = None,
+    thumbnail_url: Optional[str] = None,
+    view_count: Optional[int] = None,
+    tags: Optional[List[str]] = None,
+    note: Optional[str] = None,
+    subtitle: Optional[str] = None,
+    status: Optional[str] = None,
+    kideo_video_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Render a kid-video recommendation card inline in chat.
+
+    Produces a card with thumbnail, channel/duration/source metadata, a Kideo
+    library-status pill, and an "ADD TO KIDEO" direct-action button. Mirrors
+    :func:`show_media_card` for movies/TV.
+
+    Args:
+        title: Video title.
+        source: ``"youtube"`` or ``"curiositystream"``.
+        url: Full video URL — required so the ADD TO KIDEO button can submit it.
+        video_id: Source-specific id (YouTube watch id, CuriosityStream numeric id).
+        channel: Channel / producer name.
+        duration_seconds: Length in seconds (rendered as ``Hh MMm`` or ``MM:SS``).
+        published_at: ISO timestamp; the year is rendered.
+        thumbnail_url: Thumbnail image URL (16:9). Falls back to a glyph poster.
+        view_count: View count (rendered as e.g. ``1.2M views``).
+        tags: Educational tags rendered as small chips.
+        note: Italic footer line — short educational rationale or pacing note.
+        subtitle: Optional secondary line under the title.
+        status: Override the auto-resolved Kideo status. One of
+            ``"in_library" | "queued" | "processing" | "error" | "not_added"``.
+        kideo_video_id: Override the auto-resolved Kideo UUID.
+
+    Returns:
+        ``{"status": "success", "block": "...", "instructions": "..."}``.
+        Include the ``block`` string verbatim in your reply.
+    """
+    if source not in _VIDEO_SOURCES:
+        return {
+            "status": "error",
+            "message": f"source must be one of {sorted(_VIDEO_SOURCES)}",
+        }
+    if status is not None and status not in _VIDEO_STATUSES:
+        return {
+            "status": "error",
+            "message": f"status must be one of {sorted(_VIDEO_STATUSES)}",
+        }
+    if not url:
+        return {"status": "error", "message": "url is required"}
+
+    resolved_status: Optional[str] = status
+    resolved_kideo_id = kideo_video_id
+    if resolved_status is None:
+        looked_status, looked_id = _lookup_kideo_status(url)
+        resolved_status = looked_status or "not_added"
+        if resolved_kideo_id is None:
+            resolved_kideo_id = looked_id
+
+    data: Dict[str, Any] = {
+        "title": title,
+        "source": source,
+        "url": url,
+        "status": resolved_status,
+    }
+    if video_id:
+        data["video_id"] = video_id
+    if channel:
+        data["channel"] = channel
+    if duration_seconds is not None:
+        try:
+            data["duration_seconds"] = max(0, int(duration_seconds))
+        except (ValueError, TypeError):
+            pass
+    if published_at:
+        data["published_at"] = published_at
+    if thumbnail_url:
+        data["thumbnail_url"] = thumbnail_url
+    if view_count is not None:
+        try:
+            data["view_count"] = max(0, int(view_count))
+        except (ValueError, TypeError):
+            pass
+    if tags:
+        data["tags"] = [str(t) for t in tags if t]
+    if note:
+        data["note"] = note
+    if subtitle:
+        data["subtitle"] = subtitle
+    if resolved_kideo_id:
+        data["kideo_video_id"] = resolved_kideo_id
+
+    return {
+        "status": "success",
+        "block": format_card_block("video", data),
+        "instructions": "Include the 'block' string verbatim in your reply.",
+    }
+
+
 show_media_card_tool = FunctionTool(show_media_card)
 show_season_breakdown_tool = FunctionTool(show_season_breakdown)
 show_ha_device_card_tool = FunctionTool(show_ha_device_card)
+show_video_card_tool = FunctionTool(show_video_card)
 
 CARD_TOOLS = [
     show_media_card_tool,
     show_season_breakdown_tool,
     show_ha_device_card_tool,
+    show_video_card_tool,
 ]

--- a/radbot/tools/youtube/kideo_client.py
+++ b/radbot/tools/youtube/kideo_client.py
@@ -202,6 +202,35 @@ def list_videos(status: Optional[str] = None) -> List[Dict[str, Any]]:
     return resp.json()
 
 
+def find_video_by_url(url: str) -> Optional[Dict[str, Any]]:
+    """Look up a Kideo video by its source URL.
+
+    Tries a direct query first (``GET /api/videos?url=<encoded>``) and falls
+    back to scanning the full list if the server doesn't honor the filter.
+    Returns the matching video dict (id, title, status, ...) or None.
+
+    Used by :func:`radbot.tools.shared.card_protocol._lookup_kideo_status`
+    to set library status on rendered video cards.
+    """
+    if not url:
+        return None
+    client = _get_client()
+    try:
+        resp = client.get("/api/videos", params={"url": url})
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        return None
+    body = resp.json()
+    if isinstance(body, dict):
+        body = body.get("videos") or body.get("items") or [body]
+    if not isinstance(body, list):
+        return None
+    for item in body:
+        if isinstance(item, dict) and item.get("url") == url:
+            return item
+    return None
+
+
 def get_popular_videos(
     collection_id: str, limit: int = 20, days: Optional[int] = None
 ) -> List[Dict[str, Any]]:

--- a/radbot/web/api/videos.py
+++ b/radbot/web/api/videos.py
@@ -1,0 +1,154 @@
+"""Kid-video REST endpoints for direct-action buttons in VideoCard.
+
+Thin wrappers over :mod:`radbot.tools.youtube.kideo_client` so the frontend
+can add a video to Kideo (and check library status) without a full LLM
+roundtrip — mirrors the casa/Overseerr setup in :mod:`radbot.web.api.media`.
+
+Endpoints:
+  * ``GET  /api/videos/collections``                — list Kideo collections
+  * ``GET  /api/videos/kideo-status?url=...``       — check Kideo status
+  * ``POST /api/videos/add-to-kideo``               — add a video to Kideo
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/videos", tags=["videos"])
+
+
+# ── Status mapping ───────────────────────────────────────────────────────
+# Kideo's per-video status strings → the four UI states VideoCard renders.
+_KIDEO_STATUS_MAP = {
+    "ready": "in_library",
+    "available": "in_library",
+    "downloaded": "in_library",
+    "queued": "queued",
+    "pending": "queued",
+    "downloading": "processing",
+    "transcoding": "processing",
+    "error": "error",
+    "failed": "error",
+}
+
+
+def _map_status(raw: Optional[str]) -> str:
+    return _KIDEO_STATUS_MAP.get((raw or "").lower(), "in_library")
+
+
+# ── Routes ───────────────────────────────────────────────────────────────
+
+
+@router.get("/collections")
+async def list_collections() -> Dict[str, Any]:
+    """List Kideo collections for the add-to-Kideo collection picker."""
+    from radbot.tools.youtube.kideo_client import list_collections
+
+    try:
+        collections = list_collections()
+    except Exception as e:
+        logger.error("Kideo list_collections failed: %s", e)
+        raise HTTPException(502, f"Kideo unreachable: {e}")
+    return {"collections": collections or []}
+
+
+@router.get("/kideo-status")
+async def get_kideo_status(url: str = Query(..., min_length=1)) -> Dict[str, Any]:
+    """Look up a video by URL and report its Kideo library status."""
+    from radbot.tools.youtube.kideo_client import find_video_by_url
+
+    try:
+        match = find_video_by_url(url)
+    except Exception as e:
+        logger.error("Kideo find_video_by_url failed: %s", e)
+        raise HTTPException(502, f"Kideo unreachable: {e}")
+    if not match:
+        return {"status": "not_added", "kideo_video_id": None}
+    return {
+        "status": _map_status(match.get("status")),
+        "kideo_video_id": match.get("id"),
+    }
+
+
+class AddToKideoBody(BaseModel):
+    url: str
+    collection_id: Optional[str] = None
+    generate_tags: bool = True
+
+
+def _is_youtube(url: str) -> bool:
+    return "youtube.com" in url or "youtu.be" in url
+
+
+def _extract_youtube_id(url: str) -> Optional[str]:
+    if "v=" in url:
+        return url.split("v=", 1)[1].split("&", 1)[0]
+    if "youtu.be/" in url:
+        return url.split("youtu.be/", 1)[1].split("?", 1)[0]
+    return None
+
+
+def _maybe_generate_tags(url: str, kideo_video_id: str) -> List[str]:
+    """Generate + apply educational tags for a YouTube video. Best-effort."""
+    if not _is_youtube(url):
+        return []
+    yt_id = _extract_youtube_id(url)
+    if not yt_id:
+        return []
+    try:
+        from radbot.tools.youtube.tag_generator import generate_tags_for_video
+        from radbot.tools.youtube.kideo_client import set_video_tags
+        from radbot.tools.youtube.youtube_client import get_video_details
+
+        details_list = get_video_details([yt_id])
+        if not details_list:
+            return []
+        details = details_list[0]
+        details["video_id"] = yt_id
+        tags = generate_tags_for_video(details)
+        if tags:
+            set_video_tags(kideo_video_id, tags)
+        return tags
+    except Exception as e:
+        logger.warning("Tag generation failed for %s: %s", url, e)
+        return []
+
+
+@router.post("/add-to-kideo")
+async def add_to_kideo(body: AddToKideoBody) -> Dict[str, Any]:
+    """Add a video to Kideo. Optionally generate + apply educational tags."""
+    if "/shorts/" in body.url:
+        raise HTTPException(
+            400, "YouTube Shorts are not allowed — only full-length videos"
+        )
+    from radbot.tools.youtube.kideo_client import add_video
+
+    try:
+        result = add_video(url=body.url, collection_id=body.collection_id)
+    except Exception as e:
+        logger.error("Kideo add_video failed: %s", e)
+        raise HTTPException(502, f"Kideo add failed: {e}")
+
+    kideo_video_id = result.get("id")
+    tags: List[str] = []
+    if body.generate_tags and kideo_video_id:
+        tags = _maybe_generate_tags(body.url, kideo_video_id)
+
+    return {
+        "status": _map_status(result.get("status")),
+        "kideo_video_id": kideo_video_id,
+        "title": result.get("title"),
+        "collection_id": body.collection_id,
+        "tags": tags,
+    }
+
+
+def register_videos_router(app):
+    app.include_router(router)
+    logger.debug("Videos router registered")

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -53,6 +53,7 @@ from radbot.web.api.health import router as health_router
 from radbot.web.api.alerts import router as alerts_router
 from radbot.web.api.notifications import router as notifications_router
 from radbot.web.api.media import router as media_router
+from radbot.web.api.videos import router as videos_router
 from radbot.web.api.ha import router as ha_router
 
 logger = logging.getLogger(__name__)
@@ -88,6 +89,7 @@ def create_app():
     app.include_router(terminal_router)
     app.include_router(notifications_router)
     app.include_router(media_router)
+    app.include_router(videos_router)
     app.include_router(ha_router)
     register_terminal_websocket(app)
     logger.debug("API routers registered during app initialization")

--- a/radbot/web/frontend/src/components/chat/AgentCards.tsx
+++ b/radbot/web/frontend/src/components/chat/AgentCards.tsx
@@ -744,3 +744,392 @@ export function HaDeviceCard({ d }: { d: HaDevice }) {
 // HandoffLine now lives in HandoffLine.tsx (uses the shared agent-registry
 // for colors/glyphs). Re-export its type here for any legacy imports.
 export type { HandoffInfo } from "@/components/chat/HandoffLine";
+
+// ─────────────────────────────────────────────────────────
+// VideoCard — kid-video recommendations from the kidsvid agent.
+// Mirrors MediaCard but for YouTube / CuriosityStream videos with
+// an ADD TO KIDEO direct-action button (POST /api/videos/add-to-kideo).
+// ─────────────────────────────────────────────────────────
+
+export type VideoStatus =
+  | "in_library"
+  | "queued"
+  | "processing"
+  | "error"
+  | "not_added";
+
+export interface VideoCardData {
+  title: string;
+  source: "youtube" | "curiositystream";
+  url: string;
+  status: VideoStatus;
+  subtitle?: string;
+  video_id?: string;
+  channel?: string;
+  duration_seconds?: number;
+  published_at?: string;
+  thumbnail_url?: string;
+  view_count?: number;
+  tags?: string[];
+  note?: string;
+  kideo_video_id?: string;
+}
+
+interface KideoCollection {
+  id: string;
+  name: string;
+  color?: string;
+  icon?: string;
+  video_count?: number;
+}
+
+function formatDuration(seconds?: number): string | null {
+  if (!seconds || seconds <= 0) return null;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${String(m).padStart(2, "0")}m`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatViews(views?: number): string | null {
+  if (!views || views <= 0) return null;
+  if (views >= 1_000_000)
+    return `${(views / 1_000_000).toFixed(views >= 10_000_000 ? 0 : 1)}M views`;
+  if (views >= 1_000)
+    return `${(views / 1_000).toFixed(views >= 10_000 ? 0 : 1)}K views`;
+  return `${views} views`;
+}
+
+function publishedYear(published?: string): string | null {
+  if (!published) return null;
+  const m = published.match(/^(\d{4})/);
+  return m ? m[1] : null;
+}
+
+function VideoStatusPill({ status }: { status: VideoStatus }) {
+  const map: Record<VideoStatus, { label: string; color: string }> = {
+    in_library: {
+      label: "IN LIBRARY",
+      color: "text-terminal-green border-terminal-green/40 bg-terminal-green/10",
+    },
+    queued: {
+      label: "QUEUED",
+      color: "text-terminal-amber border-terminal-amber/40 bg-terminal-amber/10",
+    },
+    processing: {
+      label: "PROCESSING",
+      color: "text-radbot-sunset border-radbot-sunset/40 bg-radbot-sunset/10",
+    },
+    error: {
+      label: "ERROR",
+      color: "text-terminal-red border-terminal-red/40 bg-terminal-red/10",
+    },
+    not_added: {
+      label: "NOT IN KIDEO",
+      color: "text-txt-secondary border-border bg-bg-tertiary",
+    },
+  };
+  const m = map[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold tracking-[0.12em] px-1.5 py-0.5 rounded-sm border",
+        m.color,
+      )}
+    >
+      <span className="w-1.5 h-1.5 rounded-full bg-current" aria-hidden />
+      {m.label}
+    </span>
+  );
+}
+
+function VideoThumbnail({ v }: { v: VideoCardData }) {
+  const accent = v.source === "curiositystream" ? "#66ccff" : "#ff66aa";
+  const [imgErr, setImgErr] = useState(false);
+  const hasImage = !!v.thumbnail_url && !imgErr;
+  const glyph = (v.title.trim()[0] || "?").toUpperCase();
+  const sourceBadge = v.source === "curiositystream" ? "CS" : "YT";
+  const duration = formatDuration(v.duration_seconds);
+
+  return (
+    <div
+      className="flex-none relative rounded-sm border border-border overflow-hidden"
+      style={{
+        width: 142,
+        height: 80,
+        background: hasImage
+          ? "#0e1419"
+          : `radial-gradient(ellipse at 30% 30%, ${accent}55, #121c2b 70%)`,
+        boxShadow: hasImage
+          ? `0 0 14px -6px ${accent}99`
+          : `inset 0 0 32px -6px ${accent}`,
+      }}
+    >
+      {hasImage && (
+        <img
+          src={v.thumbnail_url}
+          alt={v.title}
+          loading="lazy"
+          onError={() => setImgErr(true)}
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+      )}
+      {!hasImage && (
+        <div className="absolute inset-0 grid place-items-center">
+          <span
+            className="font-pixel text-[2rem] leading-none"
+            style={{ color: accent, textShadow: `0 0 12px ${accent}aa` }}
+          >
+            {glyph}
+          </span>
+        </div>
+      )}
+      <span
+        className="absolute top-1.5 left-1.5 font-mono text-[0.5rem] font-bold tracking-[0.14em] px-1 py-[1px] rounded-sm z-10"
+        style={{
+          background: `${accent}33`,
+          color: accent,
+          border: `1px solid ${accent}55`,
+          backdropFilter: hasImage ? "blur(4px)" : undefined,
+        }}
+      >
+        {sourceBadge}
+      </span>
+      {duration && (
+        <span
+          className="absolute bottom-1 right-1 font-mono text-[0.55rem] font-bold tracking-wider px-1 py-[1px] rounded-sm bg-black/70 text-white z-10"
+        >
+          {duration}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function VideoCard({ v }: { v: VideoCardData }) {
+  const sourceLabel = v.source === "curiositystream" ? "CURIOSITYSTREAM" : "YOUTUBE";
+  const year = publishedYear(v.published_at);
+  const views = formatViews(v.view_count);
+
+  return (
+    <div className="inline-flex align-top gap-3.5 p-3.5 mr-2 mb-2 bg-bg-secondary border border-border rounded-sm w-[480px] max-w-full">
+      <VideoThumbnail v={v} />
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        {/* Top badge row: source · year · channel */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="inline-flex items-center gap-1 font-mono text-[0.6rem] text-txt-secondary tracking-[0.12em] uppercase px-1 py-[1px] border border-border rounded-sm">
+            <Icon.play size={10} /> {sourceLabel}
+          </span>
+          {year && (
+            <span className="font-mono text-[0.6rem] text-txt-secondary/70 tracking-[0.1em]">
+              · {year}
+            </span>
+          )}
+          {v.channel && (
+            <span className="font-mono text-[0.6rem] text-txt-secondary tracking-[0.1em] truncate max-w-[180px]">
+              · {v.channel}
+            </span>
+          )}
+        </div>
+
+        {/* Title */}
+        <div className="text-[0.95rem] font-bold text-txt-primary leading-tight">
+          {v.title}
+        </div>
+        {v.subtitle && (
+          <div className="text-[0.72rem] text-txt-secondary -mt-1">{v.subtitle}</div>
+        )}
+
+        {/* Status + views row */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <VideoStatusPill status={v.status} />
+          {views && (
+            <span className="font-mono text-[0.6rem] text-txt-secondary tracking-[0.1em] uppercase">
+              {views}
+            </span>
+          )}
+        </div>
+
+        {/* Tags */}
+        {v.tags && v.tags.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap">
+            {v.tags.slice(0, 5).map((tag) => (
+              <span
+                key={tag}
+                className="font-mono text-[0.6rem] text-txt-secondary/80 tracking-[0.06em] px-1 py-[1px] rounded-sm border border-border/60 bg-bg-primary/40"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Note */}
+        {v.note && (
+          <div className="text-[0.7rem] text-txt-secondary/80 italic leading-snug">
+            {v.note}
+          </div>
+        )}
+
+        {/* Actions */}
+        <VideoActions v={v} />
+      </div>
+    </div>
+  );
+}
+
+function VideoActions({ v }: { v: VideoCardData }) {
+  const [status, setStatus] = useState<VideoStatus>(v.status);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [showPicker, setShowPicker] = useState(false);
+  const [collections, setCollections] = useState<KideoCollection[] | null>(null);
+  const [collectionsErr, setCollectionsErr] = useState<string | null>(null);
+  const inLibrary = status === "in_library";
+
+  const openYouTubeLabel =
+    v.source === "curiositystream" ? "OPEN ON CURIOSITYSTREAM" : "OPEN ON YOUTUBE";
+
+  const submit = async (collectionId: string | null) => {
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    setShowPicker(false);
+    try {
+      const res = await fetch("/api/videos/add-to-kideo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: v.url, collection_id: collectionId }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail || `${res.status} ${res.statusText}`);
+      }
+      const body = await res.json();
+      setStatus((body.status as VideoStatus) || "queued");
+    } catch (e: any) {
+      setErr(e.message || "Add failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openPicker = async () => {
+    setShowPicker(true);
+    if (collections !== null) return;
+    try {
+      const res = await fetch("/api/videos/collections");
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const body = await res.json();
+      setCollections(body.collections || []);
+    } catch (e: any) {
+      setCollectionsErr(e.message || "Couldn't load collections");
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-2 flex-wrap pt-1">
+        <button
+          onClick={inLibrary ? undefined : openPicker}
+          disabled={inLibrary || busy}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-sm",
+            "font-mono text-[0.65rem] font-bold tracking-[0.08em]",
+            "transition-all focus:outline-none focus:ring-1 focus:ring-accent-blue",
+            inLibrary
+              ? "bg-bg-tertiary text-txt-secondary/60 border border-border cursor-not-allowed"
+              : "text-bg-primary hover:brightness-110",
+          )}
+          style={
+            inLibrary
+              ? undefined
+              : {
+                  background: "#33FF33",
+                  border: "1px solid #33FF33",
+                }
+          }
+        >
+          <Icon.plus size={10} />
+          {busy
+            ? "ADDING…"
+            : inLibrary
+              ? "IN LIBRARY"
+              : status === "queued" || status === "processing"
+                ? "QUEUED"
+                : "ADD TO KIDEO"}
+        </button>
+
+        <a
+          href={v.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "inline-flex items-center gap-1 px-2.5 py-1 rounded-sm no-underline",
+            "font-mono text-[0.65rem] font-bold tracking-[0.08em]",
+            "text-txt-secondary border border-border bg-bg-tertiary",
+            "hover:text-txt-primary hover:border-txt-secondary transition-colors",
+            "focus:outline-none focus:ring-1 focus:ring-accent-blue",
+          )}
+        >
+          <Icon.play size={10} />
+          {openYouTubeLabel}
+        </a>
+
+        {err && (
+          <span className="font-mono text-[0.6rem] text-terminal-red">{err}</span>
+        )}
+      </div>
+
+      {showPicker && (
+        <div className="mt-2 p-2 bg-bg-primary/60 border border-border rounded-sm">
+          <div className="font-mono text-[0.6rem] text-txt-secondary tracking-[0.1em] uppercase mb-1.5">
+            Add to collection
+          </div>
+          {collections === null && !collectionsErr && (
+            <div className="font-mono text-[0.65rem] text-txt-secondary">
+              Loading…
+            </div>
+          )}
+          {collectionsErr && (
+            <div className="font-mono text-[0.65rem] text-terminal-red">
+              {collectionsErr}
+            </div>
+          )}
+          {collections && collections.length === 0 && (
+            <div className="font-mono text-[0.65rem] text-txt-secondary">
+              No collections yet — adding without one.
+            </div>
+          )}
+          {collections && (
+            <div className="flex items-center gap-1 flex-wrap">
+              <button
+                onClick={() => submit(null)}
+                className="font-mono text-[0.65rem] px-2 py-1 rounded-sm border border-border bg-bg-tertiary text-txt-secondary hover:text-txt-primary hover:border-txt-secondary transition-colors"
+              >
+                NO COLLECTION
+              </button>
+              {collections.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => submit(c.id)}
+                  className="font-mono text-[0.65rem] px-2 py-1 rounded-sm border border-border bg-bg-tertiary text-txt-secondary hover:text-txt-primary hover:border-txt-secondary transition-colors"
+                  style={c.color ? { color: c.color, borderColor: `${c.color}66` } : undefined}
+                >
+                  {c.name}
+                </button>
+              ))}
+              <button
+                onClick={() => setShowPicker(false)}
+                className="font-mono text-[0.6rem] px-1.5 py-1 text-txt-secondary/60 hover:text-txt-primary"
+              >
+                CANCEL
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/radbot/web/frontend/src/components/chat/ChatMessage.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatMessage.tsx
@@ -8,9 +8,11 @@ import {
   MediaCard,
   SeasonBreakdownCard,
   HaDeviceCard,
+  VideoCard,
   type MediaCardData,
   type SeasonBreakdownData,
   type HaDevice,
+  type VideoCardData,
 } from "@/components/chat/AgentCards";
 import HandoffLine, { type HandoffInfo } from "@/components/chat/HandoffLine";
 import InboxSummary, {
@@ -234,6 +236,8 @@ export default function ChatMessage({ message }: Props) {
                           return <SeasonBreakdownCard data={data as SeasonBreakdownData} />;
                         case "ha-device":
                           return <HaDeviceCard d={data as HaDevice} />;
+                        case "video":
+                          return <VideoCard v={data as VideoCardData} />;
                         case "handoff":
                           return <HandoffLine handoff={data as HandoffInfo} />;
                         case "inbox":

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -24,7 +24,7 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 
 - `scope_sub_agent_context_callback` (before-model callback on every sub-agent) trims LLM input to the *current user turn only*. Prevents context bleed (e.g. Casa volunteering movie cards because an earlier turn mentioned movies) and keeps sub-agent prompts from growing linearly with session length. Root Beto keeps full history for conversational coherence. See `radbot/callbacks/scope_to_current_turn.py`.
 - `/api/agents/agent-info` walks `root_agent.sub_agents` at runtime to return the live roster (name, config key, resolved model, gemini_only flag) — the frontend admin palette reads this instead of a hard-coded list.
-- Agents emit **structured UI cards** via fenced code blocks (`` ```radbot:<kind> ``). Casa ships `CARD_TOOLS` (`show_media_card`, `show_season_breakdown`, `show_ha_device_card`). Every `agent_transfer` event is also auto-wrapped as a `radbot:handoff` block by `session_runner.py` — no LLM call needed. See `radbot/tools/shared/card_protocol.py`.
+- Agents emit **structured UI cards** via fenced code blocks (`` ```radbot:<kind> ``). Casa ships `show_media_card`, `show_season_breakdown`, `show_ha_device_card`; kidsvid ships `show_video_card` (kid-video cards with ADD TO KIDEO button). Every `agent_transfer` event is also auto-wrapped as a `radbot:handoff` block by `session_runner.py` — no LLM call needed. See `radbot/tools/shared/card_protocol.py`.
 
 ## Agent Summary
 
@@ -36,7 +36,7 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 | **tracker** | `agent/tracker_agent/factory.py` | `resolve_agent_model("tracker_agent")` | 13 | Tasks, projects, webhooks |
 | **comms** | `agent/comms_agent/factory.py` | `resolve_agent_model("comms_agent")` | 12 | Email (Gmail), Jira |
 | **axel** | `agent/execution_agent/factory.py` | `config_manager.get_agent_model("axel_agent_model")` | 17+ MCP | Shell, files, code exec, Claude Code, Nomad, MCP |
-| **kidsvid** | `agent/youtube_agent/factory.py` | `resolve_agent_model("kidsvid_agent")` | 17 | Children's video curation (YouTube + CuriosityStream + Kideo) |
+| **kidsvid** | `agent/youtube_agent/factory.py` | `resolve_agent_model("kidsvid_agent")` | 18 | Children's video curation (YouTube + CuriosityStream + Kideo + video card) |
 | **scout** | `agent/research_agent/factory.py` | `config_manager.get_agent_model("scout_agent")` | 2 | Research, design collaboration (sequential thinking) |
 | **search_agent** | `tools/adk_builtin/search_tool.py` | Gemini 2+ (hardcoded) | 1 | Google Search grounding |
 | **code_execution_agent** | `tools/adk_builtin/code_execution_tool.py` | Gemini 2+ (hardcoded) | 0* | Python code execution |
@@ -66,10 +66,10 @@ Beto is a **pure orchestrator** — it holds only memory tools and routes reques
 | Overseerr | 4 | `radbot.tools.overseerr.OVERSEERR_TOOLS` |
 | Lidarr | 5 | `radbot.tools.lidarr.LIDARR_TOOLS` (`search_lidarr_artist`, `search_lidarr_album`, `add_lidarr_artist`, `add_lidarr_album`, `list_lidarr_quality_profiles`) |
 | Picnic | 12 | `radbot.tools.picnic.PICNIC_TOOLS` |
-| Card protocol | 3 | `radbot.tools.shared.card_protocol.CARD_TOOLS` (`show_media_card`, `show_season_breakdown`, `show_ha_device_card`) |
+| Card protocol | 3 | `radbot.tools.shared.card_protocol` (`show_media_card`, `show_season_breakdown`, `show_ha_device_card`) |
 | Memory | 2 | `create_agent_memory_tools("casa")` |
 
-Emits UI cards inline with replies. Casa is the only agent that currently ships `CARD_TOOLS`.
+Emits UI cards inline with replies. Casa ships the movie/TV/HA card tools; kidsvid ships `show_video_card` for kid-video cards.
 
 ### planner — Calendar, Scheduling, Reminders
 
@@ -120,6 +120,7 @@ Emits UI cards inline with replies. Casa is the only agent that currently ships 
 | CuriosityStream | 2 | `CURIOSITYSTREAM_TOOLS`: `search_curiositystream`, `list_curiositystream_categories` |
 | Kideo library | 10 | `KIDEO_TOOLS`: `add_video_to_kideo`, `add_videos_to_kideo_batch`, `list_kideo_collections`, `create_kideo_collection`, `generate_video_tags`, `set_kideo_video_tags`, `get_kideo_popular_videos`, `get_kideo_tag_stats`, `get_kideo_channel_stats`, `retag_untagged_kideo_videos` |
 | Memory | 2 | `create_agent_memory_tools("kidsvid")` |
+| Card protocol | 1 | `show_video_card` (from `radbot.tools.shared.card_protocol`) — emits `radbot:video` block rendered as `<VideoCard />` with ADD TO KIDEO button |
 
 YouTube Shorts are filtered out at ingest time in `kideo_tools.py` (both search and Kideo submission paths).
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -31,7 +31,7 @@ Non-tool services (TTS, STT, ntfy) expose REST endpoints only — they are not r
 | `tools/youtube/` (YouTube) | 3 | kidsvid | `search_youtube_videos`, `get_youtube_video_details`, `get_youtube_channel_info` |
 | `tools/youtube/` (CuriosityStream) | 2 | kidsvid | `search_curiositystream`, `list_curiositystream_categories` |
 | `tools/youtube/` (Kideo) | 10 | kidsvid | `add_video_to_kideo`, `add_videos_to_kideo_batch`, `list_kideo_collections`, `create_kideo_collection`, `generate_video_tags`, `set_kideo_video_tags`, `get_kideo_popular_videos`, `get_kideo_tag_stats`, `get_kideo_channel_stats`, `retag_untagged_kideo_videos` |
-| `tools/shared/card_protocol.py` (cards) | 3 | casa | `show_media_card`, `show_season_breakdown`, `show_ha_device_card` |
+| `tools/shared/card_protocol.py` (cards) | 4 | casa, kidsvid | `show_media_card`, `show_season_breakdown`, `show_ha_device_card`, `show_video_card` |
 | Axel execution tools | 4 | axel | `code_execution_tool`, `run_tests`, `validate_code`, `generate_documentation` |
 | `load_artifacts` (ADK) | 1 | axel | built-in |
 
@@ -289,13 +289,14 @@ Three client modules wired onto the kidsvid agent.
 
 Emits ` ```radbot:<kind> ` fenced JSON blocks the agent includes verbatim in its reply. Frontend parses into UI components.
 
-Valid kinds: `media`, `seasons`, `ha-device`, `handoff`.
+Valid kinds: `media`, `seasons`, `ha-device`, `handoff`, `video`.
 
 | Tool | Parameters | Notes |
 |------|-----------|-------|
 | `show_media_card` | `tmdb_id`, `media_type`, `title`, `year`, ... | Best-effort Overseerr poster lookup when `tmdb_id` + `media_type` known |
 | `show_season_breakdown` | `tmdb_id`, `title`, `seasons` (list) | Per-season progress/status |
 | `show_ha_device_card` | `entity_id`, `state`, `brightness_pct`, ... | Domain-inferred icon |
+| `show_video_card` | `title`, `source`, `url`, `video_id`, `channel`, `duration_seconds`, `thumbnail_url`, `tags`, `note`, ... | Kidsvid card. Auto-resolves Kideo library status via `kideo_client.find_video_by_url`. Direct-action ADD TO KIDEO button hits `/api/videos/add-to-kideo` |
 
 `handoff` blocks are emitted server-side, not by agents — `session_runner.py` wraps every `agent_transfer` event as a `radbot:handoff` block (reflexive/duplicate transfers filtered).
 

--- a/specs/web.md
+++ b/specs/web.md
@@ -81,6 +81,7 @@ All registered in `radbot/web/app.py` via `app.include_router()` / `register_*_r
 | `api/alerts.py` | `/api/alerts` | Alertmanager ingestion + policies |
 | `api/notifications.py` | `/api/notifications` | Unified notification feed (new 2026-04-11) |
 | `api/media.py` | `/api/media` | Direct Overseerr/TMDB actions — bypasses agent (new 2026-04-18) |
+| `api/videos.py` | `/api/videos` | Direct Kideo actions for kidsvid `<VideoCard />` — bypasses agent |
 | `api/ha.py` | `/api/ha` | Direct Home Assistant state + service — bypasses agent (new 2026-04-18) |
 | `api/terminal.py` | `/terminal` | Terminal PTY WebSocket + workspace REST |
 | `api/terminal_proxy.py` | (helper) | `WorkspaceProxy`: workspace worker lifecycle |
@@ -107,6 +108,16 @@ Frontend buttons on Casa-rendered UI cards hit these REST endpoints directly —
 |--------|------|---------|
 | `GET` | `/api/ha/state/{entity_id}` | Normalized `HaDevice` (domain-inferred icon, `brightness_pct`, state mapping) |
 | `POST` | `/api/ha/service` | `ha_client.call_service()`, returns fresh entity state |
+
+### Kideo videos (`/api/videos`) — `web/api/videos.py`
+
+Powers the ADD TO KIDEO button + library-status pill on kidsvid's `<VideoCard />`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/videos/collections` | Kideo collections for the picker dropdown |
+| `GET` | `/api/videos/kideo-status?url=X` | Library status for a video URL (`in_library` / `queued` / `processing` / `not_added`) |
+| `POST` | `/api/videos/add-to-kideo` | `{url, collection_id?, generate_tags?}` — adds + (best-effort) AI-tags YouTube videos |
 
 ## Per-Session Token Stats (2026-04-18)
 
@@ -191,5 +202,5 @@ Registered in `pages/AdminPage.tsx` via `NAV_ITEMS` + `PANEL_MAP`.
 
 ### Chat Components (post-refresh 2026-04-18)
 
-- `components/chat/AgentCards.tsx` — renders `MediaCard`, `SeasonBreakdownCard`, `HaDeviceCard`, `HandoffLine` (parses ` ```radbot:<kind> ` fenced blocks from message text)
+- `components/chat/AgentCards.tsx` — renders `MediaCard`, `SeasonBreakdownCard`, `HaDeviceCard`, `VideoCard`, `HandoffLine` (parses ` ```radbot:<kind> ` fenced blocks from message text). `<VideoCard />` is kidsvid's kid-video card with an ADD TO KIDEO direct-action button calling `/api/videos`.
 - Terminal refresh: mascot, stats footer, notifications drawer — see commit `9ebfb9f`


### PR DESCRIPTION
## Summary

Re-ships PR #10's **video card + ADD TO KIDEO button** feature. Same code surface; the one thing explicitly left out is PR #10's rewrite of \`kidsvid.md\`, which caused the "agent stalls before searching" regression we hit earlier today.

Two commits:

1. **\`9ee6806\`** — cherry-pick of the original PR #10 commit (\`4d9364c\`). All code, schema, API, React + spec updates land verbatim.
2. **\`61cbb3c\`** — revert the \`kidsvid.md\` portion of that cherry-pick, restoring the pre-PR-10 instruction. The \`show_video_card\` TOOL is still wired onto kidsvid (via the factory change in commit 1) — the LLM can choose to emit cards when it's confident in the metadata, but it's not forced to on every recommendation.

## What ships

- \`radbot/tools/shared/card_protocol.py\` — new \`video\` card kind, \`_lookup_kideo_status\` auto-resolver, \`show_video_card_tool\`
- \`radbot/tools/youtube/kideo_client.py\` — \`find_video_by_url\` for library-status auto-resolve
- \`radbot/web/api/videos.py\` — new router (\`/collections\`, \`/kideo-status\`, \`/add-to-kideo\`)
- \`radbot/web/app.py\` — router registration
- \`radbot/web/frontend/src/components/chat/AgentCards.tsx\` — \`<VideoCard />\` + \`<VideoActions />\` React components with inline collection picker
- \`radbot/web/frontend/src/components/chat/ChatMessage.tsx\` — routes \`radbot:video\` blocks to \`<VideoCard />\`
- \`radbot/agent/youtube_agent/factory.py\` — wire \`show_video_card_tool\` onto kidsvid
- Spec updates in \`specs/agents.md\`, \`specs/tools.md\`, \`specs/web.md\`

## What doesn't ship (delta vs. original PR #10)

- \`kidsvid.md\` rewrite — kept the pre-PR-10 wording. The new instruction had a "required arguments" list of 11 fields per video and explicit "convert YouTube ISO duration PT15M30S to seconds" guidance; in practice the LLM stalled on vague prompts instead of searching. The card tool stays optional from the LLM's perspective.

## Re-introducing the always-emit-card behavior later (if we want it)

Once this PR is stable, a follow-up can:
1. Pick 5-10 prompt shapes (vague + specific).
2. For each, confirm the model still triggers \`search_youtube_videos\` BEFORE \`show_video_card\`.
3. Layer card guidance in \`kidsvid.md\` conservatively (e.g. "emit a card when you already have title/url/channel from search output" — no complex format demands).

## Test plan

- [ ] Deploy. Ask kidsvid for a video recommendation. Search happens. Prose reply renders. Whether a card also renders depends on the model's choice — either is fine for this PR.
- [ ] Manual emit test: ask kidsvid directly "show me a card for \<a specific video URL\>". Confirm the \`radbot:video\` block renders as \`<VideoCard />\` with ADD TO KIDEO button.
- [ ] POST \`/api/videos/add-to-kideo\` flow: click the button in the UI, verify the video lands in Kideo and the pill flips to IN LIBRARY.
- [ ] No regression to kidsvid's 1-turn behavior on "search for crafting videos for paula".

🤖 Generated with [Claude Code](https://claude.com/claude-code)