### PR TITLE
feat(mcp-bridge): expose radbot as MCP server for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Autonomous coding workflow powered by Claude Code CLI and GitHub App authenticat
 *   **`get_current_time`**: Current time for any city (defaults to UTC)
 *   **`get_weather`**: Weather reports by city
 
+### MCP Bridge
+
+Exposes radbot itself as an MCP server for external clients (primarily Claude Code on laptop/desktop). 16 tools covering Telos read, wiki read/write (ai-intel vault over a shared mount), project registry, todo/scheduler lists, and Qdrant memory search — all returning markdown. `GET /setup/claude-code.md` is an unauth'd bootstrap that walks a new machine through settings + SessionStart-hook install. See `docs/implementation/mcp_bridge.md`.
+
 ### Configuration
 
 Credentials and settings stored in an encrypted PostgreSQL credential store with an admin UI at `/admin`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,13 +12,13 @@
 | Domain | File | Covers |
 |--------|------|--------|
 | Agents | specs/agents.md | beto routing, sub-agents (including kidsvid), tool assignments, memory scoping, per-turn context scoping callback, structured UI cards, handoff chips |
-| Tools | specs/tools.md | FunctionTool modules, MCP, tool patterns, card protocol, direct-action REST |
-| Web | specs/web.md | FastAPI, React SPA, API routes, WS protocol, session modes, admin panels, notifications, token stats |
-| Storage | specs/storage.md | PostgreSQL tables (incl. `notifications`, `llm_usage_log`, `workspace_workers`), Qdrant, credential store |
+| Tools | specs/tools.md | FunctionTool modules, MCP consumer + bridge server, tool patterns, card protocol, direct-action REST |
+| Web | specs/web.md | FastAPI, React SPA, API routes, WS protocol, session modes, admin panels, notifications, token stats, MCP bridge transport |
+| Storage | specs/storage.md | PostgreSQL tables (incl. `notifications`, `llm_usage_log`, `workspace_workers`, `projects.wiki_path`/`path_patterns`), Qdrant, credential store (`mcp_token`) |
 | Integrations | specs/integrations.md | HA, Overseerr, Lidarr, Picnic, Jira, Gmail, ntfy, Ollama, GitHub, YouTube/CuriosityStream/Kideo |
-| Config | specs/config.md | cfg system, priority chain, DB sections, session mode, admin UI, hot-reload |
+| Config | specs/config.md | cfg system, priority chain, DB sections, session mode, admin UI, hot-reload, `RADBOT_MCP_TOKEN` + `RADBOT_WIKI_PATH` env vars |
 | Workers | specs/workers.md | Workspace/terminal workers, PTY server, Nomad jobs, proxy, legacy session-worker notes |
-| Deployment | specs/deployment.md | Docker (main + worker), Nomad, CI/CD, env vars |
+| Deployment | specs/deployment.md | Docker (main + worker), Nomad, CI/CD, env vars, ai-intel wiki volume mount |
 
 ## Cross-Cutting
 
@@ -30,6 +30,7 @@
 - **Token + cost telemetry**: `telemetry_after_model_callback` writes to `llm_usage_log` with `session_id` threaded through. `GET /api/sessions/{id}/stats` exposes per-session totals + rolling today/month cost.
 - **Unified notifications**: `notifications` table aggregates scheduled-task results, reminders, alerts, ntfy inbound. `/api/notifications/*` and `pages/NotificationsPage.tsx` drive the feed + drawer.
 - **Telos (persistent user context)**: beto owns a structured persona / context store (mission, problems, goals, projects, challenges, wisdom, predictions, taste, journal) in `telos_entries`. `inject_telos_context` (on beto only — sub-agents don't get it) appends a ~300B anchor to `system_instruction` every turn and a ~2KB full block on the first turn of each session. One-time onboarding via `uv run python -m radbot.tools.telos.cli onboard`. Beto keeps the file alive via silent tools (journal, predictions, wisdom, taste) and confirm-required tools (goals, mission, problems). See `docs/implementation/telos.md`.
+- **MCP bridge** (`radbot.mcp_server`): exposes radbot to external MCP clients (primarily Claude Code on laptop/desktop) over stdio or HTTP/SSE. 16 tools covering Telos read, wiki read/write (at `$RADBOT_WIKI_PATH`), project registry (with `projects.path_patterns` for cwd matching), todo/scheduler listings, Qdrant memory search. All tool returns are markdown `TextContent`. HTTP auth: bearer token from credential store (`mcp_token` key, rotatable from admin UI) or `RADBOT_MCP_TOKEN` env var. `GET /setup/claude-code.md` is an unauth'd markdown bootstrap for new-machine config. See `docs/implementation/mcp_bridge.md`.
 - **Config priority**: DB config > file config > credential store > env vars. See `specs/config.md`.
 - **Error pattern**: Agent tools return `{"status": "success/error", ...}` dicts.
 - **Logging**: Structured JSON via `radbot/logging_config.py`. One INFO per operation, DEBUG for hot loops.

--- a/docs/implementation/mcp_bridge.md
+++ b/docs/implementation/mcp_bridge.md
@@ -1,0 +1,233 @@
+# MCP Bridge — exposing radbot to external MCP clients
+
+## Purpose
+
+Let Claude Code (or any MCP client) running on any of the user's machines
+read from and write to radbot's state — Telos, todo, wiki, memory —
+without needing radbot to be local. Complements the existing
+`radbot/tools/mcp/` module, which is the *consumer* side (radbot calling
+external MCP servers). This module is the *server* side.
+
+Primary consumer: Claude Code with a SessionStart hook that auto-injects
+project context on `cd` into a registered repo. Secondary consumer: any
+future mobile / phone client that wants to reach radbot over HTTPS.
+
+## Directory layout
+
+```
+radbot/mcp_server/
+├── __init__.py
+├── __main__.py          # stdio entrypoint — `uv run python -m radbot.mcp_server`
+├── server.py            # MCP Server factory + list_tools / call_tool handlers
+├── auth.py              # credential-store + env bearer-token validation
+├── http_transport.py    # mounts /mcp/sse and /mcp/messages/ on FastAPI
+└── tools/
+    ├── __init__.py      # module registry — aggregates all tools() / dispatches call()
+    ├── telos.py         # telos_get_full, telos_get_section, telos_get_entry, telos_search_journal
+    ├── wiki.py          # wiki_read, wiki_list, wiki_search, wiki_write
+    ├── projects.py      # project_match, project_list, project_register, project_get_context
+    ├── tasks.py         # list_tasks, list_reminders, list_scheduled_tasks
+    └── memory.py        # search_memory
+```
+
+## Transports
+
+- **stdio**: `uv run python -m radbot.mcp_server`. For local dev, MCP
+  Inspector, or subprocess-style Claude Code config. No auth — the trust
+  boundary is the OS user.
+- **HTTP/SSE**: `mount_mcp_on_app(app)` attaches `GET /mcp/sse` (event
+  stream) and `POST /mcp/messages/` (client→server) to the existing
+  FastAPI app. Bearer auth via `RADBOT_MCP_TOKEN` or credential store.
+
+Both transports serve the same `Server` instance produced by
+`create_server()`. Tool registration happens once.
+
+## Tool surface
+
+| Tool | Return shape | Notes |
+|---|---|---|
+| `telos_get_full` | markdown | Canonical Telos render |
+| `telos_get_section(section, include_inactive?)` | markdown | Bullets per entry |
+| `telos_get_entry(section, ref_code)` | markdown | Header + content + metadata |
+| `telos_search_journal(query, limit?)` | markdown | Newest matches first |
+| `wiki_read(path)` | markdown | File contents verbatim |
+| `wiki_list(glob?)` | markdown | Grouped by dir; 500-entry cap |
+| `wiki_search(query, glob?, limit?)` | markdown | `path:line — text` bullets |
+| `wiki_write(path, content)` | plain confirmation | Atomic via `.tmp` rename |
+| `project_match(cwd)` | plain string | Name or empty; used by SessionStart hook |
+| `project_list()` | markdown table | name · patterns · wiki_path |
+| `project_register(name, path_patterns, wiki_path?)` | plain confirmation | Upsert |
+| `project_get_context(name)` | markdown | Reads `wiki_path` file (PR 1); PR 2 swaps in live Telos hierarchy |
+| `list_tasks(status?, project?)` | markdown | Grouped by status |
+| `list_reminders(status?)` | markdown | Relative-time phrasing |
+| `list_scheduled_tasks()` | markdown table | name · cron · enabled · prompt |
+| `search_memory(query, agent_scope?, limit?)` | markdown | Default scope `beto`; `all` to widen |
+
+**Convention:** all tool returns are `TextContent` blocks. Markdown when
+there's anything structured; plain single-line text for primitives
+(`project_match`) and confirmations (`wiki_write`). Never raw JSON — this
+is LLM-facing. JSON consumers use REST at `/api/*`.
+
+## Auth
+
+Lookup order for the HTTP token:
+
+1. Credential store entry `mcp_token` (managed via admin UI)
+2. `RADBOT_MCP_TOKEN` env var (bootstrap value from Nomad)
+
+This matches radbot's general config-priority rule: credential store beats
+env var. That means rotation from the admin UI takes effect immediately
+without redeploying the Nomad job. The env var is the "first-boot" value;
+after first rotate it's effectively unused.
+
+If both are unset, `/mcp/sse` returns **503 MCP bridge disabled** and
+`/mcp/messages/` rejects all requests. Fail-closed by design.
+
+Rotation: `POST /api/mcp/token/rotate` generates a 32-byte URL-safe token
+(`secrets.token_urlsafe`), writes it to the credential store, and returns
+it **once**. The admin UI shows it in a one-time reveal modal with a copy
+button and a warning that existing clients will 401 until re-provisioned.
+
+## Wiki root
+
+Configured via `RADBOT_WIKI_PATH` env var (default `/mnt/ai-intel` in the
+Nomad container). The `wiki_*` tools sanitize every input path:
+
+1. Absolute paths are rejected outright.
+2. Relative paths are joined with the root, normalized, then `realpath`'d.
+3. The resolved absolute path must start with `<root>/` or equal `<root>`.
+4. Symlinks pointing outside the root fail step 3 because `realpath`
+   follows them.
+
+Tests cover: parent traversal (`../../../etc/passwd`), absolute paths,
+symlinks leading out of root. All return `**Error:** ...` markdown.
+
+## Project registry
+
+Extends the existing `projects` table (created by `tools/todo/db/schema.py`)
+with two columns (idempotent migration):
+
+| Column | Type | Purpose |
+|---|---|---|
+| `wiki_path` | TEXT | Path to the project's wiki page (relative to wiki root) |
+| `path_patterns` | TEXT[] | `cwd` substrings that identify this project |
+
+`project_match(cwd)` is the critical read: it does a SQL `LIKE '%<pattern>%'`
+against each element of `path_patterns` and returns the longest matching
+project name (ties broken by most-specific name). The SessionStart hook
+(see below) calls this on every session start; an empty result means "no
+radbot project matches this cwd — stay silent."
+
+`project_register(name, path_patterns, wiki_path)` is an UPSERT. Admin UI
+exposes an inline-edit table for browsing/adding/deleting.
+
+## REST endpoints
+
+All under `/api/mcp/`, admin-token-gated (same bearer as `/api/telos/*`):
+
+| Method + Path | Purpose |
+|---|---|
+| `GET /api/mcp/status` | Auth configured, token source, wiki mount check, SSE + setup URLs |
+| `GET /api/mcp/token/reveal` | Explicit reveal — returns cleartext token |
+| `POST /api/mcp/token/rotate` | Generates + stores + returns new token |
+| `GET /api/mcp/projects` | List all projects |
+| `POST /api/mcp/projects` | Upsert `{name, path_patterns, wiki_path?}` |
+| `PATCH /api/mcp/projects/{name}` | Partial update |
+| `DELETE /api/mcp/projects/{name}` | Remove |
+
+Plus the MCP-transport endpoints (not under `/api/`, different auth):
+
+| Path | Purpose |
+|---|---|
+| `GET /mcp/sse` | SSE event stream (bearer → MCP session) |
+| `POST /mcp/messages/` | Client → server message posts |
+| `GET /setup/claude-code.md` | Unauth'd markdown bootstrap guide (templated base_url) |
+
+## Setup endpoint
+
+`GET /setup/claude-code.md` returns a templated markdown guide that
+Claude Code on any new machine can follow to configure itself. Public,
+unauth'd (the user hasn't been given a token yet on a fresh machine).
+Template variable: `{base_url}`, filled from `request.base_url`.
+
+Flow for the user on a new device:
+
+1. Point Claude Code at the URL: "configure radbot from
+   `https://radbot.demonsafe.com/setup/claude-code.md`"
+2. Claude walks the 6-step wizard: get token from admin UI → add to
+   `~/.claude/settings.json` → install SessionStart hook → (optional)
+   mount wiki → install `/park` and `/resume` skills → verify
+3. Done in ~60 seconds, no files committed to any repo
+
+## SessionStart hook (Claude Code side)
+
+Minimal shell script at `~/.claude/hooks/radbot-project-context.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+: "${RADBOT_URL:=https://radbot.demonsafe.com}"
+[ -z "${RADBOT_MCP_TOKEN:-}" ] && exit 0
+
+project=$(curl -sf -H "Authorization: Bearer $RADBOT_MCP_TOKEN" \
+  "$RADBOT_URL/api/projects/match?cwd=$PWD" \
+  | jq -r '.project // empty' 2>/dev/null) || exit 0
+[ -z "$project" ] && exit 0
+
+curl -sf -H "Authorization: Bearer $RADBOT_MCP_TOKEN" \
+  "$RADBOT_URL/api/projects/$project/context.md"
+```
+
+Output goes to stdout → Claude Code loads it as session context. Silent
+on unknown paths, so it's safe to leave enabled on every machine. Lives
+in `~/.claude/settings.json` under `hooks.SessionStart` — **user-level,
+never committed to any repo**, so work-repo privacy is preserved.
+
+> Note: `GET /api/projects/match?cwd=...` and
+> `GET /api/projects/{name}/context.md` are companion REST endpoints to
+> the MCP tools of the same names. They're thin wrappers around the MCP
+> tool logic so shell scripts can consume them. Added in this PR's
+> admin router (`radbot/web/api/mcp.py`).
+
+## Nomad changes
+
+```hcl
+config {
+  volumes = [
+    "local/config.yaml:/app/config.yaml",
+    "${var.shared_dir}ai-intel:/mnt/ai-intel",   # new
+  ]
+}
+
+env {
+  RADBOT_CREDENTIAL_KEY = var.radbot_credential_key
+  RADBOT_ADMIN_TOKEN    = var.radbot_admin_token
+  RADBOT_MCP_TOKEN      = var.radbot_mcp_token   # new — bootstrap
+  RADBOT_WIKI_PATH      = "/mnt/ai-intel"        # new
+  RADBOT_CONFIG_FILE    = "/app/config.yaml"
+}
+
+variable "radbot_mcp_token" { type = string }
+variable "shared_dir"       { type = string }
+```
+
+Lives in `~/git/perrymanuk/hashi-homelab/nomad_jobs/ai-ml/radbot/nomad.job`.
+Deployed via a separate PR in that repo.
+
+## Testing
+
+Unit tests cover the high-risk paths:
+
+- `tests/unit/test_mcp_server_auth.py` — token lookup priority, 401/503 flows
+- `tests/unit/test_mcp_wiki_sanitization.py` — absolute paths, `..`
+  traversal, symlinks leading outside root, read/write atomicity
+- `tests/unit/test_mcp_setup_endpoint.py` — 200, content-type,
+  base_url templating, unauth access
+
+## Deferred to later PRs
+
+- **PR 2 — TELOS hierarchy**: new `milestones`/`explorations`/`project_tasks`
+  sections + `telos_render_project(name)`. Replaces the current
+  `project_get_context` (reads static wiki file) with the live render.
+- **PR 3 — `/park` + `/resume`**: `parked_sessions` table + MCP tools +
+  Claude Code skills for cross-device session continuity.

