### PR TITLE
feat(telos): admin panel + REST API (Phase 2)

### DIFF
--- a/radbot/web/api/telos.py
+++ b/radbot/web/api/telos.py
@@ -1,0 +1,364 @@
+"""REST API for the Telos user-context store.
+
+Protected by the admin bearer token (same mechanism as `admin.py` and
+`alerts.py`). Drives both the onboarding wizard and the normal editor in
+the admin panel, and supports markdown import/export for power users.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+
+from radbot.tools.telos import db as telos_db
+from radbot.tools.telos.markdown_io import (
+    parse_telos_markdown,
+    render_telos_markdown,
+)
+from radbot.tools.telos.models import (
+    IDENTITY_REF,
+    REF_PREFIX,
+    SECTION_HEADERS,
+    STATUS_VALUES,
+    Entry,
+    Section,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/telos", tags=["telos"])
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _require_admin(request: Request) -> None:
+    expected = os.environ.get("RADBOT_ADMIN_TOKEN", "")
+    if not expected:
+        try:
+            from radbot.config.config_loader import config_loader
+
+            expected = config_loader.get_config().get("admin_token") or ""
+        except Exception:
+            pass
+    if not expected:
+        raise HTTPException(503, "Admin API disabled — RADBOT_ADMIN_TOKEN not set")
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer ") and auth[7:] == expected:
+        return
+    raise HTTPException(401, "Invalid or missing admin bearer token")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize(entry: Entry) -> Dict[str, Any]:
+    return {
+        "entry_id": entry.entry_id,
+        "section": entry.section.value,
+        "ref_code": entry.ref_code,
+        "content": entry.content,
+        "metadata": entry.metadata,
+        "status": entry.status,
+        "sort_order": entry.sort_order,
+        "created_at": entry.created_at.isoformat() if entry.created_at else None,
+        "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+    }
+
+
+def _parse_section(name: str) -> Section:
+    try:
+        return Section(name)
+    except ValueError:
+        valid = ", ".join(s.value for s in Section)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown section {name!r}. Valid: {valid}.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class EntryInput(BaseModel):
+    content: str
+    ref_code: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    status: str = "active"
+    sort_order: int = 0
+
+
+class EntryPatch(BaseModel):
+    content: Optional[str] = None
+    metadata_merge: Optional[Dict[str, Any]] = None
+    metadata_replace: Optional[Dict[str, Any]] = None
+    status: Optional[str] = None
+    sort_order: Optional[int] = None
+
+
+class ArchiveInput(BaseModel):
+    reason: Optional[str] = None
+
+
+class BulkEntryInput(BaseModel):
+    section: str
+    content: str
+    ref_code: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    status: str = "active"
+    sort_order: int = 0
+
+
+class BulkInput(BaseModel):
+    entries: List[BulkEntryInput]
+    replace: bool = False
+
+
+class ImportInput(BaseModel):
+    markdown: str
+    replace: bool = False
+
+
+class ResolvePredictionInput(BaseModel):
+    outcome: bool
+    actual_value: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/status")
+async def get_status(_auth: None = Depends(_require_admin)) -> Dict[str, Any]:
+    """One-shot onboarding status. Drives the wizard-vs-editor branch."""
+    return {
+        "has_identity": telos_db.has_identity(),
+    }
+
+
+@router.get("/sections")
+async def list_sections_meta(_auth: None = Depends(_require_admin)) -> Dict[str, Any]:
+    """Per-section active entry counts and headers, for UI summaries."""
+    grouped = telos_db.list_all_active()
+    out = []
+    for section in Section:
+        out.append(
+            {
+                "section": section.value,
+                "header": SECTION_HEADERS[section],
+                "has_ref_codes": section in REF_PREFIX,
+                "active_count": len(grouped.get(section, [])),
+            }
+        )
+    return {"sections": out}
+
+
+@router.get("/section/{section}")
+async def get_section(
+    section: str,
+    include_inactive: bool = False,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    sec = _parse_section(section)
+    order = "created_at_desc" if sec == Section.JOURNAL else "sort_order_asc"
+    status = None if include_inactive else "active"
+    entries = telos_db.list_section(sec, status=status, order_by=order)
+    return {
+        "section": sec.value,
+        "entries": [_serialize(e) for e in entries],
+    }
+
+
+@router.get("/entry/{section}/{ref_code}")
+async def get_entry(
+    section: str,
+    ref_code: str,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    sec = _parse_section(section)
+    entry = telos_db.get_entry(sec, ref_code)
+    if not entry:
+        raise HTTPException(404, f"No entry {ref_code} in {sec.value}.")
+    return _serialize(entry)
+
+
+@router.post("/entry/{section}", status_code=201)
+async def add_entry(
+    section: str,
+    body: EntryInput,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    sec = _parse_section(section)
+    if body.status not in STATUS_VALUES:
+        raise HTTPException(400, f"Invalid status {body.status!r}.")
+    entry = telos_db.add_entry(
+        sec,
+        body.content,
+        ref_code=body.ref_code or None,
+        metadata=body.metadata,
+        status=body.status,
+        sort_order=body.sort_order,
+    )
+    return _serialize(entry)
+
+
+@router.put("/entry/{section}/{ref_code}")
+async def update_entry(
+    section: str,
+    ref_code: str,
+    body: EntryPatch,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    sec = _parse_section(section)
+    if body.metadata_merge is not None and body.metadata_replace is not None:
+        raise HTTPException(
+            400, "Pass at most one of metadata_merge / metadata_replace."
+        )
+    if body.status is not None and body.status not in STATUS_VALUES:
+        raise HTTPException(400, f"Invalid status {body.status!r}.")
+    entry = telos_db.update_entry(
+        sec,
+        ref_code,
+        content=body.content,
+        metadata_merge=body.metadata_merge,
+        metadata_replace=body.metadata_replace,
+        status=body.status,
+        sort_order=body.sort_order,
+    )
+    if not entry:
+        raise HTTPException(404, f"No entry {ref_code} in {sec.value}.")
+    return _serialize(entry)
+
+
+@router.post("/archive/{section}/{ref_code}")
+async def archive_entry(
+    section: str,
+    ref_code: str,
+    body: ArchiveInput = Body(default_factory=ArchiveInput),
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    sec = _parse_section(section)
+    ok = telos_db.archive_entry(sec, ref_code, reason=body.reason)
+    if not ok:
+        raise HTTPException(404, f"No entry {ref_code} in {sec.value}.")
+    return {"status": "archived", "section": sec.value, "ref_code": ref_code}
+
+
+@router.post("/bulk")
+async def bulk_upsert(
+    body: BulkInput,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Atomic multi-section upsert. Used by the onboarding wizard to save
+    everything in one go. If `replace=True`, wipes all entries first."""
+    entries: List[Entry] = []
+    for item in body.entries:
+        try:
+            sec = Section(item.section)
+        except ValueError:
+            raise HTTPException(400, f"Unknown section {item.section!r}.")
+        if item.status not in STATUS_VALUES:
+            raise HTTPException(400, f"Invalid status {item.status!r}.")
+        entries.append(
+            Entry(
+                section=sec,
+                ref_code=item.ref_code,
+                content=item.content,
+                metadata=item.metadata or {},
+                status=item.status,
+                sort_order=item.sort_order,
+            )
+        )
+    if body.replace:
+        telos_db.reset_all()
+    rows = telos_db.bulk_upsert(entries)
+    return {
+        "status": "success",
+        "inserted_or_updated": len(rows),
+        "replaced": body.replace,
+    }
+
+
+@router.post("/import")
+async def import_markdown(
+    body: ImportInput,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Merge (or replace) Telos contents from canonical markdown."""
+    entries = parse_telos_markdown(body.markdown)
+    if not entries:
+        raise HTTPException(
+            400,
+            "Parsed zero entries — input may not be canonical Telos markdown.",
+        )
+    if body.replace:
+        telos_db.reset_all()
+    rows = telos_db.bulk_upsert(entries)
+    return {
+        "status": "success",
+        "imported": len(rows),
+        "replaced": body.replace,
+    }
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_markdown(_auth: None = Depends(_require_admin)) -> str:
+    entries = telos_db.list_all()
+    return render_telos_markdown(entries)
+
+
+@router.post("/resolve-prediction/{ref_code}")
+async def resolve_prediction(
+    ref_code: str,
+    body: ResolvePredictionInput,
+    _auth: None = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Resolve a prediction and auto-record a wrong_about entry on strong
+    miscalibration (confident and wrong, or dismissive and right)."""
+    existing = telos_db.get_entry(Section.PREDICTIONS, ref_code)
+    if not existing:
+        raise HTTPException(404, f"No prediction {ref_code}.")
+    prob = (existing.metadata or {}).get("probability")
+    meta = {
+        "resolution": "true" if body.outcome else "false",
+    }
+    if body.actual_value:
+        meta["actual_value"] = body.actual_value
+    updated = telos_db.update_entry(
+        Section.PREDICTIONS,
+        ref_code,
+        status="completed",
+        metadata_merge=meta,
+    )
+
+    miscalibrated = False
+    if isinstance(prob, (int, float)):
+        if (not body.outcome and prob >= 0.75) or (body.outcome and prob <= 0.25):
+            miscalibrated = True
+
+    if miscalibrated:
+        telos_db.add_entry(
+            Section.WRONG_ABOUT,
+            f"Miscalibrated on {ref_code}: predicted {prob:.0%} for "
+            f"{existing.content!r}; outcome was "
+            f"{'true' if body.outcome else 'false'}.",
+            metadata={"source_prediction": ref_code},
+        )
+
+    return {
+        "status": "success",
+        "entry": _serialize(updated) if updated else None,
+        "miscalibrated": miscalibrated,
+    }

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -55,6 +55,7 @@ from radbot.web.api.notifications import router as notifications_router
 from radbot.web.api.media import router as media_router
 from radbot.web.api.videos import router as videos_router
 from radbot.web.api.ha import router as ha_router
+from radbot.web.api.telos import router as telos_router
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,7 @@ def create_app():
     app.include_router(media_router)
     app.include_router(videos_router)
     app.include_router(ha_router)
+    app.include_router(telos_router)
     register_terminal_websocket(app)
     logger.debug("API routers registered during app initialization")
 

--- a/radbot/web/frontend/src/components/admin/panels/TelosPanel.tsx
+++ b/radbot/web/frontend/src/components/admin/panels/TelosPanel.tsx
@@ -1,0 +1,746 @@
+/** Telos admin panel — wizard for first-time onboarding, editor after. */
+
+import { useEffect, useMemo, useState } from "react";
+import { useAdminStore } from "@/stores/admin-store";
+import { Card, Note, FormInput, FormTextarea } from "@/components/admin/FormFields";
+import {
+  TelosEntry,
+  TelosStatus,
+  telosAddEntry,
+  telosArchive,
+  telosBulk,
+  telosExportMarkdown,
+  telosGetSection,
+  telosGetStatus,
+  telosImportMarkdown,
+  telosResolvePrediction,
+  telosUpdateEntry,
+  TelosBulkEntry,
+} from "@/lib/admin-api";
+import { cn } from "@/lib/utils";
+
+// Section order + display metadata for the editor.
+const SECTIONS: Array<{
+  key: string;
+  label: string;
+  single?: boolean;
+  prose?: boolean;
+  hint?: string;
+}> = [
+  { key: "identity", label: "Identity", single: true, prose: true, hint: "Who you are — one entry only." },
+  { key: "mission", label: "Mission", prose: true, hint: "What you want to put into the world." },
+  { key: "problems", label: "Problems", hint: "Big things you're trying to solve." },
+  { key: "narratives", label: "Narratives", hint: "How you describe yourself in a sentence or two." },
+  { key: "goals", label: "Goals", hint: "Concrete targets (deadline / KPI optional in metadata)." },
+  { key: "projects", label: "Projects", hint: "Current active work." },
+  { key: "challenges", label: "Challenges", hint: "What's actively blocking you." },
+  { key: "strategies", label: "Strategies", hint: "How you're tackling the problems." },
+  { key: "wisdom", label: "Wisdom", hint: "Principles you live by." },
+  { key: "ideas", label: "Ideas", hint: "Strong opinions / hot takes." },
+  { key: "predictions", label: "Predictions" },
+  { key: "wrong_about", label: "Wrong About", hint: "Things you got wrong — calibration history." },
+  { key: "best_books", label: "Best Books" },
+  { key: "best_movies", label: "Best Movies" },
+  { key: "best_music", label: "Best Music" },
+  { key: "taste", label: "Taste", hint: "Misc preferences (food, tools, games, …)." },
+  { key: "history", label: "History", prose: true, hint: "Background that shapes how you think." },
+  { key: "traumas", label: "Traumas", hint: "Sensitive — never auto-loaded; opt-in only." },
+  { key: "metrics", label: "Metrics", hint: "Long-lived KPIs you track over time." },
+  { key: "journal", label: "Recent Journal" },
+];
+
+// ── Top-level panel ─────────────────────────────────────────
+
+export function TelosPanel() {
+  const token = useAdminStore((s) => s.token);
+  const toast = useAdminStore((s) => s.toast);
+  const [status, setStatus] = useState<TelosStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const reload = async () => {
+    try {
+      const s = await telosGetStatus(token);
+      setStatus(s);
+    } catch (e: any) {
+      toast("Failed to load Telos: " + e.message, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  if (loading) {
+    return <div className="text-txt-secondary text-sm">Loading Telos…</div>;
+  }
+  if (!status) {
+    return <div className="text-terminal-red text-sm">Could not reach Telos API.</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-1">Telos</h2>
+      <p className="text-txt-secondary text-sm mb-5">
+        Persistent user-context store that beto reads every turn.
+      </p>
+      {status.has_identity ? (
+        <TelosEditor onReset={reload} />
+      ) : (
+        <TelosWizard
+          onComplete={async () => {
+            await reload();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Wizard (first-run onboarding) ───────────────────────────
+
+interface WizardData {
+  // Identity
+  name: string;
+  location: string;
+  role: string;
+  pronouns: string;
+  // Section lists: one item per line in each textarea
+  problems: string;
+  mission: string;
+  goals: string;
+  projects: string;
+  challenges: string;
+  wisdom: string;
+  bestBook: string;
+  bestMovie: string;
+  bestMusic: string;
+  history: string;
+}
+
+const EMPTY_WIZARD: WizardData = {
+  name: "", location: "", role: "", pronouns: "",
+  problems: "", mission: "", goals: "", projects: "",
+  challenges: "", wisdom: "",
+  bestBook: "", bestMovie: "", bestMusic: "",
+  history: "",
+};
+
+function TelosWizard({ onComplete }: { onComplete: () => void | Promise<void> }) {
+  const token = useAdminStore((s) => s.token);
+  const toast = useAdminStore((s) => s.toast);
+  const [step, setStep] = useState(0);
+  const [data, setData] = useState<WizardData>(EMPTY_WIZARD);
+  const [submitting, setSubmitting] = useState(false);
+
+  const steps = [
+    "Identity",
+    "Problems",
+    "Mission",
+    "Goals",
+    "Projects",
+    "Challenges",
+    "Wisdom",
+    "Taste",
+    "History",
+  ];
+  const total = steps.length;
+
+  const canProceed = step !== 0 || data.name.trim().length > 0;
+
+  const submit = async () => {
+    if (!data.name.trim()) {
+      toast("Name is required.", "error");
+      setStep(0);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const entries: TelosBulkEntry[] = [];
+
+      // Identity (singleton, ref_code = ME)
+      const identityBits = [data.name.trim()];
+      if (data.location.trim()) identityBits.push(`based in ${data.location.trim()}`);
+      if (data.role.trim()) identityBits.push(data.role.trim());
+      entries.push({
+        section: "identity",
+        ref_code: "ME",
+        content: identityBits.join(", "),
+        metadata: {
+          name: data.name.trim(),
+          location: data.location.trim() || undefined,
+          role: data.role.trim() || undefined,
+          pronouns: data.pronouns.trim() || undefined,
+        },
+      });
+
+      const addLines = (section: string, blob: string, prefix?: string) => {
+        const lines = blob.split(/\n+/).map((l) => l.trim()).filter(Boolean);
+        lines.forEach((content, i) => {
+          entries.push({
+            section,
+            content,
+            ref_code: prefix ? `${prefix}${i + 1}` : null,
+            sort_order: i,
+          });
+        });
+      };
+
+      if (data.mission.trim()) {
+        entries.push({ section: "mission", ref_code: "M1", content: data.mission.trim() });
+      }
+      addLines("problems", data.problems, "P");
+      addLines("goals", data.goals, "G");
+      addLines("projects", data.projects, "PRJ");
+      addLines("challenges", data.challenges, "C");
+      addLines("wisdom", data.wisdom);
+      if (data.bestBook.trim()) {
+        entries.push({
+          section: "best_books",
+          content: data.bestBook.trim(),
+          metadata: { sentiment: "love" },
+        });
+      }
+      if (data.bestMovie.trim()) {
+        entries.push({
+          section: "best_movies",
+          content: data.bestMovie.trim(),
+          metadata: { sentiment: "love" },
+        });
+      }
+      if (data.bestMusic.trim()) {
+        entries.push({
+          section: "best_music",
+          content: data.bestMusic.trim(),
+          metadata: { sentiment: "love" },
+        });
+      }
+      if (data.history.trim()) {
+        entries.push({ section: "history", content: data.history.trim() });
+      }
+
+      await telosBulk(token, entries, false);
+      toast(`Onboarded — saved ${entries.length} entries.`);
+      await onComplete();
+    } catch (e: any) {
+      toast("Onboarding failed: " + e.message, "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <Note>
+        One-time setup (~5 min). Each step is optional except Identity — skip
+        anything you'd rather let beto learn from conversations.
+      </Note>
+
+      <div className="flex items-center gap-2 mb-4 text-xs text-txt-secondary">
+        <span className="font-mono">Step {step + 1}/{total}</span>
+        <div className="flex-1 h-1 bg-bg-tertiary rounded-full overflow-hidden">
+          <div
+            className="h-full bg-radbot-sunset transition-all"
+            style={{ width: `${((step + 1) / total) * 100}%` }}
+          />
+        </div>
+        <span>{steps[step]}</span>
+      </div>
+
+      <Card title={steps[step]}>
+        {step === 0 && (
+          <>
+            <FormInput label="Name" value={data.name} onChange={(v) => setData({ ...data, name: v })} hint="Required — commits the onboarding sentinel so beto stops asking." />
+            <FormInput label="Location" value={data.location} onChange={(v) => setData({ ...data, location: v })} />
+            <FormInput label="Role / occupation" value={data.role} onChange={(v) => setData({ ...data, role: v })} />
+            <FormInput label="Pronouns (optional)" value={data.pronouns} onChange={(v) => setData({ ...data, pronouns: v })} />
+          </>
+        )}
+        {step === 1 && (
+          <FormTextarea label="Problems (one per line)" value={data.problems} onChange={(v) => setData({ ...data, problems: v })} placeholder="P1: ...\nP2: ..." />
+        )}
+        {step === 2 && (
+          <FormTextarea label="Mission" value={data.mission} onChange={(v) => setData({ ...data, mission: v })} placeholder="What you want to put into the world." />
+        )}
+        {step === 3 && (
+          <FormTextarea label="Goals (one per line)" value={data.goals} onChange={(v) => setData({ ...data, goals: v })} placeholder="Ship telos phase 2\nSleep 8h nightly" />
+        )}
+        {step === 4 && (
+          <FormTextarea label="Projects (one per line)" value={data.projects} onChange={(v) => setData({ ...data, projects: v })} />
+        )}
+        {step === 5 && (
+          <FormTextarea label="Challenges (one per line)" value={data.challenges} onChange={(v) => setData({ ...data, challenges: v })} />
+        )}
+        {step === 6 && (
+          <FormTextarea label="Wisdom / principles (one per line)" value={data.wisdom} onChange={(v) => setData({ ...data, wisdom: v })} />
+        )}
+        {step === 7 && (
+          <>
+            <FormInput label="Best book" value={data.bestBook} onChange={(v) => setData({ ...data, bestBook: v })} />
+            <FormInput label="Best movie" value={data.bestMovie} onChange={(v) => setData({ ...data, bestMovie: v })} />
+            <FormInput label="Best music / album / artist" value={data.bestMusic} onChange={(v) => setData({ ...data, bestMusic: v })} />
+          </>
+        )}
+        {step === 8 && (
+          <FormTextarea label="History (optional prose)" value={data.history} onChange={(v) => setData({ ...data, history: v })} large placeholder="Anything about your background that shapes how you think." />
+        )}
+      </Card>
+
+      <div className="flex items-center gap-2 mt-3">
+        <button
+          disabled={step === 0}
+          onClick={() => setStep(step - 1)}
+          className="px-3 py-2 border border-border rounded-md text-sm bg-bg-tertiary hover:border-radbot-sunset disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        >
+          Back
+        </button>
+        {step < total - 1 && (
+          <button
+            disabled={!canProceed}
+            onClick={() => setStep(step + 1)}
+            className="px-3 py-2 border border-border rounded-md text-sm bg-bg-tertiary hover:border-radbot-sunset disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+          >
+            Next
+          </button>
+        )}
+        <div className="flex-1" />
+        <button
+          disabled={submitting || !data.name.trim()}
+          onClick={submit}
+          className="px-4 py-2 bg-radbot-sunset text-bg-primary rounded-md text-sm font-medium hover:bg-radbot-sunset/80 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {submitting ? "Saving…" : "Finish & Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Editor (post-onboarding) ────────────────────────────────
+
+function TelosEditor({ onReset }: { onReset: () => void }) {
+  const token = useAdminStore((s) => s.token);
+  const toast = useAdminStore((s) => s.toast);
+  const [activeSection, setActiveSection] = useState<string>("identity");
+  const [entries, setEntries] = useState<TelosEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+
+  const activeMeta = useMemo(
+    () => SECTIONS.find((s) => s.key === activeSection)!,
+    [activeSection],
+  );
+
+  const loadSection = async (key: string) => {
+    setLoading(true);
+    try {
+      const res = await telosGetSection(token, key, false);
+      setEntries(res.entries);
+    } catch (e: any) {
+      toast("Load failed: " + e.message, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSection(activeSection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSection, token]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-xs text-txt-secondary">
+          Identity present — beto has your Telos.
+        </div>
+        <button
+          onClick={() => setShowImport((v) => !v)}
+          className="px-3 py-1.5 border border-border rounded-md text-xs bg-bg-tertiary hover:border-radbot-sunset cursor-pointer"
+        >
+          {showImport ? "Hide Import / Export" : "Import / Export markdown"}
+        </button>
+      </div>
+
+      {showImport && <ImportExportCard />}
+
+      <div className="grid grid-cols-[180px_1fr] gap-4">
+        <div className="bg-bg-secondary border border-border rounded-md overflow-hidden self-start">
+          {SECTIONS.map((s) => (
+            <button
+              key={s.key}
+              onClick={() => setActiveSection(s.key)}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-sm border-l-[3px] border-transparent",
+                "hover:bg-bg-tertiary",
+                activeSection === s.key && "bg-bg-tertiary border-l-radbot-sunset text-txt-primary",
+                activeSection !== s.key && "text-txt-secondary",
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        <div>
+          <SectionEditor
+            sectionMeta={activeMeta}
+            entries={entries}
+            loading={loading}
+            onReload={() => loadSection(activeSection)}
+          />
+        </div>
+      </div>
+
+      <div className="mt-6 pt-3 border-t border-border text-xs text-txt-secondary">
+        Raw reset only available via CLI: <code className="font-mono text-[0.72rem]">python -m radbot.tools.telos.cli reset</code> in the container.
+        <button
+          onClick={onReset}
+          className="ml-3 underline hover:text-radbot-sunset cursor-pointer"
+        >
+          Refresh status
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Section editor ──────────────────────────────────────────
+
+function SectionEditor({
+  sectionMeta,
+  entries,
+  loading,
+  onReload,
+}: {
+  sectionMeta: (typeof SECTIONS)[number];
+  entries: TelosEntry[];
+  loading: boolean;
+  onReload: () => void;
+}) {
+  const token = useAdminStore((s) => s.token);
+  const toast = useAdminStore((s) => s.toast);
+  const [adding, setAdding] = useState(false);
+  const [newContent, setNewContent] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+
+  const isIdentity = sectionMeta.key === "identity";
+  const identityEntry = isIdentity ? entries[0] : null;
+
+  const doAdd = async () => {
+    if (!newContent.trim()) return;
+    try {
+      await telosAddEntry(token, sectionMeta.key, { content: newContent.trim() });
+      toast(`Added to ${sectionMeta.label}.`);
+      setNewContent("");
+      setAdding(false);
+      onReload();
+    } catch (e: any) {
+      toast("Add failed: " + e.message, "error");
+    }
+  };
+
+  const doUpsertIdentity = async () => {
+    if (!newContent.trim()) return;
+    try {
+      await telosAddEntry(token, "identity", {
+        content: newContent.trim(),
+        ref_code: "ME",
+      });
+      toast("Identity saved.");
+      setNewContent("");
+      onReload();
+    } catch (e: any) {
+      toast("Save failed: " + e.message, "error");
+    }
+  };
+
+  const doUpdate = async (section: string, refCode: string) => {
+    try {
+      await telosUpdateEntry(token, section, refCode, { content: editContent });
+      toast("Updated.");
+      setEditingId(null);
+      onReload();
+    } catch (e: any) {
+      toast("Update failed: " + e.message, "error");
+    }
+  };
+
+  const doArchive = async (section: string, refCode: string) => {
+    if (!confirm(`Archive ${section}:${refCode}?`)) return;
+    try {
+      await telosArchive(token, section, refCode);
+      toast("Archived.");
+      onReload();
+    } catch (e: any) {
+      toast("Archive failed: " + e.message, "error");
+    }
+  };
+
+  const doResolvePrediction = async (refCode: string, outcome: boolean) => {
+    try {
+      const res = await telosResolvePrediction(token, refCode, outcome);
+      toast(
+        res.miscalibrated
+          ? "Resolved (miscalibrated — added to wrong_about)."
+          : "Resolved.",
+      );
+      onReload();
+    } catch (e: any) {
+      toast("Resolve failed: " + e.message, "error");
+    }
+  };
+
+  return (
+    <Card title={sectionMeta.label}>
+      {sectionMeta.hint && (
+        <div className="text-[0.72rem] text-txt-secondary/60 mb-3">{sectionMeta.hint}</div>
+      )}
+
+      {loading && <div className="text-sm text-txt-secondary">Loading…</div>}
+
+      {!loading && isIdentity && (
+        <div>
+          {identityEntry ? (
+            <>
+              <div className="text-sm text-txt-primary whitespace-pre-wrap mb-3 p-3 bg-bg-tertiary rounded-md border border-border">
+                {identityEntry.content}
+              </div>
+              <FormTextarea
+                label="Replace identity content"
+                value={newContent}
+                onChange={setNewContent}
+                placeholder={identityEntry.content}
+              />
+              <button
+                onClick={doUpsertIdentity}
+                disabled={!newContent.trim()}
+                className="px-3 py-1.5 bg-radbot-sunset text-bg-primary rounded-md text-sm font-medium hover:bg-radbot-sunset/80 disabled:opacity-40 cursor-pointer"
+              >
+                Save
+              </button>
+            </>
+          ) : (
+            <div className="text-sm text-txt-secondary">No identity yet — onboarding should have caught this.</div>
+          )}
+        </div>
+      )}
+
+      {!loading && !isIdentity && (
+        <>
+          {entries.length === 0 && (
+            <div className="text-sm text-txt-secondary/60 italic mb-3">No entries yet.</div>
+          )}
+
+          <div className="flex flex-col gap-2 mb-4">
+            {entries.map((e) => (
+              <div
+                key={e.entry_id}
+                className="flex items-start gap-2 p-2 bg-bg-tertiary rounded-md border border-border"
+              >
+                {e.ref_code && (
+                  <span className="font-mono text-[0.7rem] text-radbot-sunset flex-shrink-0 pt-0.5">
+                    {e.ref_code}
+                  </span>
+                )}
+                <div className="flex-1 min-w-0">
+                  {editingId === e.entry_id ? (
+                    <textarea
+                      value={editContent}
+                      onChange={(ev) => setEditContent(ev.target.value)}
+                      className="w-full p-1.5 bg-bg-primary border border-border rounded-md text-sm font-mono resize-y"
+                      rows={3}
+                      autoFocus
+                    />
+                  ) : (
+                    <div className="text-sm text-txt-primary break-words whitespace-pre-wrap">
+                      {e.content}
+                    </div>
+                  )}
+                  {e.metadata && Object.keys(e.metadata).length > 0 && (
+                    <div className="text-[0.7rem] text-txt-secondary/60 mt-1 font-mono">
+                      {Object.entries(e.metadata)
+                        .filter(([, v]) => v !== null && v !== undefined && v !== "")
+                        .map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : v}`)
+                        .join("  ·  ")}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col gap-1 flex-shrink-0">
+                  {editingId === e.entry_id ? (
+                    <>
+                      <button
+                        onClick={() => e.ref_code && doUpdate(e.section, e.ref_code)}
+                        className="px-2 py-0.5 text-[0.7rem] border border-terminal-green/50 text-terminal-green rounded hover:bg-terminal-green/10 cursor-pointer"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="px-2 py-0.5 text-[0.7rem] border border-border text-txt-secondary rounded hover:border-radbot-sunset cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      {e.ref_code && (
+                        <button
+                          onClick={() => {
+                            setEditingId(e.entry_id);
+                            setEditContent(e.content);
+                          }}
+                          className="px-2 py-0.5 text-[0.7rem] border border-border text-txt-secondary rounded hover:border-radbot-sunset cursor-pointer"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {e.ref_code && sectionMeta.key === "predictions" && e.status === "active" && (
+                        <>
+                          <button
+                            onClick={() => doResolvePrediction(e.ref_code!, true)}
+                            className="px-2 py-0.5 text-[0.7rem] border border-terminal-green/50 text-terminal-green rounded hover:bg-terminal-green/10 cursor-pointer"
+                          >
+                            True
+                          </button>
+                          <button
+                            onClick={() => doResolvePrediction(e.ref_code!, false)}
+                            className="px-2 py-0.5 text-[0.7rem] border border-terminal-red/50 text-terminal-red rounded hover:bg-terminal-red/10 cursor-pointer"
+                          >
+                            False
+                          </button>
+                        </>
+                      )}
+                      {e.ref_code && (
+                        <button
+                          onClick={() => doArchive(e.section, e.ref_code!)}
+                          className="px-2 py-0.5 text-[0.7rem] border border-border text-txt-secondary rounded hover:border-terminal-red hover:text-terminal-red cursor-pointer"
+                        >
+                          Archive
+                        </button>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {adding ? (
+            <div>
+              <FormTextarea
+                label={`New ${sectionMeta.label.toLowerCase()} entry`}
+                value={newContent}
+                onChange={setNewContent}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={doAdd}
+                  disabled={!newContent.trim()}
+                  className="px-3 py-1.5 bg-radbot-sunset text-bg-primary rounded-md text-sm font-medium hover:bg-radbot-sunset/80 disabled:opacity-40 cursor-pointer"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => { setAdding(false); setNewContent(""); }}
+                  className="px-3 py-1.5 border border-border rounded-md text-sm hover:border-radbot-sunset cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setAdding(true)}
+              className="px-3 py-1.5 border border-border rounded-md text-sm bg-bg-tertiary hover:border-radbot-sunset cursor-pointer"
+            >
+              + Add entry
+            </button>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}
+
+// ── Markdown import / export ────────────────────────────────
+
+function ImportExportCard() {
+  const token = useAdminStore((s) => s.token);
+  const toast = useAdminStore((s) => s.toast);
+  const [markdown, setMarkdown] = useState("");
+  const [replace, setReplace] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const doExport = async () => {
+    setBusy(true);
+    try {
+      const md = await telosExportMarkdown(token);
+      setMarkdown(md);
+      toast("Exported current Telos to the textarea.");
+    } catch (e: any) {
+      toast("Export failed: " + e.message, "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doImport = async () => {
+    if (!markdown.trim()) {
+      toast("Nothing to import.", "error");
+      return;
+    }
+    if (replace && !confirm("This will DELETE all existing Telos entries before importing. Continue?")) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await telosImportMarkdown(token, markdown, replace);
+      toast(`Imported ${res.imported} entries.`);
+    } catch (e: any) {
+      toast("Import failed: " + e.message, "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card title="Import / Export markdown">
+      <Note>
+        Canonical Telos markdown (`## IDENTITY`, `## PROBLEMS`, …). Export first
+        to see the current format, edit, then import back. "Replace" wipes all
+        entries before importing — leave off to merge.
+      </Note>
+      <FormTextarea
+        label="Markdown"
+        value={markdown}
+        onChange={setMarkdown}
+        large
+        placeholder="# TELOS\n\n## IDENTITY\n..."
+      />
+      <div className="flex items-center gap-2">
+        <button
+          onClick={doExport}
+          disabled={busy}
+          className="px-3 py-1.5 border border-border rounded-md text-sm bg-bg-tertiary hover:border-radbot-sunset disabled:opacity-40 cursor-pointer"
+        >
+          Export current
+        </button>
+        <button
+          onClick={doImport}
+          disabled={busy || !markdown.trim()}
+          className="px-3 py-1.5 bg-radbot-sunset text-bg-primary rounded-md text-sm font-medium hover:bg-radbot-sunset/80 disabled:opacity-40 cursor-pointer"
+        >
+          Import
+        </button>
+        <label className="flex items-center gap-1.5 text-xs text-txt-secondary cursor-pointer ml-2">
+          <input type="checkbox" checked={replace} onChange={(e) => setReplace(e.target.checked)} />
+          replace all (danger)
+        </label>
+      </div>
+    </Card>
+  );
+}

--- a/radbot/web/frontend/src/lib/admin-api.ts
+++ b/radbot/web/frontend/src/lib/admin-api.ts
@@ -163,3 +163,125 @@ export async function getSessionUsage(token: string): Promise<SessionUsageStats>
 export async function getGmailAccounts(token: string): Promise<{ accounts: any[]; error?: string }> {
   return adminFetch("/admin/api/gmail/accounts", { token });
 }
+
+// ── Telos ────────────────────────────────────────────────
+export interface TelosEntry {
+  entry_id: string;
+  section: string;
+  ref_code: string | null;
+  content: string;
+  metadata: Record<string, any>;
+  status: string;
+  sort_order: number;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface TelosStatus {
+  has_identity: boolean;
+}
+
+export interface TelosBulkEntry {
+  section: string;
+  content: string;
+  ref_code?: string | null;
+  metadata?: Record<string, any>;
+  status?: string;
+  sort_order?: number;
+}
+
+export async function telosGetStatus(token: string): Promise<TelosStatus> {
+  return adminFetch("/api/telos/status", { token });
+}
+
+export async function telosGetSection(
+  token: string,
+  section: string,
+  includeInactive = false,
+): Promise<{ section: string; entries: TelosEntry[] }> {
+  const qs = includeInactive ? "?include_inactive=true" : "";
+  return adminFetch(`/api/telos/section/${encodeURIComponent(section)}${qs}`, { token });
+}
+
+export async function telosAddEntry(
+  token: string,
+  section: string,
+  body: { content: string; ref_code?: string | null; metadata?: Record<string, any>; status?: string; sort_order?: number },
+): Promise<TelosEntry> {
+  return adminFetch(`/api/telos/entry/${encodeURIComponent(section)}`, {
+    token,
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function telosUpdateEntry(
+  token: string,
+  section: string,
+  refCode: string,
+  patch: { content?: string; metadata_merge?: Record<string, any>; metadata_replace?: Record<string, any>; status?: string; sort_order?: number },
+): Promise<TelosEntry> {
+  return adminFetch(`/api/telos/entry/${encodeURIComponent(section)}/${encodeURIComponent(refCode)}`, {
+    token,
+    method: "PUT",
+    body: JSON.stringify(patch),
+  });
+}
+
+export async function telosArchive(
+  token: string,
+  section: string,
+  refCode: string,
+  reason?: string,
+): Promise<{ status: string }> {
+  return adminFetch(`/api/telos/archive/${encodeURIComponent(section)}/${encodeURIComponent(refCode)}`, {
+    token,
+    method: "POST",
+    body: JSON.stringify({ reason: reason ?? null }),
+  });
+}
+
+export async function telosBulk(
+  token: string,
+  entries: TelosBulkEntry[],
+  replace = false,
+): Promise<{ status: string; inserted_or_updated: number; replaced: boolean }> {
+  return adminFetch("/api/telos/bulk", {
+    token,
+    method: "POST",
+    body: JSON.stringify({ entries, replace }),
+  });
+}
+
+export async function telosImportMarkdown(
+  token: string,
+  markdown: string,
+  replace = false,
+): Promise<{ status: string; imported: number; replaced: boolean }> {
+  return adminFetch("/api/telos/import", {
+    token,
+    method: "POST",
+    body: JSON.stringify({ markdown, replace }),
+  });
+}
+
+export async function telosExportMarkdown(token: string): Promise<string> {
+  const res = await fetch("/api/telos/export", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.text();
+}
+
+export async function telosResolvePrediction(
+  token: string,
+  refCode: string,
+  outcome: boolean,
+  actualValue?: string,
+): Promise<{ status: string; miscalibrated: boolean; entry: TelosEntry | null }> {
+  return adminFetch(`/api/telos/resolve-prediction/${encodeURIComponent(refCode)}`, {
+    token,
+    method: "POST",
+    body: JSON.stringify({ outcome, actual_value: actualValue ?? null }),
+  });
+}

--- a/radbot/web/frontend/src/pages/AdminPage.tsx
+++ b/radbot/web/frontend/src/pages/AdminPage.tsx
@@ -16,6 +16,7 @@ import { MCPServersPanel } from "@/components/admin/panels/MCPPanel";
 import { CredentialsPanel } from "@/components/admin/panels/CredentialsPanel";
 import { RawConfigPanel } from "@/components/admin/panels/RawConfigPanel";
 import { CostTrackingPanel } from "@/components/admin/panels/TelemetryPanels";
+import { TelosPanel } from "@/components/admin/panels/TelosPanel";
 
 // ── Navigation definition ──────────────────────────────────
 interface NavItem {
@@ -32,6 +33,8 @@ const NAV_ITEMS: NavItem[] = [
   { id: "web_server", label: "Web Server", group: "Core" },
   { id: "logging", label: "Logging", group: "Core" },
   { id: "cost_tracking", label: "Cost Tracking", group: "Core" },
+  // Personal
+  { id: "telos", label: "Telos", group: "Personal" },
   // Connections
   { id: "gmail", label: "Gmail", group: "Connections", statusKey: "gmail" },
   { id: "calendar", label: "Calendar", group: "Connections", statusKey: "calendar" },
@@ -74,6 +77,7 @@ const PANEL_MAP: Record<string, React.ComponentType> = {
   web_server: WebServerPanel,
   logging: LoggingPanel,
   cost_tracking: CostTrackingPanel,
+  telos: TelosPanel,
   gmail: GmailPanel,
   calendar: CalendarPanel,
   jira: JiraPanel,

--- a/specs/web.md
+++ b/specs/web.md
@@ -83,6 +83,7 @@ All registered in `radbot/web/app.py` via `app.include_router()` / `register_*_r
 | `api/media.py` | `/api/media` | Direct Overseerr/TMDB actions — bypasses agent (new 2026-04-18) |
 | `api/videos.py` | `/api/videos` | Direct Kideo actions for kidsvid `<VideoCard />` — bypasses agent |
 | `api/ha.py` | `/api/ha` | Direct Home Assistant state + service — bypasses agent (new 2026-04-18) |
+| `api/telos.py` | `/api/telos` | Telos user-context store — admin-token-protected CRUD + bulk + markdown import/export + prediction resolve |
 | `api/terminal.py` | `/terminal` | Terminal PTY WebSocket + workspace REST |
 | `api/terminal_proxy.py` | (helper) | `WorkspaceProxy`: workspace worker lifecycle |
 | `api/tts.py` | `/api/tts` | Text-to-speech |
@@ -101,6 +102,24 @@ Frontend buttons on Casa-rendered UI cards hit these REST endpoints directly —
 | `GET` | `/api/media/search?query=X` | `MediaCardData[]` with TMDB `poster_url` (max 15 results) |
 | `GET` | `/api/media/{tmdb_id}?media_type=movie\|tv` | Enriched detail (seasons, on-server fractions, content_rating) |
 | `POST` | `/api/media/request` | Wraps Overseerr `create_request` — auto-fills all seasons for TV |
+
+### Telos (`/api/telos`) — `web/api/telos.py`
+
+All endpoints require the admin bearer token (same as `/admin/api/*`). Drives the `TelosPanel` admin UI and supports power-user markdown import/export.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/telos/status` | `{has_identity}` — wizard-vs-editor branch |
+| `GET` | `/api/telos/sections` | Per-section active-entry counts + headers |
+| `GET` | `/api/telos/section/{section}?include_inactive=false` | Entries in a section |
+| `GET` | `/api/telos/entry/{section}/{ref_code}` | Single entry |
+| `POST` | `/api/telos/entry/{section}` | Add entry (body: `{content, ref_code?, metadata?, status?, sort_order?}`) |
+| `PUT` | `/api/telos/entry/{section}/{ref_code}` | Patch entry (body: `{content?, metadata_merge?, metadata_replace?, status?, sort_order?}`) |
+| `POST` | `/api/telos/archive/{section}/{ref_code}` | Soft delete (body: `{reason?}`) |
+| `POST` | `/api/telos/bulk` | Atomic multi-section upsert — used by the onboarding wizard (body: `{entries, replace?}`) |
+| `POST` | `/api/telos/import` | Merge-or-replace from canonical Telos markdown (body: `{markdown, replace?}`) |
+| `GET` | `/api/telos/export` | Current Telos as canonical markdown (text/plain) |
+| `POST` | `/api/telos/resolve-prediction/{ref_code}` | Resolve a prediction; auto-adds `wrong_about` on miscalibration (body: `{outcome, actual_value?}`) |
 
 ### Home Assistant (`/api/ha`) — `web/api/ha.py`
 
@@ -194,6 +213,7 @@ Flat panel structure (no more grouping superclasses).
 | `DeveloperPanels.tsx` | `GitHubAppPanel`, `ClaudeCodePanel` |
 | `InfrastructurePanels.tsx` | `PostgresqlPanel`, `QdrantPanel` |
 | `TelemetryPanels.tsx` | `CostTrackingPanel` |
+| `TelosPanel.tsx` | `TelosPanel` (wizard for fresh install, editor after — per-section nav, add/edit/archive, prediction resolve, markdown import/export) |
 | `MCPPanel.tsx` | `MCPServersPanel` |
 | `CredentialsPanel.tsx` | `CredentialsPanel` |
 | `RawConfigPanel.tsx` | `RawConfigPanel` |


### PR DESCRIPTION
## Summary

Phase 2 of Telos: admin panel + REST API so the persona/context store beto already reads every turn can be edited from `/admin/` → Telos. No more shelling into the Nomad container for a 9-question setup.

Branches on `GET /api/telos/status`: wizard mode for fresh installs (9-step guided flow → single bulk POST), editor mode after (per-section list with add/edit/archive, prediction resolve, markdown import/export).

## What's in it

**REST API** — `radbot/web/api/telos.py`, admin-token protected (same auth as `/admin/api/*` and `/api/alerts/*`).

| Method | Path |
|---|---|
| GET | `/api/telos/status` |
| GET | `/api/telos/sections` |
| GET | `/api/telos/section/{section}?include_inactive=` |
| GET | `/api/telos/entry/{section}/{ref_code}` |
| POST | `/api/telos/entry/{section}` |
| PUT | `/api/telos/entry/{section}/{ref_code}` |
| POST | `/api/telos/archive/{section}/{ref_code}` |
| POST | `/api/telos/bulk` *(wizard submit)* |
| POST | `/api/telos/import` *(markdown merge / replace)* |
| GET | `/api/telos/export` *(canonical Telos markdown)* |
| POST | `/api/telos/resolve-prediction/{ref_code}` *(auto-logs wrong_about on miscalibration)* |

**Frontend** — `radbot/web/frontend/src/components/admin/panels/TelosPanel.tsx`:

- Top-level `TelosPanel` polls `/api/telos/status` and routes to `TelosWizard` (empty DB) or `TelosEditor`.
- `TelosWizard`: 9 steps, single `telosBulk` submit. Identity is required (it's the onboarding sentinel); everything else is skip-friendly.
- `TelosEditor`: left sidebar over all sections, main pane shows entries with add / inline edit / archive. Identity is treated as a singleton (upsert not list).
- Predictions render True / False resolve buttons that call `resolve-prediction` and toast when miscalibration is detected.
- `ImportExportCard`: paste markdown in, paste exported markdown out, optional `replace all` with a confirm prompt.

**Admin wiring** — new "Personal" group with "Telos" nav item in `NAV_ITEMS` + `PANEL_MAP` (AdminPage.tsx).

**Admin API helpers** — 9 new functions in `admin-api.ts` (`telosGetStatus`, `telosGetSection`, `telosAddEntry`, `telosUpdateEntry`, `telosArchive`, `telosBulk`, `telosImportMarkdown`, `telosExportMarkdown`, `telosResolvePrediction`).

**Specs** — `specs/web.md` gets the new `api/telos.py` row, a full endpoint table, and the `TelosPanel.tsx` entry in the admin panels table.

## Test plan

- [ ] `make build-frontend` succeeds (I couldn't run `tsc -b` in the sandbox — first thing to verify).
- [ ] Fresh install: navigate to `/admin/` → Telos → wizard renders; complete the flow; status flips to `has_identity: true`; editor replaces the wizard on next load.
- [ ] Existing install (after Phase 1 onboarding): editor renders directly; identity shown as a single entry; other sections list their current state.
- [ ] Add a new goal via "+ Add entry" on the Goals section; verify it appears in beto's context (ask beto "what goals am I tracking?").
- [ ] Edit a goal inline; verify `telos show` reflects the change.
- [ ] Archive a wisdom entry; verify it disappears from the list (active only).
- [ ] Add a prediction in the chat via beto (`I'd bet 80% X by June`), then resolve it from the admin panel with outcome=false. Confirm a new `wrong_about` row is created.
- [ ] Export current telos → copy → clear textarea → paste back → import (merge). No dupes, no losses.
- [ ] Import with `replace all` wipes first then loads (confirm dialog fires).
- [ ] Verify all endpoints reject requests without a valid admin bearer token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)