### PR TITLE
fix(mcp-bridge): correct SessionStart hook shape in setup guide

### DIFF
--- a/docs/implementation/mcp_bridge.md
+++ b/docs/implementation/mcp_bridge.md
@@ -183,6 +183,27 @@ on unknown paths, so it's safe to leave enabled on every machine. Lives
 in `~/.claude/settings.json` under `hooks.SessionStart` — **user-level,
 never committed to any repo**, so work-repo privacy is preserved.
 
+The `SessionStart` value is an array of matcher-scoped blocks:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "~/.claude/hooks/radbot-project-context.sh"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Matcher `""` = match everything. Putting command entries directly in the
+outer array (skipping the matcher wrapper) is a shape error Claude Code
+rejects with `hooks: Expected array, but received undefined`.
+
 > Note: `GET /api/projects/match?cwd=...` and
 > `GET /api/projects/{name}/context.md` are companion REST endpoints to
 > the MCP tools of the same names. They're thin wrappers around the MCP

--- a/radbot/web/api/setup.py
+++ b/radbot/web/api/setup.py
@@ -86,17 +86,29 @@ curl -sf \\
 
 Make it executable: `chmod +x ~/.claude/hooks/radbot-project-context.sh`
 
-Then merge into `~/.claude/settings.json`:
+Then merge into `~/.claude/settings.json`. Claude Code's hook shape is
+`[{{matcher, hooks: [...]}}]` — do **not** put command entries directly
+in the outer `SessionStart` array:
 
 ```json
 {{
   "hooks": {{
     "SessionStart": [
-      {{"type": "command", "command": "~/.claude/hooks/radbot-project-context.sh"}}
+      {{
+        "matcher": "",
+        "hooks": [
+          {{"type": "command", "command": "~/.claude/hooks/radbot-project-context.sh"}}
+        ]
+      }}
     ]
   }}
 }}
 ```
+
+If the user already has entries under `hooks.SessionStart`, add a new
+matcher block to the outer array (or append your command to an existing
+block's inner `hooks` list if its matcher is `""`). An empty matcher
+matches every session start.
 
 ## 4. (Optional) Mount the ai-intel wiki locally
 


### PR DESCRIPTION
## Summary

PR 1's setup guide (`/setup/claude-code.md`) and the mcp_bridge.md implementation doc both showed the wrong Claude Code hook shape. Users who followed the guide hit:

\`\`\`
/home/perry/.claude/settings.json
 └ hooks
   └ SessionStart
     └ 0
       └ hooks: Expected array, but received undefined

Files with errors are skipped entirely, not just the invalid settings.
\`\`\`

The outer \`SessionStart\` array holds matcher-scoped blocks, not command entries directly. Correct shape:

\`\`\`json
{
  "hooks": {
    "SessionStart": [
      {
        "matcher": "",
        "hooks": [
          {"type": "command", "command": "~/.claude/hooks/radbot-project-context.sh"}
        ]
      }
    ]
  }
}
\`\`\`

## Files changed

- \`radbot/web/api/setup.py\` — the templated guide Claude Code fetches via WebFetch on a fresh machine
- \`docs/implementation/mcp_bridge.md\` — the architecture doc's example

Docs-only, no runtime code touched.

## Existing-machine impact

Anyone who followed the bad guide before this lands has a broken \`~/.claude/settings.json\` that Claude Code ignores entirely — also losing \`mcpServers\`, \`permissions\`, and plugin enablement until they patch it. The companion \`perrymanuk/claude-skills\` PR fixes the skill body so \`radbot:setup\` writes the right shape on next use.

## Test plan

- [ ] \`curl https://radbot.demonsafe.com/setup/claude-code.md\` (after deploy) shows the \`matcher\`/\`hooks\` nesting in section 3
- [ ] A fresh machine following the guide produces a \`settings.json\` Claude Code accepts without the "Expected array" error
- [ ] \`~/.claude/hooks/radbot-project-context.sh\` fires on session start and injects project context when \`cd\`ing into a registered repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)