--- a/radbot/mcp_server/__init__.py
+++ b/radbot/mcp_server/__init__.py
@@ -1,0 +1,21 @@
+"""MCP server bridge — exposes radbot primitives to external MCP clients.
+
+This is the *server* side of MCP (distinct from `radbot/tools/mcp/`, which is
+the *consumer* side that lets radbot call external MCP servers).
+
+Transports:
+
+- **stdio** — `uv run python -m radbot.mcp_server` for local dev / subprocess use
+- **HTTP/SSE** — mounted on the FastAPI app at `/mcp/sse` + `/mcp/messages/`
+  via `http_transport.mount_mcp_on_app(app)` (called from `web/app.py`)
+
+Auth (HTTP only): bearer token matching `RADBOT_MCP_TOKEN` env var.
+
+Tool return format: markdown `TextContent` blocks. Single-primitive returns
+(e.g. a bare project name) may use plain text. Never structured JSON to the
+LLM — consumers of JSON should use the REST API at `/api/*`.
+"""
+
+from .server import create_server
+
+__all__ = ["create_server"]

--- a/radbot/mcp_server/__main__.py
+++ b/radbot/mcp_server/__main__.py
@@ -1,0 +1,54 @@
+"""Stdio entrypoint for local / subprocess use.
+
+Usage::
+
+    uv run python -m radbot.mcp_server
+
+Intended for development, testing with MCP Inspector, and any Claude Code
+config that prefers to launch the server as a subprocess instead of
+connecting to the HTTP/SSE endpoint on the deployed instance.
+
+Stdio transport does not use bearer auth — it's a local subprocess, so the
+trust boundary is the OS user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+import mcp.server.stdio
+from mcp.server.models import InitializationOptions
+from mcp.server.lowlevel import NotificationOptions
+
+from .server import create_server
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    server = create_server()
+    async with mcp.server.stdio.stdio_server() as (read, write):
+        init_options = InitializationOptions(
+            server_name="radbot-mcp",
+            server_version="0.1.0",
+            capabilities=server.get_capabilities(
+                notification_options=NotificationOptions(),
+                experimental_capabilities={},
+            ),
+        )
+        await server.run(read, write, init_options)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    try:
+        asyncio.run(_run())
+        return 0
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/radbot/mcp_server/auth.py
+++ b/radbot/mcp_server/auth.py
@@ -1,0 +1,76 @@
+"""Bearer token auth for the HTTP/SSE MCP transport.
+
+Stdio transport runs as a local subprocess and does not use auth.
+
+Token lookup order (matches radbot's standard priority: credential store
+beats env var):
+
+1. Credential store entry `mcp_token` (rotatable from the admin UI)
+2. `RADBOT_MCP_TOKEN` env var (bootstrap value set by the Nomad job)
+
+If both are unset, the HTTP endpoints return 503. Rotating via the admin
+UI writes a new value to the credential store and existing clients must
+re-copy the token (there is no refresh-token flow — this is a personal
+system, not a production API).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+_CREDENTIAL_KEY = "mcp_token"
+
+
+def _expected_token() -> str | None:
+    """The expected bearer token, or None if auth is unconfigured.
+
+    Credential store wins over env var so admin-UI rotation takes effect
+    without redeploying the Nomad job.
+    """
+    try:
+        from radbot.credentials.store import get_credential_store
+
+        store = get_credential_store()
+        if store.available:
+            stored = (store.get(_CREDENTIAL_KEY) or "").strip()
+            if stored:
+                return stored
+    except Exception as exc:
+        logger.debug("credential_store_unavailable err=%s", exc)
+
+    env_token = os.environ.get("RADBOT_MCP_TOKEN", "").strip()
+    return env_token or None
+
+
+def is_auth_configured() -> bool:
+    return _expected_token() is not None
+
+
+def check_bearer(request: Request) -> JSONResponse | None:
+    """Validate the Authorization header on `request`.
+
+    Returns `None` on success, or a 401/503 JSONResponse on failure that the
+    caller should return immediately.
+    """
+    expected = _expected_token()
+    if expected is None:
+        return JSONResponse(
+            {"error": "MCP bridge disabled — RADBOT_MCP_TOKEN not set"},
+            status_code=503,
+        )
+    header = request.headers.get("Authorization", "")
+    if not header.startswith("Bearer "):
+        return JSONResponse(
+            {"error": "Missing bearer token"}, status_code=401
+        )
+    if header[7:].strip() != expected:
+        return JSONResponse(
+            {"error": "Invalid bearer token"}, status_code=401
+        )
+    return None

--- a/radbot/mcp_server/http_transport.py
+++ b/radbot/mcp_server/http_transport.py
@@ -1,0 +1,63 @@
+"""HTTP/SSE transport for the radbot MCP server.
+
+Mounts the MCP `SseServerTransport` on the existing FastAPI app at
+`/mcp/sse` (GET, SSE stream) and `/mcp/messages/` (POST, client → server
+messages). Both are gated by `auth.check_bearer`.
+
+Usage from `web/app.py`::
+
+    from radbot.mcp_server.http_transport import mount_mcp_on_app
+    mount_mcp_on_app(app)
+
+If `RADBOT_MCP_TOKEN` is unset, the routes still mount but return 503 —
+this keeps the import path stable regardless of config.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+from mcp.server.sse import SseServerTransport
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Mount, Route
+
+from . import auth
+from .server import create_server
+
+logger = logging.getLogger(__name__)
+
+SSE_PATH = "/mcp/sse"
+MESSAGES_PATH = "/mcp/messages/"
+
+
+def mount_mcp_on_app(app: FastAPI) -> None:
+    """Attach MCP SSE + messages routes to the FastAPI app."""
+    transport = SseServerTransport(MESSAGES_PATH)
+    server = create_server()
+
+    async def handle_sse(request: Request) -> Response:
+        auth_err = auth.check_bearer(request)
+        if auth_err is not None:
+            return auth_err
+        async with transport.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
+            await server.run(
+                streams[0], streams[1], server.create_initialization_options()
+            )
+        return Response()
+
+    async def handle_messages(scope, receive, send):
+        # ASGI-level handler so we can still pre-check auth on the raw request
+        request = Request(scope, receive=receive)
+        auth_err = auth.check_bearer(request)
+        if auth_err is not None:
+            await auth_err(scope, receive, send)
+            return
+        await transport.handle_post_message(scope, receive, send)
+
+    app.router.routes.append(Route(SSE_PATH, endpoint=handle_sse, methods=["GET"]))
+    app.router.routes.append(Mount(MESSAGES_PATH, app=handle_messages))
+    logger.info("mcp_http_mounted sse=%s messages=%s", SSE_PATH, MESSAGES_PATH)

--- a/radbot/mcp_server/server.py
+++ b/radbot/mcp_server/server.py
@@ -1,0 +1,56 @@
+"""MCP Server factory and tool dispatch.
+
+Creates a `mcp.server.lowlevel.Server` and wires `list_tools` / `call_tool`
+handlers to the modules in `radbot.mcp_server.tools`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp import types as mcp_types
+from mcp.server.lowlevel import Server
+
+from . import tools as tool_registry
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "radbot-mcp"
+SERVER_VERSION = "0.1.0"
+
+
+def create_server() -> Server:
+    """Build and return an MCP Server with all radbot tools registered."""
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def _list_tools() -> list[mcp_types.Tool]:  # noqa: D401
+        return tool_registry.all_tools()
+
+    @server.call_tool()
+    async def _call_tool(
+        name: str, arguments: dict[str, Any] | None
+    ) -> list[mcp_types.TextContent]:
+        args = arguments or {}
+        logger.info("mcp_call_tool name=%s", name)
+        try:
+            return await tool_registry.dispatch(name, args)
+        except KeyError:
+            return [
+                mcp_types.TextContent(
+                    type="text",
+                    text=f"Unknown tool: `{name}`. "
+                    "Call `ListTools` to see available tools.",
+                )
+            ]
+        except Exception as exc:  # surfaced to the model as a tool result
+            logger.exception("mcp_call_tool failed name=%s", name)
+            return [
+                mcp_types.TextContent(
+                    type="text",
+                    text=f"Tool `{name}` failed: {exc}",
+                )
+            ]
+
+    return server

