### PR TITLE
fix(kidsvid): recommend via cards + always invite confirmation (not auto-add)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ env/
 Thumbs.db
 
 **/.claude/settings.local.json
+# Claude Code session worktrees (ephemeral, local-only)
+.claude/worktrees/
 .env*
 !.env.example
 !.env.docker

--- a/radbot/config/default_configs/instructions/kidsvid.md
+++ b/radbot/config/default_configs/instructions/kidsvid.md
@@ -173,25 +173,36 @@ CuriosityStream videos can be added to Kideo just like YouTube videos — use th
 
 You can add approved videos to **Kideo**, a curated offline video library where children watch content in a safe, ad-free player — no YouTube interface, no recommendations sidebar, no comments, no algorithmic rabbit holes.
 
-When the parent asks you to "add" or "save" videos, or when they approve your recommendations, use the Kideo tools:
+### Recommendation vs. adding — two distinct flows
+
+**Recommending (default):** when the parent asks you to search or find videos, present each recommendation as a **video card** via `show_video_card()`. Each card renders in the UI with a primary "ADD TO KIDEO" button so the parent can add any video they approve with one click. **Do NOT call `add_video_to_kideo` for recommendations** — leave the add-decision to the parent.
+
+**Adding (explicit only):** call `add_video_to_kideo()` / `add_videos_to_kideo_batch()` only when the parent has **explicitly asked you to add** videos (phrases like "add these", "save these to Kideo", "add them all", "add the first two"). When in doubt, recommend via cards and wait for explicit approval.
+
+### Tools
 
 - `list_kideo_collections()` — See existing collections (e.g. "Dinosaurs", "Space", "Art")
 - `create_kideo_collection(name, color, icon)` — Create a new collection for a topic or child
-- `add_video_to_kideo(url, collection_id)` — Add a single video to Kideo (returns kideo video_id)
-- `add_videos_to_kideo_batch(urls, collection_id)` — Add multiple videos at once (returns kideo video_ids)
+- `add_video_to_kideo(url, collection_id)` — Add a single video to Kideo (use only on explicit parent request)
+- `add_videos_to_kideo_batch(urls, collection_id)` — Add multiple videos at once (use only on explicit parent request)
 - `generate_video_tags(video_id, title, description, channel_title)` — Auto-generate educational tags using AI (pass the YouTube video ID)
 - `set_kideo_video_tags(video_id, tags)` — Apply tags to a video in Kideo (pass the Kideo UUID)
 
-**Workflow:**
-1. Search YouTube and curate your recommendations
-2. Present them to the parent with your assessment
-3. When the parent approves (or asks you to "add them"), submit to Kideo
-4. Always organize into collections — create a new collection if there isn't a suitable one
-5. Name collections descriptively ("Leon - Dinosaurs", "Science Experiments", "Bedtime Stories")
-6. **Always generate and apply tags** when adding videos:
-   - Call `generate_video_tags()` with the YouTube video ID, title, description, and channel
-   - Then call `set_kideo_video_tags()` with the Kideo video UUID and the generated tags
-   - Tags help with discovery and organization (e.g. "dinosaurs", "crafting", "outer space", "math")
+### Recommendation workflow
+
+1. Search YouTube + CuriosityStream and curate your picks
+2. For each, call `show_video_card()` and include the returned `block` string in your reply. The card carries title, URL, channel, duration, thumbnail, and a Kideo library-status pill. Parents click the card's button to add.
+3. Keep the surrounding prose concise — curriculum framing, sequencing, follow-up activities. The cards handle the per-video metadata.
+4. **Close with an invitation to confirm** — one short sentence like "Tap ADD TO KIDEO on any of these you'd like to save for Paula" or "Let me know if you'd like any of these added, or I can look for more." Never silently leave cards without an invitation to act — the parent should always feel asked.
+
+### Explicit-add workflow (only when parent asks)
+
+1. Confirm which videos: "add all of them", "add the first two", specific titles, etc.
+2. Always organize into collections — use `list_kideo_collections` and `create_kideo_collection` as needed.
+3. Call `add_video_to_kideo` / `add_videos_to_kideo_batch`.
+4. **Always generate and apply tags** after adding:
+   - `generate_video_tags()` with the YouTube video ID, title, description, and channel
+   - `set_kideo_video_tags()` with the Kideo video UUID and the generated tags
 
 Videos are downloaded and transcoded by Kideo, so they're available offline and the child never interacts with YouTube directly. This is a key part of the safety model.
 


### PR DESCRIPTION
## Summary

Instruction-only fix for kidsvid's Kideo flow. After PR #24 landed video cards, kidsvid started auto-calling \`add_video_to_kideo\` instead of presenting cards with the ADD TO KIDEO button for the parent to click. User noted: "it used to always ask if I wanted to add the videos it found" — the new behavior regressed that.

## What changed

Split the Kideo section in \`kidsvid.md\` into two clear flows:

**Recommending (default):** present each pick via \`show_video_card()\`. Do NOT call \`add_video_to_kideo\` for recommendations. Close with an explicit invitation to confirm — "tap ADD TO KIDEO on the ones you'd like" or similar. Never silently leave cards without inviting the parent to act.

**Adding (explicit only):** call \`add_video_to_kideo\` / \`add_videos_to_kideo_batch\` only when the parent uses phrases like "add these", "save these to Kideo", "add the first two". When in doubt, recommend and wait.

Tool list stays unchanged — only the instruction guidance around when to call each one.

## What this restores

Pre-PR #10 behavior was "ask-first" — kidsvid would present recommendations and wait for "yes please add those" before calling \`add_video_to_kideo\`. The cards are the modern replacement for that verbal ask: each card has an ADD TO KIDEO button, so the parent gets the same explicit-approval UX but with one-click convenience.

## Test plan

- [ ] Deploy. Ask "find crafting videos for paula". Expect: search → cards rendered → closing sentence inviting parent to tap ADD.
- [ ] Confirm no \`add_video_to_kideo\` tool call appears in the log during the recommendation turn.
- [ ] Then say "add the first two" explicitly. Expect \`add_video_to_kideo\` calls at that point, with tag generation + collection assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)