--- a/radbot/mcp_server/tools/__init__.py
+++ b/radbot/mcp_server/tools/__init__.py
@@ -1,0 +1,38 @@
+"""Tool registry for the radbot MCP server.
+
+Each submodule (`telos`, `wiki`, `projects`, `tasks`, `memory`) exposes:
+
+- `tools() -> list[mcp.types.Tool]` — tool definitions for ListTools
+- `async call(name: str, arguments: dict) -> list[TextContent]` — dispatcher
+  for tools owned by that module
+
+Modules that are empty stubs contribute zero tools until their tools are
+implemented (post-scaffold phase of PR 1).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp import types as mcp_types
+
+from . import memory, projects, tasks, telos, wiki
+
+_MODULES = [telos, wiki, projects, tasks, memory]
+
+
+def all_tools() -> list[mcp_types.Tool]:
+    out: list[mcp_types.Tool] = []
+    for module in _MODULES:
+        out.extend(module.tools())
+    return out
+
+
+async def dispatch(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    for module in _MODULES:
+        for tool in module.tools():
+            if tool.name == name:
+                return await module.call(name, arguments)
+    raise KeyError(name)

--- a/radbot/mcp_server/tools/memory.py
+++ b/radbot/mcp_server/tools/memory.py
@@ -1,0 +1,131 @@
+"""Semantic-memory MCP tool — Qdrant-backed search over agent memory.
+
+Default scope is `beto` (matches radbot's primary orchestrator). Pass
+`agent_scope` to narrow to a specific sub-agent (casa, planner, etc.) or
+the sentinel `all` to widen.
+
+Returns markdown: one bullet per hit with score, snippet, source agent,
+and relative date where available.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp import types as mcp_types
+
+_USER_ID = "web_user"  # single-user system; matches CLAUDE.md convention
+_APP_NAME = "radbot"
+_DEFAULT_SCOPE = "beto"
+_WIDEN_SENTINEL = "all"
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="search_memory",
+            description=(
+                "Semantic search across radbot's Qdrant-backed agent memory. "
+                "Default scope is `beto` (the root orchestrator). Pass "
+                f"`agent_scope` to target a sub-agent, or `{_WIDEN_SENTINEL}` "
+                "to search across every agent."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "agent_scope": {
+                        "type": "string",
+                        "description": (
+                            "Agent namespace to restrict results to. Default 'beto'. "
+                            "Use 'all' to search across every agent."
+                        ),
+                        "default": _DEFAULT_SCOPE,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 25,
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "search_memory":
+        return [_do_search(
+            arguments["query"],
+            arguments.get("agent_scope", _DEFAULT_SCOPE),
+            int(arguments.get("limit", 5)),
+        )]
+    raise KeyError(name)
+
+
+def _do_search(query: str, agent_scope: str, limit: int) -> mcp_types.TextContent:
+    from radbot.memory.qdrant_memory import QdrantMemoryService
+
+    try:
+        service = QdrantMemoryService()
+    except Exception as e:
+        return mcp_types.TextContent(
+            type="text", text=f"**Error:** memory service unavailable: {e}"
+        )
+
+    filter_conditions: dict[str, Any] | None = None
+    if agent_scope and agent_scope.lower() != _WIDEN_SENTINEL:
+        filter_conditions = {"source_agent": agent_scope}
+
+    try:
+        hits = service.search_memory(
+            app_name=_APP_NAME,
+            user_id=_USER_ID,
+            query=query,
+            limit=limit,
+            filter_conditions=filter_conditions,
+        )
+    except Exception as e:
+        return mcp_types.TextContent(
+            type="text", text=f"**Error:** search failed: {e}"
+        )
+
+    if not hits:
+        scope_label = agent_scope if agent_scope else _DEFAULT_SCOPE
+        return mcp_types.TextContent(
+            type="text",
+            text=f"_No memory hits for `{query}` (scope: {scope_label})._",
+        )
+
+    scope_label = agent_scope if agent_scope else _DEFAULT_SCOPE
+    lines = [
+        f"## Memory search for `{query}` (scope: {scope_label}, {len(hits)} hits)",
+        "",
+    ]
+    for h in hits:
+        score = h.get("score")
+        score_str = f" · score={score:.3f}" if isinstance(score, (int, float)) else ""
+        payload = h.get("payload") or h
+        source_agent = payload.get("source_agent") or "—"
+        mem_type = payload.get("memory_type") or ""
+        ts = payload.get("timestamp") or payload.get("ingested_at") or ""
+        snippet = (payload.get("text") or payload.get("content") or "").strip()
+        if len(snippet) > 320:
+            snippet = snippet[:320] + "…"
+        meta_bits = [f"agent={source_agent}"]
+        if mem_type:
+            meta_bits.append(f"type={mem_type}")
+        if ts:
+            meta_bits.append(f"ts={ts}")
+        lines.append(f"- _({' · '.join(meta_bits)}{score_str})_")
+        if snippet:
+            # Render snippet as blockquote for visual separation
+            for sline in snippet.splitlines():
+                lines.append(f"  > {sline}")
+        lines.append("")
+    return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())

--- a/radbot/mcp_server/tools/projects.py
+++ b/radbot/mcp_server/tools/projects.py
@@ -1,0 +1,219 @@
+"""Project registry MCP tools.
+
+Projects are radbot's existing `projects` table rows extended with two
+columns added in PR 1: `wiki_path` (markdown file under the wiki root)
+and `path_patterns` (TEXT[] of cwd substrings that identify this project).
+
+`project_match(cwd)` is the key tool: the Claude Code SessionStart hook
+calls it to decide whether to inject project context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="project_match",
+            description=(
+                "Return the name of the project whose `path_patterns` match "
+                "the given cwd (any element of path_patterns must appear as a "
+                "substring of cwd). Returns empty if no match."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"cwd": {"type": "string"}},
+                "required": ["cwd"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_list",
+            description="Return a markdown table of all registered projects.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_register",
+            description=(
+                "Create or update a project entry. `name` is the canonical "
+                "identifier. `path_patterns` is a list of cwd substrings "
+                "(e.g. ['/git/perrymanuk/radbot']). `wiki_path` is optional, "
+                "relative to the wiki root."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "path_patterns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "wiki_path": {"type": "string"},
+                },
+                "required": ["name", "path_patterns"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_get_context",
+            description=(
+                "Return the project's context as markdown. Phase 1: reads the "
+                "registered `wiki_path` file. Phase 2 (PR 2): will render the "
+                "live Telos project hierarchy (milestones, tasks, explorations)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "project_match":
+        return [_do_match(arguments["cwd"])]
+    if name == "project_list":
+        return [_do_list()]
+    if name == "project_register":
+        return [_do_register(
+            arguments["name"],
+            list(arguments.get("path_patterns") or []),
+            arguments.get("wiki_path"),
+        )]
+    if name == "project_get_context":
+        return [_do_get_context(arguments["name"])]
+    raise KeyError(name)
+
+
+def _err(msg: str) -> mcp_types.TextContent:
+    return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
+
+
+def _do_match(cwd: str) -> mcp_types.TextContent:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn, get_db_cursor(conn) as c:
+        c.execute(
+            "SELECT name FROM projects "
+            "WHERE EXISTS (SELECT 1 FROM unnest(path_patterns) p WHERE %s LIKE '%%' || p || '%%') "
+            "ORDER BY length(name) DESC LIMIT 1",
+            (cwd,),
+        )
+        row = c.fetchone()
+
+    if not row:
+        return mcp_types.TextContent(type="text", text="")
+    return mcp_types.TextContent(type="text", text=row[0])
+
+
+def _do_list() -> mcp_types.TextContent:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn, get_db_cursor(conn) as c:
+        c.execute(
+            "SELECT name, path_patterns, wiki_path FROM projects ORDER BY name"
+        )
+        rows = c.fetchall()
+
+    if not rows:
+        return mcp_types.TextContent(
+            type="text", text="_No projects registered._"
+        )
+
+    lines = [
+        "## Registered projects",
+        "",
+        "| Name | Path patterns | Wiki page |",
+        "|---|---|---|",
+    ]
+    for name, patterns, wiki_path in rows:
+        patterns_str = ", ".join(f"`{p}`" for p in (patterns or [])) or "—"
+        wiki_str = f"`{wiki_path}`" if wiki_path else "—"
+        lines.append(f"| `{name}` | {patterns_str} | {wiki_str} |")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _do_register(
+    name: str, path_patterns: list[str], wiki_path: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    clean_patterns = [p.strip() for p in path_patterns if p and p.strip()]
+    if not clean_patterns:
+        return _err("At least one non-empty path_pattern is required.")
+
+    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO projects (name, path_patterns, wiki_path)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (name) DO UPDATE
+              SET path_patterns = EXCLUDED.path_patterns,
+                  wiki_path = EXCLUDED.wiki_path
+            RETURNING (xmax = 0) AS inserted
+            """,
+            (name, clean_patterns, wiki_path),
+        )
+        inserted = c.fetchone()[0]
+
+    verb = "Registered" if inserted else "Updated"
+    wiki_note = f" · wiki_path=`{wiki_path}`" if wiki_path else ""
+    return mcp_types.TextContent(
+        type="text",
+        text=f"{verb} project `{name}` · patterns={clean_patterns}{wiki_note}",
+    )
+
+
+def _do_get_context(name: str) -> mcp_types.TextContent:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    # Import here to reuse the same root + sanitization logic
+    from .wiki import _resolve_under_root, _wiki_root
+
+    with get_db_connection() as conn, get_db_cursor(conn) as c:
+        c.execute("SELECT wiki_path FROM projects WHERE name = %s", (name,))
+        row = c.fetchone()
+
+    if not row:
+        return _err(f"Unknown project: `{name}`")
+    wiki_path = row[0]
+    if not wiki_path:
+        return mcp_types.TextContent(
+            type="text",
+            text=(
+                f"## Project: {name}\n\n"
+                "_No wiki page registered for this project. "
+                "Set `wiki_path` via `project_register` to surface context here._"
+            ),
+        )
+
+    if _wiki_root() is None:
+        return _err("Wiki not configured: RADBOT_WIKI_PATH unset or missing.")
+
+    abs_path, err = _resolve_under_root(wiki_path)
+    if abs_path is None:
+        return _err(err)
+
+    import os as _os
+    if not _os.path.isfile(abs_path):
+        return _err(
+            f"Project `{name}` references missing wiki file: `{wiki_path}`"
+        )
+
+    try:
+        with open(abs_path, "r", encoding="utf-8") as f:
+            return mcp_types.TextContent(type="text", text=f.read())
+    except OSError as e:
+        return _err(f"Failed to read wiki page: {e}")

--- a/radbot/mcp_server/tools/tasks.py
+++ b/radbot/mcp_server/tools/tasks.py
@@ -1,0 +1,197 @@
+"""Task / reminder / scheduler MCP tools.
+
+Return format: markdown. All heavy imports are lazy (DB connection, scheduler
+engine, etc.) to keep module-import cost minimal.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="list_tasks",
+            description=(
+                "List radbot todo tasks across all projects, grouped by status. "
+                "Optional status filter: `backlog`, `inprogress`, or `done`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["backlog", "inprogress", "done"],
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Filter to a specific project name.",
+                    },
+                },
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="list_reminders",
+            description=(
+                "List pending (or past) reminders. Default status=`pending`. "
+                "Returns a markdown list with relative-time phrasing."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "delivered", "cancelled"],
+                        "default": "pending",
+                    }
+                },
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="list_scheduled_tasks",
+            description=(
+                "List APScheduler cron tasks: name, cron expression, prompt "
+                "preview, enabled flag."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "list_tasks":
+        return [_render_tasks(arguments.get("status"), arguments.get("project"))]
+    if name == "list_reminders":
+        return [_render_reminders(arguments.get("status", "pending"))]
+    if name == "list_scheduled_tasks":
+        return [_render_scheduled()]
+    raise KeyError(name)
+
+
+def _relative_time(dt: datetime) -> str:
+    """Human-readable relative phrasing for a future (or past) UTC timestamp."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    now = datetime.now(tz=timezone.utc)
+    delta = dt - now
+    secs = int(delta.total_seconds())
+    past = secs < 0
+    secs = abs(secs)
+    if secs < 60:
+        unit = f"{secs}s"
+    elif secs < 3600:
+        unit = f"{secs // 60}m"
+    elif secs < 86400:
+        unit = f"{secs // 3600}h"
+    elif secs < 86400 * 30:
+        unit = f"{secs // 86400}d"
+    else:
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    return f"{unit} ago" if past else f"in {unit}"
+
+
+def _render_tasks(status: str | None, project: str | None) -> mcp_types.TextContent:
+    from radbot.tools.todo.db.connection import get_db_connection
+    from radbot.tools.todo.db.queries import list_all_tasks
+
+    if status and status not in ("backlog", "inprogress", "done"):
+        return mcp_types.TextContent(
+            type="text", text=f"**Error:** invalid status `{status}`"
+        )
+
+    with get_db_connection() as conn:
+        rows = list_all_tasks(conn, status_filter=status)
+
+    if project:
+        rows = [r for r in rows if r.get("project_name") == project]
+
+    if not rows:
+        filt = " · ".join(
+            bit for bit in (
+                f"status={status}" if status else None,
+                f"project={project}" if project else None,
+            ) if bit
+        )
+        return mcp_types.TextContent(
+            type="text", text=f"_No tasks{(' (' + filt + ')') if filt else ''}._"
+        )
+
+    # Group by status for readability
+    by_status: dict[str, list[dict[str, Any]]] = {
+        "backlog": [], "inprogress": [], "done": [],
+    }
+    for r in rows:
+        by_status.setdefault(r.get("status", "backlog"), []).append(r)
+
+    lines: list[str] = []
+    for st in ("inprogress", "backlog", "done"):
+        bucket = by_status.get(st) or []
+        if not bucket:
+            continue
+        lines.append(f"## {st} ({len(bucket)})")
+        lines.append("")
+        for r in bucket:
+            title = r.get("title") or (r.get("description") or "").split("\n", 1)[0][:80]
+            proj = r.get("project_name") or "—"
+            lines.append(f"- **[{proj}]** {title}")
+        lines.append("")
+    return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())
+
+
+def _render_reminders(status: str) -> mcp_types.TextContent:
+    from radbot.tools.reminders import db as rem_db
+
+    try:
+        rows = rem_db.list_reminders(status=status)
+    except Exception as e:
+        return mcp_types.TextContent(
+            type="text", text=f"**Error:** {e}"
+        )
+
+    if not rows:
+        return mcp_types.TextContent(
+            type="text", text=f"_No reminders with status `{status}`._"
+        )
+
+    lines = [f"## Reminders ({status}, {len(rows)})", ""]
+    for r in rows:
+        remind_at = r.get("remind_at")
+        when = _relative_time(remind_at) if isinstance(remind_at, datetime) else str(remind_at)
+        lines.append(f"- **{when}** — {r.get('message', '').strip()}")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _render_scheduled() -> mcp_types.TextContent:
+    from radbot.tools.scheduler import db as sched_db
+
+    rows = sched_db.list_tasks()
+    if not rows:
+        return mcp_types.TextContent(
+            type="text", text="_No scheduled tasks._"
+        )
+
+    lines = [
+        "## Scheduled tasks",
+        "",
+        "| Name | Cron | Enabled | Prompt |",
+        "|---|---|---|---|",
+    ]
+    for r in rows:
+        name = r.get("name", "?")
+        cron = r.get("cron_expression", "?")
+        enabled = "✓" if r.get("enabled") else "—"
+        prompt = (r.get("prompt") or "").replace("\n", " ")[:80]
+        lines.append(f"| `{name}` | `{cron}` | {enabled} | {prompt} |")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))

--- a/radbot/mcp_server/tools/telos.py
+++ b/radbot/mcp_server/tools/telos.py
@@ -1,0 +1,208 @@
+"""Telos MCP tools — expose radbot's user-context store to external clients.
+
+All tools return markdown `TextContent`. Heavy imports are lazy to keep
+module-import cost minimal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="telos_get_full",
+            description=(
+                "Return the full Telos user context as canonical markdown "
+                "(identity, mission, goals, projects, wisdom, recent journal, "
+                "etc.). Use sparingly — this can be large. Prefer "
+                "`telos_get_section` when only one area is relevant."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="telos_get_section",
+            description=(
+                "Return all entries in one Telos section as markdown. "
+                "Sections: identity, history, problems, mission, narratives, "
+                "goals, challenges, strategies, projects, wisdom, ideas, "
+                "predictions, wrong_about, best_books, best_movies, best_music, "
+                "taste, traumas, metrics, journal."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "section": {
+                        "type": "string",
+                        "description": "Lowercase section name.",
+                    },
+                    "include_inactive": {
+                        "type": "boolean",
+                        "description": "Include completed/archived entries. Default false.",
+                        "default": False,
+                    },
+                },
+                "required": ["section"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="telos_get_entry",
+            description=(
+                "Fetch one Telos entry by (section, ref_code). Use when you "
+                "know the ref_code (e.g. 'G1', 'P2', 'PRED3'). Identity's "
+                "ref_code is 'ME'."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "section": {"type": "string"},
+                    "ref_code": {"type": "string"},
+                },
+                "required": ["section", "ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="telos_search_journal",
+            description=(
+                "Case-insensitive substring search over Telos journal entries. "
+                "Returns newest matches first. Use for 'have I ever mentioned X?' "
+                "questions."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 100},
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "telos_get_full":
+        return [_render_full()]
+    if name == "telos_get_section":
+        return [_render_section(
+            arguments["section"],
+            bool(arguments.get("include_inactive", False)),
+        )]
+    if name == "telos_get_entry":
+        return [_render_entry(arguments["section"], arguments["ref_code"])]
+    if name == "telos_search_journal":
+        return [_render_journal_search(
+            arguments["query"],
+            int(arguments.get("limit", 20)),
+        )]
+    raise KeyError(name)
+
+
+def _render_full() -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.markdown_io import render_telos_markdown
+
+    entries = telos_db.list_all()
+    if not entries:
+        md = "_No Telos entries yet._"
+    else:
+        md = render_telos_markdown(entries)
+    return mcp_types.TextContent(type="text", text=md)
+
+
+def _render_section(section: str, include_inactive: bool) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section, SECTION_HEADERS
+
+    try:
+        sec = Section(section.lower())
+    except ValueError:
+        valid = ", ".join(s.value for s in Section)
+        return mcp_types.TextContent(
+            type="text",
+            text=f"**Error:** unknown section `{section}`. Valid: {valid}",
+        )
+
+    status_filter = None if include_inactive else "active"
+    order = "created_at_desc" if sec == Section.JOURNAL else "sort_order_asc"
+    entries = telos_db.list_section(sec, status=status_filter, order_by=order)
+
+    header = SECTION_HEADERS.get(sec, sec.value.title())
+    if not entries:
+        return mcp_types.TextContent(
+            type="text", text=f"## {header}\n\n_No entries._"
+        )
+
+    lines = [f"## {header}", ""]
+    for e in entries:
+        ref = f"**{e.ref_code}** — " if e.ref_code else ""
+        status_tag = f" _({e.status})_" if e.status != "active" else ""
+        lines.append(f"- {ref}{e.content}{status_tag}")
+        if e.metadata:
+            meta_bits = [f"{k}: {v}" for k, v in e.metadata.items() if v not in (None, "", [], {})]
+            if meta_bits:
+                lines.append(f"  - {' · '.join(meta_bits)}")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _render_entry(section: str, ref_code: str) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    try:
+        sec = Section(section.lower())
+    except ValueError:
+        return mcp_types.TextContent(
+            type="text", text=f"**Error:** unknown section `{section}`"
+        )
+
+    entry = telos_db.get_entry(sec, ref_code)
+    if not entry:
+        return mcp_types.TextContent(
+            type="text",
+            text=f"**Not found:** no entry `{ref_code}` in section `{sec.value}`",
+        )
+
+    lines = [
+        f"### {sec.value}: {entry.ref_code or '(no ref)'}",
+        f"**Status:** {entry.status}",
+        "",
+        entry.content,
+    ]
+    if entry.metadata:
+        lines.append("")
+        lines.append("**Metadata:**")
+        for k, v in entry.metadata.items():
+            lines.append(f"- {k}: {v}")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _render_journal_search(query: str, limit: int) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+
+    rows = telos_db.search_journal(query, limit=limit)
+    if not rows:
+        return mcp_types.TextContent(
+            type="text", text=f"_No journal matches for `{query}`._"
+        )
+
+    lines = [f"## Journal matches for `{query}` ({len(rows)})", ""]
+    for e in rows:
+        date = e.created_at.strftime("%Y-%m-%d") if e.created_at else ""
+        lines.append(f"- **{date}** — {e.content}")
+        refs = (e.metadata or {}).get("related_refs")
+        if refs:
+            lines.append(f"  - related: {', '.join(refs)}")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))

--- a/radbot/mcp_server/tools/wiki.py
+++ b/radbot/mcp_server/tools/wiki.py
@@ -1,0 +1,286 @@
+"""Wiki filesystem MCP tools.
+
+Rooted at `$RADBOT_WIKI_PATH` (default `/mnt/ai-intel` in the Nomad
+container). Strict path sanitization: the resolved absolute path must stay
+under the configured root and must not traverse a symlink. No writes outside
+the root, no deletes.
+
+Return format: markdown.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from mcp import types as mcp_types
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ROOT = "/mnt/ai-intel"
+_MAX_READ_BYTES = 1_000_000  # 1 MB cap — markdown files only
+_MAX_WRITE_BYTES = 1_000_000
+_MAX_LIST_ENTRIES = 500
+
+
+def _wiki_root() -> str | None:
+    """Resolved absolute wiki root, or None if unconfigured / missing."""
+    root = os.environ.get("RADBOT_WIKI_PATH", _DEFAULT_ROOT).strip()
+    if not root:
+        return None
+    abs_root = os.path.realpath(os.path.expanduser(root))
+    if not os.path.isdir(abs_root):
+        return None
+    return abs_root
+
+
+def _resolve_under_root(rel_path: str) -> tuple[str, str] | tuple[None, str]:
+    """Resolve `rel_path` under the wiki root.
+
+    Returns (absolute_path, "") on success, or (None, error_message) on failure.
+    Rejects absolute paths, `..` traversal, and symlinks leading outside root.
+    """
+    root = _wiki_root()
+    if root is None:
+        return (
+            None,
+            "Wiki not configured: RADBOT_WIKI_PATH unset or directory missing.",
+        )
+
+    # Reject absolute paths outright — all access is relative to the wiki root
+    if rel_path.startswith("/"):
+        return (None, f"Absolute paths not allowed: `{rel_path}`")
+    # Collapse `..`, then re-check
+    candidate = os.path.normpath(os.path.join(root, rel_path))
+    abs_candidate = os.path.realpath(candidate)
+    if not abs_candidate.startswith(root + os.sep) and abs_candidate != root:
+        return (None, f"Path escapes wiki root: `{rel_path}`")
+    return (abs_candidate, "")
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="wiki_read",
+            description=(
+                "Read a markdown file from the ai-intel wiki. Path is relative "
+                "to the wiki root (e.g. `wiki/concepts/claude-code.md`)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="wiki_list",
+            description=(
+                "List files in the ai-intel wiki. Optional glob pattern "
+                "(e.g. `wiki/concepts/*.md`, `**/*.md`). Returns grouped "
+                "markdown index, capped at 500 entries."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "glob": {
+                        "type": "string",
+                        "description": "Glob pattern relative to wiki root. Default `**/*.md`.",
+                        "default": "**/*.md",
+                    }
+                },
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="wiki_search",
+            description=(
+                "Case-insensitive substring search across wiki markdown files. "
+                "Returns one bullet per match with path and surrounding line."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "glob": {
+                        "type": "string",
+                        "description": "Restrict search to files matching this glob. Default `**/*.md`.",
+                        "default": "**/*.md",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 50,
+                        "minimum": 1,
+                        "maximum": 500,
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="wiki_write",
+            description=(
+                "Write (create or overwrite) a markdown file in the ai-intel "
+                "wiki. Parent directories are created if missing. Path is "
+                "sanitized to stay under the wiki root."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "wiki_read":
+        return [_do_read(arguments["path"])]
+    if name == "wiki_list":
+        return [_do_list(arguments.get("glob", "**/*.md"))]
+    if name == "wiki_search":
+        return [_do_search(
+            arguments["query"],
+            arguments.get("glob", "**/*.md"),
+            int(arguments.get("limit", 50)),
+        )]
+    if name == "wiki_write":
+        return [_do_write(arguments["path"], arguments["content"])]
+    raise KeyError(name)
+
+
+def _err(msg: str) -> mcp_types.TextContent:
+    return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
+
+
+def _do_read(rel_path: str) -> mcp_types.TextContent:
+    abs_path, err = _resolve_under_root(rel_path)
+    if abs_path is None:
+        return _err(err)
+    if not os.path.isfile(abs_path):
+        return _err(f"Not a file: `{rel_path}`")
+    try:
+        size = os.path.getsize(abs_path)
+        if size > _MAX_READ_BYTES:
+            return _err(f"File too large ({size} bytes > {_MAX_READ_BYTES})")
+        with open(abs_path, "r", encoding="utf-8") as f:
+            return mcp_types.TextContent(type="text", text=f.read())
+    except OSError as e:
+        return _err(f"Read failed: {e}")
+
+
+def _do_list(glob: str) -> mcp_types.TextContent:
+    import pathlib
+
+    root = _wiki_root()
+    if root is None:
+        return _err("Wiki not configured.")
+
+    root_path = pathlib.Path(root)
+    try:
+        matches = [p for p in root_path.glob(glob) if p.is_file()][:_MAX_LIST_ENTRIES]
+    except (OSError, ValueError) as e:
+        return _err(f"Bad glob `{glob}`: {e}")
+
+    if not matches:
+        return mcp_types.TextContent(
+            type="text", text=f"_No files matching `{glob}`._"
+        )
+
+    # Group by parent directory for readability
+    by_dir: dict[str, list[str]] = {}
+    for p in matches:
+        rel = p.relative_to(root_path)
+        parent = str(rel.parent) if rel.parent != pathlib.Path(".") else "(root)"
+        by_dir.setdefault(parent, []).append(rel.name)
+
+    lines = [f"## Wiki files matching `{glob}` ({len(matches)})", ""]
+    for parent in sorted(by_dir):
+        lines.append(f"### {parent}")
+        for name in sorted(by_dir[parent]):
+            full = name if parent == "(root)" else f"{parent}/{name}"
+            lines.append(f"- `{full}`")
+        lines.append("")
+    return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())
+
+
+def _do_search(query: str, glob: str, limit: int) -> mcp_types.TextContent:
+    import pathlib
+
+    root = _wiki_root()
+    if root is None:
+        return _err("Wiki not configured.")
+
+    root_path = pathlib.Path(root)
+    q_lower = query.lower()
+    hits: list[tuple[str, int, str]] = []  # (rel_path, line_no, line)
+    try:
+        for path in root_path.glob(glob):
+            if not path.is_file():
+                continue
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    for i, line in enumerate(f, start=1):
+                        if q_lower in line.lower():
+                            rel = str(path.relative_to(root_path))
+                            hits.append((rel, i, line.rstrip()))
+                            if len(hits) >= limit:
+                                break
+            except OSError:
+                continue
+            if len(hits) >= limit:
+                break
+    except ValueError as e:
+        return _err(f"Bad glob `{glob}`: {e}")
+
+    if not hits:
+        return mcp_types.TextContent(
+            type="text", text=f"_No matches for `{query}`._"
+        )
+
+    lines = [f"## Wiki search for `{query}` ({len(hits)} hits)", ""]
+    for rel, line_no, line in hits:
+        lines.append(f"- `{rel}:{line_no}` — {line.strip()}")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _do_write(rel_path: str, content: str) -> mcp_types.TextContent:
+    if len(content.encode("utf-8")) > _MAX_WRITE_BYTES:
+        return _err(f"Content too large (> {_MAX_WRITE_BYTES} bytes)")
+
+    abs_path, err = _resolve_under_root(rel_path)
+    if abs_path is None:
+        return _err(err)
+
+    # Ensure parent dir exists (and also stays under root)
+    parent = os.path.dirname(abs_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    # Atomic write via temp + rename
+    tmp_path = abs_path + ".tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, abs_path)
+    except OSError as e:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        return _err(f"Write failed: {e}")
+
+    size = len(content.encode("utf-8"))
+    logger.info("wiki_write path=%s bytes=%d", rel_path, size)
+    return mcp_types.TextContent(
+        type="text", text=f"Wrote {size} bytes to `{rel_path}`"
+    )

--- a/radbot/tools/todo/db/schema.py
+++ b/radbot/tools/todo/db/schema.py
@@ -92,12 +92,37 @@ def create_schema_if_not_exists() -> None:
                         CREATE TABLE projects (
                             project_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                             name TEXT NOT NULL UNIQUE,
+                            wiki_path TEXT,
+                            path_patterns TEXT[] NOT NULL DEFAULT '{}',
                             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
                         );
                     """)
                     logger.info("Projects table created successfully")
                 else:
                     logger.info("Projects table already exists")
+                    # Migration: add wiki_path if missing
+                    cursor.execute("""
+                        SELECT EXISTS (
+                            SELECT 1 FROM information_schema.columns
+                            WHERE table_name = 'projects' AND column_name = 'wiki_path'
+                        );
+                    """)
+                    if not cursor.fetchone()[0]:
+                        logger.info("Adding wiki_path column to projects table")
+                        cursor.execute("ALTER TABLE projects ADD COLUMN wiki_path TEXT;")
+                    # Migration: add path_patterns if missing
+                    cursor.execute("""
+                        SELECT EXISTS (
+                            SELECT 1 FROM information_schema.columns
+                            WHERE table_name = 'projects' AND column_name = 'path_patterns'
+                        );
+                    """)
+                    if not cursor.fetchone()[0]:
+                        logger.info("Adding path_patterns column to projects table")
+                        cursor.execute(
+                            "ALTER TABLE projects ADD COLUMN path_patterns TEXT[] "
+                            "NOT NULL DEFAULT '{}';"
+                        )
     except Exception as e:
         logger.error(f"Error creating database schema: {e}")
         raise

--- a/radbot/web/api/mcp.py
+++ b/radbot/web/api/mcp.py
@@ -1,0 +1,240 @@
+"""REST endpoints for the MCP bridge: token rotation and project registry.
+
+All endpoints require the admin bearer token (same mechanism as `admin.py`).
+Used by the "MCP bridge" admin panel.
+
+Note: the MCP HTTP transport itself (`/mcp/sse`, `/mcp/messages/`) is
+mounted from `radbot.mcp_server.http_transport` and gated separately by
+`RADBOT_MCP_TOKEN`. These admin routes are about *managing* that token
+plus the project registry — not about serving MCP traffic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/mcp", tags=["mcp"])
+
+_MCP_TOKEN_CREDENTIAL_KEY = "mcp_token"
+_ADMIN_TOKEN_ENV = "RADBOT_ADMIN_TOKEN"
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _verify_admin(
+    request: Request,
+    creds: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> None:
+    expected = os.environ.get(_ADMIN_TOKEN_ENV, "")
+    if not expected:
+        try:
+            from radbot.config.config_loader import config_loader
+
+            expected = config_loader.get_config().get("admin_token") or ""
+        except Exception:
+            pass
+    if not expected:
+        raise HTTPException(503, "Admin API disabled — RADBOT_ADMIN_TOKEN not set")
+    if creds and creds.credentials == expected:
+        return
+    raise HTTPException(401, "Invalid or missing admin bearer token")
+
+
+# ---------------------------------------------------------------------------
+# Token management
+# ---------------------------------------------------------------------------
+
+
+def _mask(token: str) -> str:
+    if not token:
+        return ""
+    if len(token) <= 8:
+        return "•" * len(token)
+    return f"{token[:4]}…{token[-4:]}"
+
+
+def _get_current_token() -> tuple[str, str]:
+    """Return `(token, source)` where source is `credential_store` | `env` | ``."""
+    try:
+        from radbot.credentials.store import get_credential_store
+
+        store = get_credential_store()
+        if store.available:
+            stored = (store.get(_MCP_TOKEN_CREDENTIAL_KEY) or "").strip()
+            if stored:
+                return stored, "credential_store"
+    except Exception as exc:
+        logger.debug("credential_store_unavailable err=%s", exc)
+    env_token = os.environ.get("RADBOT_MCP_TOKEN", "").strip()
+    if env_token:
+        return env_token, "env"
+    return "", ""
+
+
+@router.get("/status", dependencies=[Depends(_verify_admin)])
+async def mcp_status(request: Request) -> dict[str, Any]:
+    """Report current MCP bridge state: auth configured?, token masked, wiki root, base_url."""
+    token, source = _get_current_token()
+    wiki_path = os.environ.get("RADBOT_WIKI_PATH", "/mnt/ai-intel")
+    wiki_mounted = os.path.isdir(wiki_path)
+    base_url = str(request.base_url).rstrip("/")
+    return {
+        "auth_configured": bool(token),
+        "token_source": source,  # credential_store | env | "" (unconfigured)
+        "token_masked": _mask(token),
+        "wiki_path": wiki_path,
+        "wiki_mounted": wiki_mounted,
+        "sse_url": f"{base_url}/mcp/sse",
+        "setup_url": f"{base_url}/setup/claude-code.md",
+    }
+
+
+@router.get("/token/reveal", dependencies=[Depends(_verify_admin)])
+async def mcp_token_reveal() -> dict[str, str]:
+    """Return the current token in cleartext.
+
+    Deliberately a separate endpoint from `/status` so reveal is an explicit
+    admin action (logged by access patterns) rather than implicit on any
+    status fetch.
+    """
+    token, source = _get_current_token()
+    if not token:
+        raise HTTPException(404, "No MCP token configured (set RADBOT_MCP_TOKEN or rotate).")
+    return {"token": token, "source": source}
+
+
+@router.post("/token/rotate", dependencies=[Depends(_verify_admin)])
+async def mcp_token_rotate() -> dict[str, str]:
+    """Generate a new token, persist to credential store, return it once.
+
+    After rotation, any client holding the previous token will 401. The UI
+    shows this token in a one-time reveal modal — users must copy it into
+    their shell profiles on each machine before dismissing.
+    """
+    from radbot.credentials.store import get_credential_store
+
+    store = get_credential_store()
+    if not store.available:
+        raise HTTPException(
+            503, "Credential store unavailable — cannot rotate (set RADBOT_CREDENTIAL_KEY)"
+        )
+
+    new_token = secrets.token_urlsafe(32)
+    store.set(
+        _MCP_TOKEN_CREDENTIAL_KEY,
+        new_token,
+        credential_type="api_token",
+    )
+    logger.info("mcp_token_rotated token_prefix=%s", new_token[:6])
+    return {"token": new_token, "source": "credential_store"}
+
+
+# ---------------------------------------------------------------------------
+# Project registry CRUD
+# ---------------------------------------------------------------------------
+
+
+class ProjectIn(BaseModel):
+    name: str = Field(..., min_length=1)
+    path_patterns: list[str] = Field(default_factory=list)
+    wiki_path: str | None = None
+
+
+class ProjectPatch(BaseModel):
+    path_patterns: list[str] | None = None
+    wiki_path: str | None = None
+
+
+def _project_row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:
+    name, patterns, wiki_path = row
+    return {
+        "name": name,
+        "path_patterns": list(patterns or []),
+        "wiki_path": wiki_path,
+    }
+
+
+@router.get("/projects", dependencies=[Depends(_verify_admin)])
+async def list_projects() -> list[dict[str, Any]]:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn, get_db_cursor(conn) as c:
+        c.execute(
+            "SELECT name, path_patterns, wiki_path FROM projects ORDER BY name"
+        )
+        return [_project_row_to_dict(r) for r in c.fetchall()]
+
+
+@router.post("/projects", dependencies=[Depends(_verify_admin)])
+async def upsert_project(body: ProjectIn) -> dict[str, Any]:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    clean_patterns = [p.strip() for p in body.path_patterns if p and p.strip()]
+
+    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO projects (name, path_patterns, wiki_path)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (name) DO UPDATE
+              SET path_patterns = EXCLUDED.path_patterns,
+                  wiki_path = EXCLUDED.wiki_path
+            RETURNING name, path_patterns, wiki_path
+            """,
+            (body.name, clean_patterns, body.wiki_path),
+        )
+        row = c.fetchone()
+    return _project_row_to_dict(row)
+
+
+@router.patch("/projects/{name}", dependencies=[Depends(_verify_admin)])
+async def patch_project(name: str, body: ProjectPatch) -> dict[str, Any]:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    sets = []
+    params: list[Any] = []
+    if body.path_patterns is not None:
+        sets.append("path_patterns = %s")
+        params.append([p.strip() for p in body.path_patterns if p and p.strip()])
+    if body.wiki_path is not None:
+        sets.append("wiki_path = %s")
+        params.append(body.wiki_path or None)
+    if not sets:
+        raise HTTPException(400, "No fields to update")
+
+    params.append(name)
+    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
+        c.execute(
+            f"UPDATE projects SET {', '.join(sets)} "
+            "WHERE name = %s RETURNING name, path_patterns, wiki_path",
+            tuple(params),
+        )
+        row = c.fetchone()
+    if row is None:
+        raise HTTPException(404, f"No project named {name!r}")
+    return _project_row_to_dict(row)
+
+
+@router.delete("/projects/{name}", dependencies=[Depends(_verify_admin)])
+async def delete_project(name: str) -> dict[str, str]:
+    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
+        c.execute("DELETE FROM projects WHERE name = %s", (name,))
+        if c.rowcount == 0:
+            raise HTTPException(404, f"No project named {name!r}")
+    return {"deleted": name}

--- a/radbot/web/api/setup.py
+++ b/radbot/web/api/setup.py
@@ -1,0 +1,156 @@
+"""Self-service Claude Code bootstrap endpoint.
+
+`GET /setup/claude-code.md` returns a markdown guide that tells Claude Code
+how to configure itself against this radbot deployment. Unauthenticated so
+it can be fetched on a fresh machine before the user has any token set.
+
+The `base_url` is derived from the request so the same endpoint renders
+correctly for dev (`http://localhost:8000`) and prod
+(`https://radbot.demonsafe.com`).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter(prefix="/setup", tags=["setup"])
+
+
+_TEMPLATE = """# Configure Claude Code for radbot
+
+**Target radbot:** `{base_url}`
+
+You're reading this because someone pointed Claude Code at
+`{base_url}/setup/claude-code.md` and asked to be configured. Walk through
+the steps below, asking for confirmation before editing any files.
+
+---
+
+## 1. Get the MCP token
+
+The token lives in the operator's deployment secrets (Nomad env var
+`RADBOT_MCP_TOKEN`). Ask the user to paste it, then help them persist it:
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+export RADBOT_MCP_TOKEN="<paste>"
+export RADBOT_URL="{base_url}"
+```
+
+Have them `source` their profile before continuing.
+
+## 2. Add the MCP server to ~/.claude/settings.json
+
+Merge the following into the existing settings (do **not** overwrite the
+whole file — read it first, merge the `mcpServers` key):
+
+```json
+{{
+  "mcpServers": {{
+    "radbot": {{
+      "type": "http",
+      "url": "{base_url}/mcp/sse",
+      "headers": {{
+        "Authorization": "Bearer ${{RADBOT_MCP_TOKEN}}"
+      }}
+    }}
+  }}
+}}
+```
+
+## 3. Install the `SessionStart` hook
+
+Create `~/.claude/hooks/radbot-project-context.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Fetches per-project context from radbot when cwd matches a registered project.
+# Silent on unknown paths so it's safe to leave installed on every machine.
+set -euo pipefail
+
+: "${{RADBOT_URL:={base_url}}}"
+[ -z "${{RADBOT_MCP_TOKEN:-}}" ] && exit 0
+
+project=$(curl -sf \\
+  -H "Authorization: Bearer $RADBOT_MCP_TOKEN" \\
+  "$RADBOT_URL/api/projects/match?cwd=$PWD" \\
+  | jq -r '.project // empty' 2>/dev/null) || exit 0
+
+[ -z "$project" ] && exit 0
+
+curl -sf \\
+  -H "Authorization: Bearer $RADBOT_MCP_TOKEN" \\
+  "$RADBOT_URL/api/projects/$project/context.md"
+```
+
+Make it executable: `chmod +x ~/.claude/hooks/radbot-project-context.sh`
+
+Then merge into `~/.claude/settings.json`:
+
+```json
+{{
+  "hooks": {{
+    "SessionStart": [
+      {{"type": "command", "command": "~/.claude/hooks/radbot-project-context.sh"}}
+    ]
+  }}
+}}
+```
+
+## 4. (Optional) Mount the ai-intel wiki locally
+
+If the user has SMB access to the shared mount, add to their shell profile:
+
+```bash
+export AI_INTEL_MOUNT="/run/user/$(id -u)/gvfs/smb-share:server=beefcake.local,share=share/ai-intel"
+```
+
+Without this, the `llm-wiki:*` skills still work via radbot's MCP
+`wiki_*` tools — they just go over the network instead of the filesystem.
+
+## 5. Install the `/park` and `/resume` skills
+
+Preferred: from the `perrymanuk/claude-skills` marketplace (likely already
+in `~/.claude/settings.json` under `extraKnownMarketplaces`):
+
+> "Install the park and resume skills from the claude-skills marketplace."
+
+Manual fallback:
+
+```bash
+git clone git@github.com:perrymanuk/claude-skills.git ~/.claude/skills-src
+ln -s ~/.claude/skills-src/park ~/.claude/skills/park
+ln -s ~/.claude/skills-src/resume ~/.claude/skills/resume
+```
+
+## 6. Verify
+
+Start a new Claude Code session and ask:
+
+> What does radbot say my full Telos contains?
+
+Expected: Claude calls `telos_get_full` via the radbot MCP server and
+summarizes the user's mission / goals / projects. If instead Claude says
+the tool isn't available, check that the CLI was restarted after the
+settings edit.
+
+## Troubleshooting
+
+- **401 Unauthorized**: token missing or stale. Re-export and restart.
+- **503 MCP bridge disabled**: server is running but `RADBOT_MCP_TOKEN` is
+  unset in radbot's deployment env. Operator needs to set it and redeploy.
+- **No SessionStart context**: cwd doesn't match any registered radbot
+  project. Register it:
+  `project_register(name="myproj", path_patterns=["/git/myorg/myproj"])`
+  via the radbot MCP.
+- **Skill not found**: skills are scanned at CLI startup. Restart Claude
+  Code after adding them.
+"""
+
+
+@router.get("/claude-code.md", response_class=PlainTextResponse)
+async def claude_code_setup(request: Request) -> str:
+    """Render the Claude Code setup guide with this deployment's base URL."""
+    base_url = str(request.base_url).rstrip("/")
+    return _TEMPLATE.format(base_url=base_url)

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -56,6 +56,8 @@ from radbot.web.api.media import router as media_router
 from radbot.web.api.videos import router as videos_router
 from radbot.web.api.ha import router as ha_router
 from radbot.web.api.telos import router as telos_router
+from radbot.web.api.setup import router as setup_router
+from radbot.web.api.mcp import router as mcp_admin_router
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +95,18 @@ def create_app():
     app.include_router(videos_router)
     app.include_router(ha_router)
     app.include_router(telos_router)
+    app.include_router(setup_router)
+    app.include_router(mcp_admin_router)
     register_terminal_websocket(app)
+
+    # Mount MCP HTTP/SSE transport (gated by RADBOT_MCP_TOKEN env var)
+    try:
+        from radbot.mcp_server.http_transport import mount_mcp_on_app
+
+        mount_mcp_on_app(app)
+    except Exception as exc:
+        logger.error("Failed to mount MCP bridge: %s", exc, exc_info=True)
+
     logger.debug("API routers registered during app initialization")
 
     return app

--- a/radbot/web/frontend/src/components/admin/panels/McpBridgePanel.tsx
+++ b/radbot/web/frontend/src/components/admin/panels/McpBridgePanel.tsx
@@ -1,0 +1,389 @@
+import { useEffect, useState } from "react";
+import { useAdminStore } from "@/stores/admin-store";
+import * as adminApi from "@/lib/admin-api";
+import type { McpProject, McpStatus } from "@/lib/admin-api";
+import { Card, Note } from "@/components/admin/FormFields";
+
+/** Admin panel for the MCP bridge: token management + project registry. */
+export function McpBridgePanel() {
+  const { token, toast } = useAdminStore();
+  const [status, setStatus] = useState<McpStatus | null>(null);
+  const [projects, setProjects] = useState<McpProject[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Reveal / rotate modal state
+  const [revealed, setRevealed] = useState<string | null>(null);
+  const [revealKind, setRevealKind] = useState<"reveal" | "rotated" | null>(null);
+  const [rotating, setRotating] = useState(false);
+
+  const reload = async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const [s, p] = await Promise.all([
+        adminApi.getMcpStatus(token),
+        adminApi.listMcpProjects(token),
+      ]);
+      setStatus(s);
+      setProjects(p);
+    } catch (e: any) {
+      toast(`MCP status load failed: ${e.message}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const handleReveal = async () => {
+    if (!token) return;
+    try {
+      const r = await adminApi.revealMcpToken(token);
+      setRevealed(r.token);
+      setRevealKind("reveal");
+    } catch (e: any) {
+      toast(`Reveal failed: ${e.message}`, "error");
+    }
+  };
+
+  const handleRotate = async () => {
+    if (!token) return;
+    if (!window.confirm(
+      "Rotate MCP token? All clients using the old token will 401 until you re-copy " +
+      "the new one into their shell profiles."
+    )) return;
+    setRotating(true);
+    try {
+      const r = await adminApi.rotateMcpToken(token);
+      setRevealed(r.token);
+      setRevealKind("rotated");
+      await reload();
+    } catch (e: any) {
+      toast(`Rotate failed: ${e.message}`, "error");
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  const copyRevealed = () => {
+    if (revealed) {
+      navigator.clipboard.writeText(revealed);
+      toast("Token copied", "success");
+    }
+  };
+
+  const closeReveal = () => {
+    setRevealed(null);
+    setRevealKind(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card title="Status">
+        {loading || !status ? (
+          <div className="text-txt-secondary text-sm">Loading…</div>
+        ) : (
+          <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+            <dt className="text-txt-secondary">Auth configured</dt>
+            <dd className={status.auth_configured ? "text-green-400" : "text-yellow-400"}>
+              {status.auth_configured ? "yes" : "no — set RADBOT_MCP_TOKEN or rotate below"}
+            </dd>
+            <dt className="text-txt-secondary">Token source</dt>
+            <dd>{status.token_source || "—"}</dd>
+            <dt className="text-txt-secondary">Wiki path</dt>
+            <dd>
+              <code>{status.wiki_path}</code>{" "}
+              <span className={status.wiki_mounted ? "text-green-400" : "text-red-400"}>
+                ({status.wiki_mounted ? "mounted" : "not mounted"})
+              </span>
+            </dd>
+            <dt className="text-txt-secondary">MCP SSE URL</dt>
+            <dd><code>{status.sse_url}</code></dd>
+            <dt className="text-txt-secondary">Setup URL</dt>
+            <dd>
+              <a href={status.setup_url} target="_blank" rel="noreferrer" className="text-blue-400 underline">
+                {status.setup_url}
+              </a>
+            </dd>
+          </dl>
+        )}
+      </Card>
+
+      <Card title="Token">
+        <Note>
+          Token is managed via the <code>RADBOT_MCP_TOKEN</code> env var or the
+          credential store (store wins over env). Rotating generates a new
+          secure value in the store; you then copy it into each machine's
+          shell profile.
+        </Note>
+        <div className="flex items-center gap-3 mt-3">
+          <code className="text-sm bg-bg-secondary rounded px-2 py-1">
+            {status?.token_masked || "(not set)"}
+          </code>
+          <button
+            className="text-sm px-3 py-1 rounded bg-bg-secondary hover:bg-bg-tertiary"
+            disabled={!status?.auth_configured}
+            onClick={handleReveal}
+          >
+            Reveal
+          </button>
+          <button
+            className="text-sm px-3 py-1 rounded bg-red-600 hover:bg-red-700 text-white"
+            onClick={handleRotate}
+            disabled={rotating}
+          >
+            {rotating ? "Rotating…" : "Rotate"}
+          </button>
+        </div>
+      </Card>
+
+      <Card title="Project registry">
+        <Note>
+          Registered projects are matched against <code>cwd</code> by the
+          <code> SessionStart </code>hook. Each pattern is a substring test — any match
+          returns this project. <code>wiki_path</code> (optional) is the wiki
+          page whose contents load as session context.
+        </Note>
+        <ProjectTable
+          projects={projects}
+          onChange={reload}
+          token={token}
+        />
+      </Card>
+
+      {revealed !== null && (
+        <RevealModal
+          kind={revealKind}
+          token={revealed}
+          onCopy={copyRevealed}
+          onClose={closeReveal}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Project editor table ──────────────────────────────────────
+
+function ProjectTable({
+  projects, onChange, token,
+}: {
+  projects: McpProject[];
+  onChange: () => void | Promise<void>;
+  token: string | null;
+}) {
+  const { toast } = useAdminStore();
+  const [newName, setNewName] = useState("");
+  const [newPatterns, setNewPatterns] = useState("");
+  const [newWiki, setNewWiki] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const add = async () => {
+    if (!token || !newName.trim()) return;
+    setBusy("new");
+    try {
+      await adminApi.upsertMcpProject(token, {
+        name: newName.trim(),
+        path_patterns: newPatterns.split(",").map((s) => s.trim()).filter(Boolean),
+        wiki_path: newWiki.trim() || null,
+      });
+      setNewName(""); setNewPatterns(""); setNewWiki("");
+      await onChange();
+      toast(`Added ${newName.trim()}`, "success");
+    } catch (e: any) {
+      toast(`Add failed: ${e.message}`, "error");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const del = async (name: string) => {
+    if (!token) return;
+    if (!window.confirm(`Delete project "${name}"?`)) return;
+    setBusy(name);
+    try {
+      await adminApi.deleteMcpProject(token, name);
+      await onChange();
+      toast(`Deleted ${name}`, "success");
+    } catch (e: any) {
+      toast(`Delete failed: ${e.message}`, "error");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="mt-3 space-y-3">
+      <table className="w-full text-sm">
+        <thead className="text-txt-secondary text-left">
+          <tr>
+            <th className="py-1 pr-4">Name</th>
+            <th className="py-1 pr-4">Path patterns</th>
+            <th className="py-1 pr-4">Wiki path</th>
+            <th className="py-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {projects.map((p) => (
+            <ProjectRow key={p.name} project={p} onChange={onChange} token={token} busy={busy === p.name} onDelete={() => del(p.name)} />
+          ))}
+          <tr className="border-t border-border">
+            <td className="py-2 pr-4">
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="radbot"
+                className="bg-bg-secondary rounded px-2 py-1 w-full"
+              />
+            </td>
+            <td className="py-2 pr-4">
+              <input
+                value={newPatterns}
+                onChange={(e) => setNewPatterns(e.target.value)}
+                placeholder="/git/me/radbot, /work/foo (comma-separated)"
+                className="bg-bg-secondary rounded px-2 py-1 w-full"
+              />
+            </td>
+            <td className="py-2 pr-4">
+              <input
+                value={newWiki}
+                onChange={(e) => setNewWiki(e.target.value)}
+                placeholder="wiki/concepts/radbot.md"
+                className="bg-bg-secondary rounded px-2 py-1 w-full"
+              />
+            </td>
+            <td className="py-2">
+              <button
+                className="text-sm px-3 py-1 rounded bg-bg-tertiary hover:bg-bg-secondary"
+                onClick={add}
+                disabled={busy === "new" || !newName.trim()}
+              >
+                {busy === "new" ? "Adding…" : "Add"}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ProjectRow({
+  project, onChange, token, busy, onDelete,
+}: {
+  project: McpProject;
+  onChange: () => void | Promise<void>;
+  token: string | null;
+  busy: boolean;
+  onDelete: () => void;
+}) {
+  const { toast } = useAdminStore();
+  const [patterns, setPatterns] = useState(project.path_patterns.join(", "));
+  const [wiki, setWiki] = useState(project.wiki_path || "");
+  const [editing, setEditing] = useState(false);
+
+  const save = async () => {
+    if (!token) return;
+    try {
+      await adminApi.upsertMcpProject(token, {
+        name: project.name,
+        path_patterns: patterns.split(",").map((s) => s.trim()).filter(Boolean),
+        wiki_path: wiki.trim() || null,
+      });
+      setEditing(false);
+      await onChange();
+      toast(`Saved ${project.name}`, "success");
+    } catch (e: any) {
+      toast(`Save failed: ${e.message}`, "error");
+    }
+  };
+
+  return (
+    <tr className="border-t border-border">
+      <td className="py-2 pr-4 font-medium">{project.name}</td>
+      <td className="py-2 pr-4">
+        {editing ? (
+          <input
+            value={patterns}
+            onChange={(e) => setPatterns(e.target.value)}
+            className="bg-bg-secondary rounded px-2 py-1 w-full"
+          />
+        ) : (
+          <code className="text-xs">{patterns || "—"}</code>
+        )}
+      </td>
+      <td className="py-2 pr-4">
+        {editing ? (
+          <input
+            value={wiki}
+            onChange={(e) => setWiki(e.target.value)}
+            className="bg-bg-secondary rounded px-2 py-1 w-full"
+          />
+        ) : (
+          <code className="text-xs">{wiki || "—"}</code>
+        )}
+      </td>
+      <td className="py-2 flex gap-2 justify-end">
+        {editing ? (
+          <>
+            <button className="text-sm px-2 py-1 rounded bg-green-700 text-white" onClick={save}>Save</button>
+            <button className="text-sm px-2 py-1 rounded bg-bg-secondary" onClick={() => setEditing(false)}>Cancel</button>
+          </>
+        ) : (
+          <>
+            <button className="text-sm px-2 py-1 rounded bg-bg-tertiary hover:bg-bg-secondary" onClick={() => setEditing(true)}>Edit</button>
+            <button className="text-sm px-2 py-1 rounded bg-red-700 text-white disabled:opacity-50" onClick={onDelete} disabled={busy}>Delete</button>
+          </>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ── Reveal / post-rotate modal ───────────────────────────────
+
+function RevealModal({
+  kind, token, onCopy, onClose,
+}: {
+  kind: "reveal" | "rotated" | null;
+  token: string;
+  onCopy: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/60 z-[1100] flex items-center justify-center">
+      <div className="bg-bg-primary rounded-lg border border-border p-6 max-w-lg w-full space-y-4">
+        <h2 className="text-lg font-medium">
+          {kind === "rotated" ? "New MCP token" : "MCP token"}
+        </h2>
+        {kind === "rotated" && (
+          <div className="text-sm bg-yellow-900/30 border border-yellow-700 rounded px-3 py-2">
+            Rotation succeeded. Existing clients will 401 until you copy this
+            token into each machine's shell profile (<code>RADBOT_MCP_TOKEN</code>).
+            This token is shown <strong>once</strong> — copy it now.
+          </div>
+        )}
+        <code className="block bg-bg-secondary rounded px-3 py-2 text-sm break-all">
+          {token}
+        </code>
+        <div className="flex justify-end gap-2">
+          <button
+            className="text-sm px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            onClick={onCopy}
+          >
+            Copy
+          </button>
+          <button
+            className="text-sm px-3 py-1 rounded bg-bg-secondary hover:bg-bg-tertiary"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/radbot/web/frontend/src/lib/admin-api.ts
+++ b/radbot/web/frontend/src/lib/admin-api.ts
@@ -285,3 +285,52 @@ export async function telosResolvePrediction(
     body: JSON.stringify({ outcome, actual_value: actualValue ?? null }),
   });
 }
+
+// ── MCP bridge ───────────────────────────────────────────
+
+export interface McpStatus {
+  auth_configured: boolean;
+  token_source: "credential_store" | "env" | "";
+  token_masked: string;
+  wiki_path: string;
+  wiki_mounted: boolean;
+  sse_url: string;
+  setup_url: string;
+}
+
+export interface McpProject {
+  name: string;
+  path_patterns: string[];
+  wiki_path: string | null;
+}
+
+export async function getMcpStatus(token: string): Promise<McpStatus> {
+  return adminFetch("/api/mcp/status", { token });
+}
+
+export async function revealMcpToken(token: string): Promise<{ token: string; source: string }> {
+  return adminFetch("/api/mcp/token/reveal", { token });
+}
+
+export async function rotateMcpToken(token: string): Promise<{ token: string; source: string }> {
+  return adminFetch("/api/mcp/token/rotate", { token, method: "POST" });
+}
+
+export async function listMcpProjects(token: string): Promise<McpProject[]> {
+  return adminFetch("/api/mcp/projects", { token });
+}
+
+export async function upsertMcpProject(token: string, project: McpProject): Promise<McpProject> {
+  return adminFetch("/api/mcp/projects", {
+    token,
+    method: "POST",
+    body: JSON.stringify(project),
+  });
+}
+
+export async function deleteMcpProject(token: string, name: string): Promise<{ deleted: string }> {
+  return adminFetch(`/api/mcp/projects/${encodeURIComponent(name)}`, {
+    token,
+    method: "DELETE",
+  });
+}

--- a/radbot/web/frontend/src/pages/AdminPage.tsx
+++ b/radbot/web/frontend/src/pages/AdminPage.tsx
@@ -17,6 +17,7 @@ import { CredentialsPanel } from "@/components/admin/panels/CredentialsPanel";
 import { RawConfigPanel } from "@/components/admin/panels/RawConfigPanel";
 import { CostTrackingPanel } from "@/components/admin/panels/TelemetryPanels";
 import { TelosPanel } from "@/components/admin/panels/TelosPanel";
+import { McpBridgePanel } from "@/components/admin/panels/McpBridgePanel";
 
 // ── Navigation definition ──────────────────────────────────
 interface NavItem {
@@ -65,6 +66,7 @@ const NAV_ITEMS: NavItem[] = [
   // Security
   { id: "sanitization", label: "Sanitization", group: "Security" },
   // Advanced
+  { id: "mcp_bridge", label: "MCP Bridge", group: "Advanced" },
   { id: "mcp_servers", label: "MCP Servers", group: "Advanced" },
   { id: "credentials", label: "Credentials", group: "Advanced" },
   { id: "raw_config", label: "Raw Config", group: "Advanced" },
@@ -100,6 +102,7 @@ const PANEL_MAP: Record<string, React.ComponentType> = {
   github_app: GitHubAppPanel,
   claude_code: ClaudeCodePanel,
   sanitization: SanitizationPanel,
+  mcp_bridge: McpBridgePanel,
   mcp_servers: MCPServersPanel,
   credentials: CredentialsPanel,
   raw_config: RawConfigPanel,

--- a/specs/config.md
+++ b/specs/config.md
@@ -23,6 +23,8 @@ admin_token:       # Admin API bearer token
 |---------|---------|
 | `RADBOT_CREDENTIAL_KEY` | Fernet key for encrypted credentials in DB |
 | `RADBOT_ADMIN_TOKEN` | Bearer token for `/admin/` API |
+| `RADBOT_MCP_TOKEN` | Bootstrap bearer token for the MCP bridge HTTP transport. Credential-store entry `mcp_token` wins over this; rotating from the admin UI leaves the env var untouched but irrelevant |
+| `RADBOT_WIKI_PATH` | Filesystem root for the ai-intel wiki that `mcp_server.tools.wiki` operates on (default `/mnt/ai-intel`; Nomad bind-mounts `${var.shared_dir}ai-intel` here) |
 | `RADBOT_CONFIG_FILE` | Path to `config.yaml` (alias: `RADBOT_CONFIG`, default: auto-discovered) |
 | `RADBOT_ENV` | `dev` → loads `config.dev.yaml` before `config.yaml` in each search directory |
 | `RADBOT_MAIN_MODEL` / `RADBOT_SUB_MODEL` | Model overrides (if no DB/file entry exists) |

--- a/specs/deployment.md
+++ b/specs/deployment.md
@@ -24,6 +24,8 @@ Nomad templates a minimal `config.yaml` with only `database:` section. All other
 |---------|---------|
 | `RADBOT_CREDENTIAL_KEY` | Fernet key for encrypted credentials in DB |
 | `RADBOT_ADMIN_TOKEN` | Bearer token for `/admin/` API |
+| `RADBOT_MCP_TOKEN` | Bootstrap bearer for MCP bridge (credential-store `mcp_token` wins when set) |
+| `RADBOT_WIKI_PATH` | Wiki root inside the container (default `/mnt/ai-intel`, matches Nomad bind-mount) |
 | `RADBOT_CONFIG_FILE` | Path to `config.yaml` (alias: `RADBOT_CONFIG`; Nomad uses the `_FILE` variant) |
 | `RADBOT_ENV` | `dev` loads `config.dev.yaml` instead of `config.yaml` |
 | `RADBOT_WORKER_IMAGE_TAG` | Overrides `config:agent.worker_image_tag` for newly-spawned workspace workers |
@@ -38,6 +40,10 @@ constraint: shared_mount = true
 service: "radbot" (Traefik-enabled)
 health: GET /health every 30s
 resources: cpu=1000, memory=2048
+
+volumes:
+  - local/config.yaml:/app/config.yaml
+  - ${var.shared_dir}ai-intel:/mnt/ai-intel   # ai-intel wiki for MCP bridge
 ```
 
 ### Reverse Proxy Gotchas

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -9,7 +9,7 @@ Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_
 | Table | Module | Key columns |
 |-------|--------|-------------|
 | `tasks` | `tools/todo/db/schema.py` | `task_id` (UUID), `project_id`, `title`, `status` (backlog/inprogress/done), `related_info` (JSONB) |
-| `projects` | `tools/todo/db/schema.py` | `project_id` (UUID), `name` (UNIQUE) |
+| `projects` | `tools/todo/db/schema.py` | `project_id` (UUID), `name` (UNIQUE), `wiki_path` (TEXT, nullable — relative path under `$RADBOT_WIKI_PATH`), `path_patterns` (TEXT[], cwd substrings used by MCP `project_match`) |
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
@@ -65,6 +65,11 @@ Semantic memory via `radbot/memory/enhanced_memory/`.
 - Key: `RADBOT_CREDENTIAL_KEY` env var
 - Access: `get_credential_store().get("key_name")`
 - Admin UI: `/admin/` manages credentials + `config:<section>` entries
+
+Notable keys:
+
+- `mcp_token` — bearer token for the MCP bridge HTTP transport. Rotatable from admin UI (`POST /api/mcp/token/rotate`); generated via `secrets.token_urlsafe(32)`. Store value wins over `RADBOT_MCP_TOKEN` env var.
+- Integration keys (`overseerr_api_key`, `lidarr_api_key`, etc.) — see `specs/integrations.md`.
 
 ### Known Credential Keys (non-exhaustive)
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -335,7 +335,7 @@ Axel-specific (not a standalone module):
 | `validate_code` | Syntax/lint validation |
 | `generate_documentation` | Docstring / README generation |
 
-## MCP Tools
+## MCP — Consumer Side
 
 Loaded dynamically on the axel agent only:
 
@@ -343,6 +343,29 @@ Loaded dynamically on the axel agent only:
 - **Dynamic MCP**: `load_dynamic_mcp_tools()` — additional MCP servers from config
 
 Tool count varies based on available MCP servers.
+
+## MCP — Bridge Server (`radbot/mcp_server/`)
+
+Exposes **radbot itself** as an MCP server so external clients (primarily Claude Code on the user's laptop / desktop) can read and mutate radbot state. Distinct from the `tools/mcp/` consumer side. See `docs/implementation/mcp_bridge.md`.
+
+**Transports:**
+
+- **stdio**: `uv run python -m radbot.mcp_server` (local, no auth)
+- **HTTP/SSE**: `GET /mcp/sse` + `POST /mcp/messages/` mounted on the FastAPI app (bearer token)
+
+**Tool surface** (16, all returning markdown `TextContent`):
+
+| Group | Tools |
+|---|---|
+| Telos | `telos_get_full`, `telos_get_section`, `telos_get_entry`, `telos_search_journal` |
+| Wiki (at `$RADBOT_WIKI_PATH`) | `wiki_read`, `wiki_list`, `wiki_search`, `wiki_write` (strict path sanitization) |
+| Projects | `project_match(cwd)`, `project_list`, `project_register`, `project_get_context` |
+| Tasks / schedule | `list_tasks`, `list_reminders`, `list_scheduled_tasks` |
+| Memory | `search_memory` (Qdrant, default scope=`beto`, pass `agent_scope="all"` to widen) |
+
+**Return convention:** markdown for any structured output, plain single-line text for primitives (`project_match` → name) and action confirmations (`wiki_write` → `Wrote N bytes to <path>`). Never JSON to the LLM — JSON consumers hit the REST API at `/api/*`.
+
+**Token auth (HTTP):** credential store (`mcp_token` key) wins over `RADBOT_MCP_TOKEN` env var. Rotatable from the "MCP Bridge" admin panel via `POST /api/mcp/token/rotate`. Fails closed (503) when both unset.
 
 ## ADK Built-in Tools
 

--- a/specs/web.md
+++ b/specs/web.md
@@ -90,6 +90,9 @@ All registered in `radbot/web/app.py` via `app.include_router()` / `register_*_r
 | `api/stt.py` | `/api/stt` | Speech-to-text |
 | `api/health.py` | `/health` | Liveness endpoint for Nomad health check |
 | `api/malformed_function_handler.py` | (helper) | Malformed-tool-call repair utilities |
+| `api/mcp.py` | `/api/mcp` | MCP bridge admin: status, token reveal/rotate, project registry CRUD (admin-token-protected) |
+| `api/setup.py` | `/setup` | `GET /setup/claude-code.md` — unauth'd markdown bootstrap guide, base_url templated from request |
+| `mcp_server/http_transport.py` | `/mcp/sse`, `/mcp/messages/` | MCP SSE + messages endpoints (bearer-token-protected, 503 when unconfigured) |
 
 ## Direct-Action Endpoints (2026-04-18)
 

--- a/tests/unit/test_mcp_server_auth.py
+++ b/tests/unit/test_mcp_server_auth.py
@@ -1,0 +1,85 @@
+"""Unit tests for radbot.mcp_server.auth."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from starlette.requests import Request
+
+from radbot.mcp_server import auth
+
+
+def _fake_request(headers: dict[str, str] | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/mcp/sse",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    return Request(scope)
+
+
+class TestExpectedToken:
+    @patch.dict("os.environ", {"RADBOT_MCP_TOKEN": ""}, clear=False)
+    def test_returns_none_when_neither_source_configured(self):
+        with patch("radbot.credentials.store.get_credential_store") as gcs:
+            gcs.side_effect = Exception("unavailable")
+            assert auth._expected_token() is None
+
+    @patch.dict("os.environ", {"RADBOT_MCP_TOKEN": "env-token"}, clear=False)
+    def test_returns_env_when_no_credential_store(self):
+        with patch("radbot.credentials.store.get_credential_store") as gcs:
+            store = MagicMock()
+            store.available = False
+            gcs.return_value = store
+            assert auth._expected_token() == "env-token"
+
+    @patch.dict("os.environ", {"RADBOT_MCP_TOKEN": "env-token"}, clear=False)
+    def test_credential_store_wins_over_env(self):
+        # Credential store has priority per radbot config ordering
+        with patch("radbot.credentials.store.get_credential_store") as gcs:
+            store = MagicMock()
+            store.available = True
+            store.get.return_value = "store-token"
+            gcs.return_value = store
+            assert auth._expected_token() == "store-token"
+
+    @patch.dict("os.environ", {"RADBOT_MCP_TOKEN": "env-token"}, clear=False)
+    def test_falls_back_to_env_when_store_is_empty(self):
+        with patch("radbot.credentials.store.get_credential_store") as gcs:
+            store = MagicMock()
+            store.available = True
+            store.get.return_value = None  # no entry
+            gcs.return_value = store
+            assert auth._expected_token() == "env-token"
+
+
+class TestCheckBearer:
+    @patch("radbot.mcp_server.auth._expected_token", return_value=None)
+    def test_returns_503_when_unconfigured(self, _):
+        resp = auth.check_bearer(_fake_request())
+        assert resp is not None
+        assert resp.status_code == 503
+
+    @patch("radbot.mcp_server.auth._expected_token", return_value="secret")
+    def test_returns_401_when_header_missing(self, _):
+        resp = auth.check_bearer(_fake_request())
+        assert resp is not None
+        assert resp.status_code == 401
+
+    @patch("radbot.mcp_server.auth._expected_token", return_value="secret")
+    def test_returns_401_when_token_mismatch(self, _):
+        resp = auth.check_bearer(_fake_request({"authorization": "Bearer wrong"}))
+        assert resp is not None
+        assert resp.status_code == 401
+
+    @patch("radbot.mcp_server.auth._expected_token", return_value="secret")
+    def test_returns_none_when_token_matches(self, _):
+        resp = auth.check_bearer(_fake_request({"authorization": "Bearer secret"}))
+        assert resp is None
+
+    @patch("radbot.mcp_server.auth._expected_token", return_value="secret")
+    def test_rejects_non_bearer_scheme(self, _):
+        resp = auth.check_bearer(_fake_request({"authorization": "Basic dXNlcjpwYXNz"}))
+        assert resp is not None
+        assert resp.status_code == 401

--- a/tests/unit/test_mcp_setup_endpoint.py
+++ b/tests/unit/test_mcp_setup_endpoint.py
@@ -1,0 +1,44 @@
+"""Tests for the /setup/claude-code.md bootstrap endpoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _client():
+    # Late import so any previously-instantiated app is reused, and environment
+    # mutations from other tests don't bleed in.
+    from radbot.web.app import app
+
+    return TestClient(app)
+
+
+def test_setup_endpoint_returns_200_plaintext():
+    r = _client().get("/setup/claude-code.md")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/plain")
+
+
+def test_setup_endpoint_templates_base_url():
+    r = _client().get("/setup/claude-code.md")
+    # TestClient uses http://testserver as base
+    assert "http://testserver" in r.text
+    assert "{base_url}" not in r.text  # placeholder must be substituted
+
+
+def test_setup_endpoint_includes_required_sections():
+    r = _client().get("/setup/claude-code.md")
+    for header in [
+        "# Configure Claude Code for radbot",
+        "## 1. Get the MCP token",
+        "## 2. Add the MCP server",
+        "## 3. Install the `SessionStart` hook",
+        "## 6. Verify",
+    ]:
+        assert header in r.text, f"missing section: {header}"
+
+
+def test_setup_endpoint_is_unauthenticated():
+    # No Authorization header — should still return 200
+    r = _client().get("/setup/claude-code.md")
+    assert r.status_code == 200

--- a/tests/unit/test_mcp_wiki_sanitization.py
+++ b/tests/unit/test_mcp_wiki_sanitization.py
@@ -1,0 +1,92 @@
+"""Path-traversal and sanitization tests for mcp_server wiki tools."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from radbot.mcp_server.tools import wiki
+
+
+@pytest.fixture
+def wiki_root(monkeypatch):
+    """Create a temp wiki root + symlinked 'outside' dir for traversal tests."""
+    with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as outside:
+        # Populate root
+        os.makedirs(os.path.join(root, "wiki", "concepts"), exist_ok=True)
+        with open(os.path.join(root, "wiki", "concepts", "thing.md"), "w") as f:
+            f.write("# thing\n\nHello.\n")
+
+        # Create a symlink inside root pointing outside
+        os.symlink(outside, os.path.join(root, "symlink-out"))
+
+        # Create a file outside root
+        with open(os.path.join(outside, "secret.md"), "w") as f:
+            f.write("TOP SECRET")
+
+        monkeypatch.setenv("RADBOT_WIKI_PATH", root)
+        yield root
+
+
+class TestResolveUnderRoot:
+    def test_resolves_relative_path_inside_root(self, wiki_root):
+        abs_path, err = wiki._resolve_under_root("wiki/concepts/thing.md")
+        assert err == ""
+        assert abs_path is not None
+        assert abs_path.startswith(wiki_root)
+
+    def test_rejects_absolute_path(self, wiki_root):
+        abs_path, err = wiki._resolve_under_root("/etc/passwd")
+        assert abs_path is None
+        assert "Absolute paths not allowed" in err
+
+    def test_rejects_parent_traversal(self, wiki_root):
+        abs_path, err = wiki._resolve_under_root("../../../../etc/passwd")
+        assert abs_path is None
+        assert "escapes wiki root" in err
+
+    def test_rejects_symlink_leading_outside(self, wiki_root):
+        # `symlink-out/secret.md` resolves via the symlink to `outside/secret.md`
+        abs_path, err = wiki._resolve_under_root("symlink-out/secret.md")
+        assert abs_path is None
+        assert "escapes wiki root" in err
+
+    def test_returns_error_when_root_unconfigured(self, monkeypatch):
+        monkeypatch.setenv("RADBOT_WIKI_PATH", "/nonexistent-path-xyz")
+        abs_path, err = wiki._resolve_under_root("foo.md")
+        assert abs_path is None
+        assert "Wiki not configured" in err
+
+
+class TestWikiRead:
+    def test_reads_file(self, wiki_root):
+        result = wiki._do_read("wiki/concepts/thing.md")
+        assert "Hello." in result.text
+
+    def test_error_on_traversal(self, wiki_root):
+        result = wiki._do_read("../../../etc/passwd")
+        assert "**Error:**" in result.text
+
+    def test_error_on_missing(self, wiki_root):
+        result = wiki._do_read("wiki/does-not-exist.md")
+        assert "**Error:**" in result.text
+
+
+class TestWikiWrite:
+    def test_writes_and_creates_dirs(self, wiki_root):
+        result = wiki._do_write("wiki/new/nested/file.md", "fresh content\n")
+        assert "Wrote" in result.text
+        full = os.path.join(wiki_root, "wiki/new/nested/file.md")
+        assert os.path.isfile(full)
+        with open(full) as f:
+            assert f.read() == "fresh content\n"
+
+    def test_rejects_write_outside_root_via_traversal(self, wiki_root):
+        result = wiki._do_write("../../../tmp/hijack.md", "nope")
+        assert "**Error:**" in result.text
+
+    def test_rejects_write_through_symlink(self, wiki_root):
+        result = wiki._do_write("symlink-out/injected.md", "nope")
+        assert "**Error:**" in result.text


### PR DESCRIPTION
## Summary

New `radbot/mcp_server/` module exposes 16 radbot tools (Telos read, wiki read/write, project registry, todo/scheduler lists, Qdrant memory search) to external MCP clients over stdio or HTTP/SSE. Primary consumer: Claude Code running on laptop/desktop/phone; hits `radbot.demonsafe.com/mcp/sse` with a bearer token, auto-loads per-project context via a user-level SessionStart hook (no files committed to any repo).

- All tool returns are markdown `TextContent` — LLM-facing, never raw JSON
- Token auth reads credential store (`mcp_token`, rotatable from admin UI) then falls back to `RADBOT_MCP_TOKEN` env var
- `GET /setup/claude-code.md` is an unauth'd templated bootstrap that walks any new machine through install

## What's included

**Code**: `radbot/mcp_server/` (stdio + HTTP transport + 16 tools), `radbot/web/api/mcp.py` (admin: status / rotate / projects CRUD), `radbot/web/api/setup.py` (bootstrap markdown), `McpBridgePanel.tsx` (admin UI), schema migration for `projects.wiki_path` + `projects.path_patterns`.

**Tests**: 24 new unit tests — auth precedence (credential-store > env), wiki path sanitization (traversal, absolute paths, symlinks), setup endpoint templating.

**Docs**: `docs/implementation/mcp_bridge.md` with architecture + tool table. Spec updates in `SPEC.md`, `specs/tools.md`, `specs/web.md`, `specs/storage.md`, `specs/config.md`, `specs/deployment.md`. README one-line feature addition.

## Complementary PRs (separate repos)

- **hashi-homelab**: add `\${var.shared_dir}ai-intel:/mnt/ai-intel` volume + `RADBOT_MCP_TOKEN` + `RADBOT_WIKI_PATH` env vars to `radbot/nomad.job`
- **perrymanuk/claude-skills**: ship `radbot-setup` (meta-bootstrap skill that WebFetches `/setup/claude-code.md`) plus `park` / `resume` stubs for the next PR

## Deferred to subsequent PRs

- **PR 2 — Telos hierarchy**: `milestones` / `explorations` / `project_tasks` sections + `telos_render_project` that replaces Phase-1 `project_get_context` (which reads the static wiki file) with live hierarchy rendering
- **PR 3 — `/park` and `/resume`**: `parked_sessions` table + MCP tools for cross-device session continuity

## Test plan

- [ ] With token unset, `GET /mcp/sse` returns 503 with correct error body
- [ ] With token set via env, HTTP MCP handshake completes
- [ ] Rotate from admin UI → old token 401s, new token 200s
- [ ] `project_register` + `project_match` + SessionStart hook round-trip: cd into a registered repo, start Claude Code, context loads
- [ ] `wiki_read`, `wiki_list`, `wiki_search`, `wiki_write` against the real SMB-mounted ai-intel vault
- [ ] Traversal attempts on `wiki_*` return markdown errors, never escape root
- [ ] `GET /setup/claude-code.md` returns 200 with `https://radbot.demonsafe.com` base URL
- [ ] All 24 unit tests pass (`pytest tests/unit/test_mcp_*.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)