### PR TITLE
fix(mcp-bridge): back project tools against Telos, not todo.projects

### DIFF
--- a/docs/implementation/mcp_bridge.md
+++ b/docs/implementation/mcp_bridge.md
@@ -54,10 +54,10 @@ Both transports serve the same `Server` instance produced by
 | `wiki_list(glob?)` | markdown | Grouped by dir; 500-entry cap |
 | `wiki_search(query, glob?, limit?)` | markdown | `path:line — text` bullets |
 | `wiki_write(path, content)` | plain confirmation | Atomic via `.tmp` rename |
-| `project_match(cwd)` | plain string | Name or empty; used by SessionStart hook |
-| `project_list()` | markdown table | name · patterns · wiki_path |
-| `project_register(name, path_patterns, wiki_path?)` | plain confirmation | Upsert |
-| `project_get_context(name)` | markdown | Reads `wiki_path` file (PR 1); PR 2 swaps in live Telos hierarchy |
+| `project_match(cwd)` | plain string (ref_code) | Used by SessionStart hook; empty on miss |
+| `project_list()` | markdown table | ref · name · patterns · wiki_path (active Telos projects only) |
+| `project_set_path_patterns(ref_code, path_patterns, wiki_path?)` | plain confirmation | Updates `metadata` on an existing Telos project via `metadata_merge` |
+| `project_get_context(ref_or_name)` | markdown | Telos content + recent journal entries with matching `related_refs`. PR 2 replaces with full hierarchy render (milestones/tasks/explorations) |
 | `list_tasks(status?, project?)` | markdown | Grouped by status |
 | `list_reminders(status?)` | markdown | Relative-time phrasing |
 | `list_scheduled_tasks()` | markdown table | name · cron · enabled · prompt |
@@ -102,38 +102,68 @@ Nomad container). The `wiki_*` tools sanitize every input path:
 Tests cover: parent traversal (`../../../etc/passwd`), absolute paths,
 symlinks leading out of root. All return `**Error:** ...` markdown.
 
-## Project registry
+## Project registry (Telos-backed)
 
-Extends the existing `projects` table (created by `tools/todo/db/schema.py`)
-with two columns (idempotent migration):
+Projects are the entries in `telos_entries` where `section='projects'` —
+the same source of truth beto uses for goal/project context injection.
+Each project's `metadata` JSONB carries two optional MCP-bridge fields:
 
-| Column | Type | Purpose |
+| metadata key | Type | Purpose |
 |---|---|---|
-| `wiki_path` | TEXT | Path to the project's wiki page (relative to wiki root) |
-| `path_patterns` | TEXT[] | `cwd` substrings that identify this project |
+| `path_patterns` | list[str] | `cwd` substrings that identify this project. `project_match(cwd)` returns the project whose longest matching pattern wins. |
+| `wiki_path` | string | Optional path (relative to wiki root) to the project's wiki page. Consumed by `project_get_context` as a "further reading" link today; PR 2 replaces `project_get_context` with a live hierarchy render and this field becomes purely informational. |
 
-`project_match(cwd)` is the critical read: it does a SQL `LIKE '%<pattern>%'`
-against each element of `path_patterns` and returns the longest matching
-project name (ties broken by most-specific name). The SessionStart hook
-(see below) calls this on every session start; an empty result means "no
-radbot project matches this cwd — stay silent."
+`project_match(cwd)` is the critical read — called by Claude Code's
+SessionStart hook on every session start. Returns the project's
+**ref_code** (e.g. `P1`) for URL-safe pass-through. Empty result means
+"no Telos project claims this cwd" and the hook stays silent.
 
-`project_register(name, path_patterns, wiki_path)` is an UPSERT. Admin UI
-exposes an inline-edit table for browsing/adding/deleting.
+`project_set_path_patterns(ref_code, path_patterns, wiki_path?)`
+attaches MCP-bridge metadata to an existing Telos project via
+`metadata_merge`. It does **not** create Telos projects — that path
+remains through beto's confirm-required `telos_add_project`, so every
+project entry still passes through the regular Telos provenance.
+
+### Deprecated: todo.projects
+
+PR-1 briefly added `wiki_path` + `path_patterns` columns to the
+`tools/todo/db/schema.py` `projects` table (a lightweight todo-list
+registry, not identity-level projects). Those columns are unused after
+this PR; the migration was removed from `init_schema`. Existing DBs keep
+the columns harmlessly; new installs don't get them.
+
+### Admin UI
+
+The "MCP Bridge" panel lists the active Telos projects and lets you
+inline-edit their `path_patterns` + `wiki_path` by calling
+`PUT /api/telos/entry/projects/{ref}` with `metadata_merge`. No
+create/delete buttons — those belong in the Telos panel.
 
 ## REST endpoints
 
-All under `/api/mcp/`, admin-token-gated (same bearer as `/api/telos/*`):
+Two routers under different auth:
+
+**Admin-token-gated** (`/api/mcp/*`) — owned by the React admin panel:
 
 | Method + Path | Purpose |
 |---|---|
 | `GET /api/mcp/status` | Auth configured, token source, wiki mount check, SSE + setup URLs |
 | `GET /api/mcp/token/reveal` | Explicit reveal — returns cleartext token |
 | `POST /api/mcp/token/rotate` | Generates + stores + returns new token |
-| `GET /api/mcp/projects` | List all projects |
-| `POST /api/mcp/projects` | Upsert `{name, path_patterns, wiki_path?}` |
-| `PATCH /api/mcp/projects/{name}` | Partial update |
-| `DELETE /api/mcp/projects/{name}` | Remove |
+
+**MCP-token-gated** (`/api/projects/*`) — called by the SessionStart
+hook; mirrors the MCP tools so shell scripts can consume them without
+an MCP client:
+
+| Method + Path | Purpose |
+|---|---|
+| `GET /api/projects/match?cwd=<path>` | Returns `{"project": "<ref_code>"}` or `{"project": null}` |
+| `GET /api/projects/{ref_or_name}/context.md` | Renders the project context markdown |
+
+Project *listing* and *editing* use the existing `/api/telos/*` routes
+(`GET /api/telos/section/projects`, `PUT /api/telos/entry/projects/{ref}`
+with `metadata_merge`). Having two write paths for one resource would
+guarantee drift.
 
 Plus the MCP-transport endpoints (not under `/api/`, different auth):
 

--- a/radbot/mcp_server/tools/projects.py
+++ b/radbot/mcp_server/tools/projects.py
@@ -1,11 +1,18 @@
-"""Project registry MCP tools.
+"""Project registry MCP tools — backed by Telos.
 
-Projects are radbot's existing `projects` table rows extended with two
-columns added in PR 1: `wiki_path` (markdown file under the wiki root)
-and `path_patterns` (TEXT[] of cwd substrings that identify this project).
+Projects are the entries in `telos_entries` with `section='projects'`.
+Each project gets its `path_patterns` (list of cwd substrings) and
+optional `wiki_path` stored in its `metadata` JSONB — both are consumed
+by the Claude Code `SessionStart` hook to auto-load context when a user
+`cd`s into a matching repo.
 
-`project_match(cwd)` is the key tool: the Claude Code SessionStart hook
-calls it to decide whether to inject project context.
+Tools in this module never *create* telos projects — that goes through
+the confirm-required `telos_add_project` agent tool. These only read
+projects and attach MCP-bridge metadata to existing ones.
+
+PR-1 previously backed these tools against the unrelated `projects`
+table in `tools/todo/db/schema.py` (todo-list projects, not telos
+identity projects). That layer became dead after this PR.
 """
 
 from __future__ import annotations
@@ -20,9 +27,10 @@ def tools() -> list[mcp_types.Tool]:
         mcp_types.Tool(
             name="project_match",
             description=(
-                "Return the name of the project whose `path_patterns` match "
-                "the given cwd (any element of path_patterns must appear as a "
-                "substring of cwd). Returns empty if no match."
+                "Return the ref_code of the Telos project whose "
+                "`metadata.path_patterns` matches the given cwd (any "
+                "pattern must appear as a substring of cwd). Returns empty "
+                "if no match. Used by Claude Code's SessionStart hook."
             ),
             inputSchema={
                 "type": "object",
@@ -33,7 +41,10 @@ def tools() -> list[mcp_types.Tool]:
         ),
         mcp_types.Tool(
             name="project_list",
-            description="Return a markdown table of all registered projects.",
+            description=(
+                "Return a markdown table of all active Telos projects — "
+                "ref_code, name, path_patterns, wiki_path."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -41,38 +52,45 @@ def tools() -> list[mcp_types.Tool]:
             },
         ),
         mcp_types.Tool(
-            name="project_register",
+            name="project_set_path_patterns",
             description=(
-                "Create or update a project entry. `name` is the canonical "
-                "identifier. `path_patterns` is a list of cwd substrings "
-                "(e.g. ['/git/perrymanuk/radbot']). `wiki_path` is optional, "
-                "relative to the wiki root."
+                "Attach MCP-bridge metadata to an existing Telos project "
+                "(`metadata.path_patterns` + optional `metadata.wiki_path`). "
+                "Does not create new projects — use the confirm-required "
+                "`telos_add_project` agent tool for that. The ref_code "
+                "argument is the project's Telos ref (e.g. `P1`)."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "name": {"type": "string"},
+                    "ref_code": {"type": "string"},
                     "path_patterns": {
                         "type": "array",
                         "items": {"type": "string"},
                     },
-                    "wiki_path": {"type": "string"},
+                    "wiki_path": {
+                        "type": "string",
+                        "description": "Optional — relative path under wiki root.",
+                    },
                 },
-                "required": ["name", "path_patterns"],
+                "required": ["ref_code", "path_patterns"],
                 "additionalProperties": False,
             },
         ),
         mcp_types.Tool(
             name="project_get_context",
             description=(
-                "Return the project's context as markdown. Phase 1: reads the "
-                "registered `wiki_path` file. Phase 2 (PR 2): will render the "
-                "live Telos project hierarchy (milestones, tasks, explorations)."
+                "Return markdown for a Telos project — its current content "
+                "plus recent journal entries whose `metadata.related_refs` "
+                "contain this project's ref_code. Accepts either a ref_code "
+                "(`P1`) or the project name (matched against Telos entry "
+                "content). PR-2 will replace this with the full hierarchy "
+                "render (milestones / explorations / project_tasks)."
             ),
             inputSchema={
                 "type": "object",
-                "properties": {"name": {"type": "string"}},
-                "required": ["name"],
+                "properties": {"ref_or_name": {"type": "string"}},
+                "required": ["ref_or_name"],
                 "additionalProperties": False,
             },
         ),
@@ -86,134 +104,178 @@ async def call(
         return [_do_match(arguments["cwd"])]
     if name == "project_list":
         return [_do_list()]
-    if name == "project_register":
-        return [_do_register(
-            arguments["name"],
+    if name == "project_set_path_patterns":
+        return [_do_set_path_patterns(
+            arguments["ref_code"],
             list(arguments.get("path_patterns") or []),
             arguments.get("wiki_path"),
         )]
     if name == "project_get_context":
-        return [_do_get_context(arguments["name"])]
+        return [_do_get_context(arguments["ref_or_name"])]
     raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (lazy imports inside to keep module-import cost minimal)
+# ---------------------------------------------------------------------------
 
 
 def _err(msg: str) -> mcp_types.TextContent:
     return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
 
 
+def _active_projects():
+    """Yield active Telos projects with parsed metadata."""
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    return telos_db.list_section(Section.PROJECTS, status="active")
+
+
 def _do_match(cwd: str) -> mcp_types.TextContent:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    with get_db_connection() as conn, get_db_cursor(conn) as c:
-        c.execute(
-            "SELECT name FROM projects "
-            "WHERE EXISTS (SELECT 1 FROM unnest(path_patterns) p WHERE %s LIKE '%%' || p || '%%') "
-            "ORDER BY length(name) DESC LIMIT 1",
-            (cwd,),
-        )
-        row = c.fetchone()
-
-    if not row:
+    """Return the ref_code of the project whose path_patterns matches cwd."""
+    # Longest-pattern-first so more specific patterns win on overlap
+    best: tuple[int, str] | None = None
+    for project in _active_projects():
+        patterns = (project.metadata or {}).get("path_patterns") or []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern:
+                continue
+            if pattern in cwd:
+                score = len(pattern)
+                if best is None or score > best[0]:
+                    best = (score, project.ref_code or "")
+    if best is None or not best[1]:
         return mcp_types.TextContent(type="text", text="")
-    return mcp_types.TextContent(type="text", text=row[0])
+    return mcp_types.TextContent(type="text", text=best[1])
 
 
 def _do_list() -> mcp_types.TextContent:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    with get_db_connection() as conn, get_db_cursor(conn) as c:
-        c.execute(
-            "SELECT name, path_patterns, wiki_path FROM projects ORDER BY name"
-        )
-        rows = c.fetchall()
-
-    if not rows:
+    projects = list(_active_projects())
+    if not projects:
         return mcp_types.TextContent(
-            type="text", text="_No projects registered._"
+            type="text", text="_No active Telos projects._"
         )
-
     lines = [
-        "## Registered projects",
+        "## Telos projects (active)",
         "",
-        "| Name | Path patterns | Wiki page |",
-        "|---|---|---|",
+        "| ref | Name | Path patterns | Wiki page |",
+        "|---|---|---|---|",
     ]
-    for name, patterns, wiki_path in rows:
-        patterns_str = ", ".join(f"`{p}`" for p in (patterns or [])) or "—"
+    for p in projects:
+        meta = p.metadata or {}
+        patterns = meta.get("path_patterns") or []
+        wiki_path = meta.get("wiki_path")
+        patterns_str = ", ".join(f"`{pat}`" for pat in patterns) or "—"
         wiki_str = f"`{wiki_path}`" if wiki_path else "—"
-        lines.append(f"| `{name}` | {patterns_str} | {wiki_str} |")
+        name = (p.content or "").splitlines()[0][:80]
+        lines.append(
+            f"| `{p.ref_code or '?'}` | {name} | {patterns_str} | {wiki_str} |"
+        )
     return mcp_types.TextContent(type="text", text="\n".join(lines))
 
 
-def _do_register(
-    name: str, path_patterns: list[str], wiki_path: str | None
+def _do_set_path_patterns(
+    ref_code: str, path_patterns: list[str], wiki_path: str | None
 ) -> mcp_types.TextContent:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
 
     clean_patterns = [p.strip() for p in path_patterns if p and p.strip()]
-    if not clean_patterns:
-        return _err("At least one non-empty path_pattern is required.")
+    metadata_merge: dict[str, Any] = {"path_patterns": clean_patterns}
+    if wiki_path is not None:
+        metadata_merge["wiki_path"] = wiki_path.strip() or None
 
-    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
-        c.execute(
-            """
-            INSERT INTO projects (name, path_patterns, wiki_path)
-            VALUES (%s, %s, %s)
-            ON CONFLICT (name) DO UPDATE
-              SET path_patterns = EXCLUDED.path_patterns,
-                  wiki_path = EXCLUDED.wiki_path
-            RETURNING (xmax = 0) AS inserted
-            """,
-            (name, clean_patterns, wiki_path),
+    entry = telos_db.update_entry(
+        Section.PROJECTS, ref_code, metadata_merge=metadata_merge
+    )
+    if entry is None:
+        return _err(
+            f"No Telos project with ref_code `{ref_code}` — create it via "
+            "`telos_add_project` first."
         )
-        inserted = c.fetchone()[0]
-
-    verb = "Registered" if inserted else "Updated"
-    wiki_note = f" · wiki_path=`{wiki_path}`" if wiki_path else ""
+    name = (entry.content or "").splitlines()[0][:80]
+    bits = [f"patterns={clean_patterns}"]
+    if wiki_path is not None:
+        bits.append(f"wiki_path={wiki_path!r}")
     return mcp_types.TextContent(
         type="text",
-        text=f"{verb} project `{name}` · patterns={clean_patterns}{wiki_note}",
+        text=f"Set MCP bridge metadata on `{ref_code}` ({name}) — {' · '.join(bits)}",
     )
 
 
-def _do_get_context(name: str) -> mcp_types.TextContent:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
+def _find_project(ref_or_name: str):
+    """Locate a project by ref_code (exact) or by name (case-insensitive).
 
-    # Import here to reuse the same root + sanitization logic
-    from .wiki import _resolve_under_root, _wiki_root
+    Name match order: exact first-line match → case-insensitive first-line
+    match → substring match against the first line. This is lenient enough
+    that "radbot" matches a project whose content is
+    "radbot https://github.com/perrymanuk/radbot".
+    """
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
 
-    with get_db_connection() as conn, get_db_cursor(conn) as c:
-        c.execute("SELECT wiki_path FROM projects WHERE name = %s", (name,))
-        row = c.fetchone()
+    needle = ref_or_name.strip()
+    direct = telos_db.get_entry(Section.PROJECTS, needle)
+    if direct is not None:
+        return direct
 
-    if not row:
-        return _err(f"Unknown project: `{name}`")
-    wiki_path = row[0]
-    if not wiki_path:
-        return mcp_types.TextContent(
-            type="text",
-            text=(
-                f"## Project: {name}\n\n"
-                "_No wiki page registered for this project. "
-                "Set `wiki_path` via `project_register` to surface context here._"
-            ),
-        )
+    needle_low = needle.lower()
+    projects = list(_active_projects())
 
-    if _wiki_root() is None:
-        return _err("Wiki not configured: RADBOT_WIKI_PATH unset or missing.")
+    def _first_line(e) -> str:
+        return (e.content or "").splitlines()[0].strip()
 
-    abs_path, err = _resolve_under_root(wiki_path)
-    if abs_path is None:
-        return _err(err)
+    for p in projects:
+        if _first_line(p) == needle:
+            return p
+    for p in projects:
+        if _first_line(p).lower() == needle_low:
+            return p
+    for p in projects:
+        if needle_low in _first_line(p).lower():
+            return p
+    return None
 
-    import os as _os
-    if not _os.path.isfile(abs_path):
-        return _err(
-            f"Project `{name}` references missing wiki file: `{wiki_path}`"
-        )
 
-    try:
-        with open(abs_path, "r", encoding="utf-8") as f:
-            return mcp_types.TextContent(type="text", text=f.read())
-    except OSError as e:
-        return _err(f"Failed to read wiki page: {e}")
+def _do_get_context(ref_or_name: str) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    project = _find_project(ref_or_name)
+    if project is None:
+        return _err(f"Unknown project: `{ref_or_name}`")
+
+    meta = project.metadata or {}
+    name = (project.content or "").splitlines()[0][:80] or project.ref_code or "?"
+    lines = [f"# Project: {name} ({project.ref_code})", ""]
+
+    if project.content and "\n" in (project.content or ""):
+        lines.append(project.content.strip())
+        lines.append("")
+
+    if meta.get("wiki_path"):
+        lines.append(f"**Wiki page:** `{meta['wiki_path']}`")
+        lines.append("")
+
+    # Journal entries tagged with this project's ref_code
+    journal_entries = telos_db.list_section(
+        Section.JOURNAL, status=None, limit=50, order_by="created_at_desc"
+    )
+    related = [
+        e for e in journal_entries
+        if project.ref_code
+        and project.ref_code in (e.metadata or {}).get("related_refs", [])
+    ][:10]
+    if related:
+        lines.append("## Recent activity")
+        lines.append("")
+        for e in related:
+            date = e.created_at.strftime("%Y-%m-%d") if e.created_at else ""
+            content = (e.content or "").splitlines()[0][:200]
+            lines.append(f"- **{date}** — {content}")
+
+    if len(lines) <= 2:
+        lines.append("_No recent activity recorded for this project._")
+
+    return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())

--- a/radbot/tools/todo/db/schema.py
+++ b/radbot/tools/todo/db/schema.py
@@ -92,37 +92,17 @@ def create_schema_if_not_exists() -> None:
                         CREATE TABLE projects (
                             project_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                             name TEXT NOT NULL UNIQUE,
-                            wiki_path TEXT,
-                            path_patterns TEXT[] NOT NULL DEFAULT '{}',
                             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
                         );
                     """)
                     logger.info("Projects table created successfully")
                 else:
                     logger.info("Projects table already exists")
-                    # Migration: add wiki_path if missing
-                    cursor.execute("""
-                        SELECT EXISTS (
-                            SELECT 1 FROM information_schema.columns
-                            WHERE table_name = 'projects' AND column_name = 'wiki_path'
-                        );
-                    """)
-                    if not cursor.fetchone()[0]:
-                        logger.info("Adding wiki_path column to projects table")
-                        cursor.execute("ALTER TABLE projects ADD COLUMN wiki_path TEXT;")
-                    # Migration: add path_patterns if missing
-                    cursor.execute("""
-                        SELECT EXISTS (
-                            SELECT 1 FROM information_schema.columns
-                            WHERE table_name = 'projects' AND column_name = 'path_patterns'
-                        );
-                    """)
-                    if not cursor.fetchone()[0]:
-                        logger.info("Adding path_patterns column to projects table")
-                        cursor.execute(
-                            "ALTER TABLE projects ADD COLUMN path_patterns TEXT[] "
-                            "NOT NULL DEFAULT '{}';"
-                        )
+                # Note: earlier PR briefly added `wiki_path` + `path_patterns`
+                # columns here to power the MCP bridge. Those moved to
+                # Telos metadata (see `tools/telos`, section `projects`).
+                # Existing DBs keep the columns harmlessly; new installs
+                # don't get them.
     except Exception as e:
         logger.error(f"Error creating database schema: {e}")
         raise

--- a/radbot/web/api/mcp.py
+++ b/radbot/web/api/mcp.py
@@ -1,12 +1,24 @@
-"""REST endpoints for the MCP bridge: token rotation and project registry.
+"""REST endpoints for the MCP bridge.
 
-All endpoints require the admin bearer token (same mechanism as `admin.py`).
-Used by the "MCP bridge" admin panel.
+Two routers are exported:
 
-Note: the MCP HTTP transport itself (`/mcp/sse`, `/mcp/messages/`) is
-mounted from `radbot.mcp_server.http_transport` and gated separately by
-`RADBOT_MCP_TOKEN`. These admin routes are about *managing* that token
-plus the project registry — not about serving MCP traffic.
+- `router` — prefix `/api/mcp`, admin-token-gated. Manages the MCP token
+  (view, reveal, rotate) and exposes operational status. Consumed by the
+  React admin panel.
+- `public_router` — prefix `/api/projects`, MCP-token-gated. Serves the
+  endpoints the Claude Code `SessionStart` hook calls: `match?cwd=...`
+  and `{ref_or_name}/context.md`. These mirror the MCP tools of the same
+  name so shell scripts can consume them without an MCP client.
+
+The MCP HTTP transport itself (`/mcp/sse`, `/mcp/messages/`) is mounted
+from `radbot.mcp_server.http_transport` and handled separately.
+
+Project listing/editing is **not** surfaced here anymore — projects live
+in `telos_entries` (section `projects`) and are managed through
+`/api/telos/*` and the Telos admin panel. The `wiki_path` and
+`path_patterns` attached to each project are stored in Telos's JSONB
+`metadata` field and edited via `PUT /api/telos/entry/projects/{ref}`
+with `metadata_merge`.
 """
 
 from __future__ import annotations
@@ -16,13 +28,14 @@ import os
 import secrets
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/mcp", tags=["mcp"])
+public_router = APIRouter(prefix="/api/projects", tags=["mcp-public"])
 
 _MCP_TOKEN_CREDENTIAL_KEY = "mcp_token"
 _ADMIN_TOKEN_ENV = "RADBOT_ADMIN_TOKEN"
@@ -52,6 +65,22 @@ def _verify_admin(
     if creds and creds.credentials == expected:
         return
     raise HTTPException(401, "Invalid or missing admin bearer token")
+
+
+def _verify_mcp(
+    request: Request,
+    creds: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> None:
+    """Auth the hook-facing endpoints against the same MCP bearer as /mcp/sse."""
+    # Reuse the transport-side auth module so there's one source of truth
+    from radbot.mcp_server import auth as mcp_auth
+
+    expected = mcp_auth._expected_token()
+    if expected is None:
+        raise HTTPException(503, "MCP bridge disabled — RADBOT_MCP_TOKEN not set")
+    if creds and creds.credentials == expected:
+        return
+    raise HTTPException(401, "Invalid or missing bearer token")
 
 
 # ---------------------------------------------------------------------------
@@ -87,14 +116,14 @@ def _get_current_token() -> tuple[str, str]:
 
 @router.get("/status", dependencies=[Depends(_verify_admin)])
 async def mcp_status(request: Request) -> dict[str, Any]:
-    """Report current MCP bridge state: auth configured?, token masked, wiki root, base_url."""
+    """Report current MCP bridge state."""
     token, source = _get_current_token()
     wiki_path = os.environ.get("RADBOT_WIKI_PATH", "/mnt/ai-intel")
     wiki_mounted = os.path.isdir(wiki_path)
     base_url = str(request.base_url).rstrip("/")
     return {
         "auth_configured": bool(token),
-        "token_source": source,  # credential_store | env | "" (unconfigured)
+        "token_source": source,
         "token_masked": _mask(token),
         "wiki_path": wiki_path,
         "wiki_mounted": wiki_mounted,
@@ -105,12 +134,7 @@ async def mcp_status(request: Request) -> dict[str, Any]:
 
 @router.get("/token/reveal", dependencies=[Depends(_verify_admin)])
 async def mcp_token_reveal() -> dict[str, str]:
-    """Return the current token in cleartext.
-
-    Deliberately a separate endpoint from `/status` so reveal is an explicit
-    admin action (logged by access patterns) rather than implicit on any
-    status fetch.
-    """
+    """Return the current token in cleartext (explicit admin action)."""
     token, source = _get_current_token()
     if not token:
         raise HTTPException(404, "No MCP token configured (set RADBOT_MCP_TOKEN or rotate).")
@@ -119,12 +143,7 @@ async def mcp_token_reveal() -> dict[str, str]:
 
 @router.post("/token/rotate", dependencies=[Depends(_verify_admin)])
 async def mcp_token_rotate() -> dict[str, str]:
-    """Generate a new token, persist to credential store, return it once.
-
-    After rotation, any client holding the previous token will 401. The UI
-    shows this token in a one-time reveal modal — users must copy it into
-    their shell profiles on each machine before dismissing.
-    """
+    """Generate a new token, persist to credential store, return it once."""
     from radbot.credentials.store import get_credential_store
 
     store = get_credential_store()
@@ -144,97 +163,32 @@ async def mcp_token_rotate() -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
-# Project registry CRUD
+# Hook-facing endpoints (MCP-token-gated)
+#
+# These mirror the `project_match` and `project_get_context` MCP tools so
+# shell scripts (notably the SessionStart hook) can consume them without
+# running a full MCP client.
 # ---------------------------------------------------------------------------
 
 
-class ProjectIn(BaseModel):
-    name: str = Field(..., min_length=1)
-    path_patterns: list[str] = Field(default_factory=list)
-    wiki_path: str | None = None
+@public_router.get("/match", dependencies=[Depends(_verify_mcp)])
+async def project_match_rest(cwd: str = Query(...)) -> dict[str, str | None]:
+    """Return `{"project": ref_code}` or `{"project": null}`."""
+    # Delegate to the MCP tool to avoid logic drift
+    from radbot.mcp_server.tools import projects as proj_tools
+
+    content = proj_tools._do_match(cwd).text.strip()
+    return {"project": content or None}
 
 
-class ProjectPatch(BaseModel):
-    path_patterns: list[str] | None = None
-    wiki_path: str | None = None
+@public_router.get(
+    "/{ref_or_name}/context.md",
+    response_class=PlainTextResponse,
+    dependencies=[Depends(_verify_mcp)],
+)
+async def project_context_rest(ref_or_name: str) -> str:
+    from radbot.mcp_server.tools import projects as proj_tools
 
-
-def _project_row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:
-    name, patterns, wiki_path = row
-    return {
-        "name": name,
-        "path_patterns": list(patterns or []),
-        "wiki_path": wiki_path,
-    }
-
-
-@router.get("/projects", dependencies=[Depends(_verify_admin)])
-async def list_projects() -> list[dict[str, Any]]:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    with get_db_connection() as conn, get_db_cursor(conn) as c:
-        c.execute(
-            "SELECT name, path_patterns, wiki_path FROM projects ORDER BY name"
-        )
-        return [_project_row_to_dict(r) for r in c.fetchall()]
-
-
-@router.post("/projects", dependencies=[Depends(_verify_admin)])
-async def upsert_project(body: ProjectIn) -> dict[str, Any]:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    clean_patterns = [p.strip() for p in body.path_patterns if p and p.strip()]
-
-    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
-        c.execute(
-            """
-            INSERT INTO projects (name, path_patterns, wiki_path)
-            VALUES (%s, %s, %s)
-            ON CONFLICT (name) DO UPDATE
-              SET path_patterns = EXCLUDED.path_patterns,
-                  wiki_path = EXCLUDED.wiki_path
-            RETURNING name, path_patterns, wiki_path
-            """,
-            (body.name, clean_patterns, body.wiki_path),
-        )
-        row = c.fetchone()
-    return _project_row_to_dict(row)
-
-
-@router.patch("/projects/{name}", dependencies=[Depends(_verify_admin)])
-async def patch_project(name: str, body: ProjectPatch) -> dict[str, Any]:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    sets = []
-    params: list[Any] = []
-    if body.path_patterns is not None:
-        sets.append("path_patterns = %s")
-        params.append([p.strip() for p in body.path_patterns if p and p.strip()])
-    if body.wiki_path is not None:
-        sets.append("wiki_path = %s")
-        params.append(body.wiki_path or None)
-    if not sets:
-        raise HTTPException(400, "No fields to update")
-
-    params.append(name)
-    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
-        c.execute(
-            f"UPDATE projects SET {', '.join(sets)} "
-            "WHERE name = %s RETURNING name, path_patterns, wiki_path",
-            tuple(params),
-        )
-        row = c.fetchone()
-    if row is None:
-        raise HTTPException(404, f"No project named {name!r}")
-    return _project_row_to_dict(row)
-
-
-@router.delete("/projects/{name}", dependencies=[Depends(_verify_admin)])
-async def delete_project(name: str) -> dict[str, str]:
-    from radbot.tools.todo.db.connection import get_db_connection, get_db_cursor
-
-    with get_db_connection() as conn, get_db_cursor(conn, commit=True) as c:
-        c.execute("DELETE FROM projects WHERE name = %s", (name,))
-        if c.rowcount == 0:
-            raise HTTPException(404, f"No project named {name!r}")
-    return {"deleted": name}
+    result = proj_tools._do_get_context(ref_or_name)
+    # `_do_get_context` always returns markdown (or an error block)
+    return result.text

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -57,7 +57,10 @@ from radbot.web.api.videos import router as videos_router
 from radbot.web.api.ha import router as ha_router
 from radbot.web.api.telos import router as telos_router
 from radbot.web.api.setup import router as setup_router
-from radbot.web.api.mcp import router as mcp_admin_router
+from radbot.web.api.mcp import (
+    router as mcp_admin_router,
+    public_router as mcp_public_router,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +100,7 @@ def create_app():
     app.include_router(telos_router)
     app.include_router(setup_router)
     app.include_router(mcp_admin_router)
+    app.include_router(mcp_public_router)
     register_terminal_websocket(app)
 
     # Mount MCP HTTP/SSE transport (gated by RADBOT_MCP_TOKEN env var)

--- a/radbot/web/frontend/src/components/admin/panels/McpBridgePanel.tsx
+++ b/radbot/web/frontend/src/components/admin/panels/McpBridgePanel.tsx
@@ -1,14 +1,22 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAdminStore } from "@/stores/admin-store";
 import * as adminApi from "@/lib/admin-api";
-import type { McpProject, McpStatus } from "@/lib/admin-api";
+import type { McpStatus, TelosEntry } from "@/lib/admin-api";
 import { Card, Note } from "@/components/admin/FormFields";
 
-/** Admin panel for the MCP bridge: token management + project registry. */
+/** Admin panel for the MCP bridge.
+ *
+ * Token management (status, reveal, rotate) is owned by this panel. Project
+ * entries live in Telos (`section='projects'`), so the registry section
+ * here just lists active Telos projects and lets the user attach
+ * `path_patterns` + `wiki_path` to each one via `metadata_merge`. Creating
+ * new Telos projects happens elsewhere (confirm-required `telos_add_project`
+ * agent tool or the Telos admin panel).
+ */
 export function McpBridgePanel() {
   const { token, toast } = useAdminStore();
   const [status, setStatus] = useState<McpStatus | null>(null);
-  const [projects, setProjects] = useState<McpProject[]>([]);
+  const [projects, setProjects] = useState<TelosEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Reveal / rotate modal state
@@ -22,10 +30,10 @@ export function McpBridgePanel() {
     try {
       const [s, p] = await Promise.all([
         adminApi.getMcpStatus(token),
-        adminApi.listMcpProjects(token),
+        adminApi.telosGetSection(token, "projects"),
       ]);
       setStatus(s);
-      setProjects(p);
+      setProjects(p.entries);
     } catch (e: any) {
       toast(`MCP status load failed: ${e.message}`, "error");
     } finally {
@@ -114,10 +122,10 @@ export function McpBridgePanel() {
 
       <Card title="Token">
         <Note>
-          Token is managed via the <code>RADBOT_MCP_TOKEN</code> env var or the
-          credential store (store wins over env). Rotating generates a new
-          secure value in the store; you then copy it into each machine's
-          shell profile.
+          Token is managed via the <code>RADBOT_MCP_TOKEN</code> env var or
+          the credential store (store wins over env). Rotating generates a
+          new secure value in the store; you then copy it into each
+          machine's shell profile.
         </Note>
         <div className="flex items-center gap-3 mt-3">
           <code className="text-sm bg-bg-secondary rounded px-2 py-1">
@@ -140,18 +148,16 @@ export function McpBridgePanel() {
         </div>
       </Card>
 
-      <Card title="Project registry">
+      <Card title="Project registry (Telos-backed)">
         <Note>
-          Registered projects are matched against <code>cwd</code> by the
-          <code> SessionStart </code>hook. Each pattern is a substring test — any match
-          returns this project. <code>wiki_path</code> (optional) is the wiki
-          page whose contents load as session context.
+          These are the projects in your Telos (<code>section: projects</code>).
+          Attach <code>path_patterns</code> (cwd substrings) and an optional
+          <code> wiki_path</code> to each one and the SessionStart hook will
+          inject that project's context whenever you <code>cd</code> into a
+          matching repo. Create or archive projects from the Telos panel —
+          they're identity entries, not MCP-bridge settings.
         </Note>
-        <ProjectTable
-          projects={projects}
-          onChange={reload}
-          token={token}
-        />
+        <ProjectTable projects={projects} onChange={reload} token={token} />
       </Card>
 
       {revealed !== null && (
@@ -166,60 +172,29 @@ export function McpBridgePanel() {
   );
 }
 
-// ── Project editor table ──────────────────────────────────────
+// ── Telos-project editor table ────────────────────────────────
 
 function ProjectTable({
   projects, onChange, token,
 }: {
-  projects: McpProject[];
+  projects: TelosEntry[];
   onChange: () => void | Promise<void>;
   token: string | null;
 }) {
-  const { toast } = useAdminStore();
-  const [newName, setNewName] = useState("");
-  const [newPatterns, setNewPatterns] = useState("");
-  const [newWiki, setNewWiki] = useState("");
-  const [busy, setBusy] = useState<string | null>(null);
-
-  const add = async () => {
-    if (!token || !newName.trim()) return;
-    setBusy("new");
-    try {
-      await adminApi.upsertMcpProject(token, {
-        name: newName.trim(),
-        path_patterns: newPatterns.split(",").map((s) => s.trim()).filter(Boolean),
-        wiki_path: newWiki.trim() || null,
-      });
-      setNewName(""); setNewPatterns(""); setNewWiki("");
-      await onChange();
-      toast(`Added ${newName.trim()}`, "success");
-    } catch (e: any) {
-      toast(`Add failed: ${e.message}`, "error");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  const del = async (name: string) => {
-    if (!token) return;
-    if (!window.confirm(`Delete project "${name}"?`)) return;
-    setBusy(name);
-    try {
-      await adminApi.deleteMcpProject(token, name);
-      await onChange();
-      toast(`Deleted ${name}`, "success");
-    } catch (e: any) {
-      toast(`Delete failed: ${e.message}`, "error");
-    } finally {
-      setBusy(null);
-    }
-  };
-
+  if (!projects.length) {
+    return (
+      <div className="mt-3 text-sm text-txt-secondary">
+        _No active Telos projects. Ask beto to add one via
+        <code> telos_add_project</code>._
+      </div>
+    );
+  }
   return (
     <div className="mt-3 space-y-3">
       <table className="w-full text-sm">
         <thead className="text-txt-secondary text-left">
           <tr>
+            <th className="py-1 pr-4">Ref</th>
             <th className="py-1 pr-4">Name</th>
             <th className="py-1 pr-4">Path patterns</th>
             <th className="py-1 pr-4">Wiki path</th>
@@ -228,43 +203,8 @@ function ProjectTable({
         </thead>
         <tbody>
           {projects.map((p) => (
-            <ProjectRow key={p.name} project={p} onChange={onChange} token={token} busy={busy === p.name} onDelete={() => del(p.name)} />
+            <ProjectRow key={p.entry_id} project={p} onChange={onChange} token={token} />
           ))}
-          <tr className="border-t border-border">
-            <td className="py-2 pr-4">
-              <input
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="radbot"
-                className="bg-bg-secondary rounded px-2 py-1 w-full"
-              />
-            </td>
-            <td className="py-2 pr-4">
-              <input
-                value={newPatterns}
-                onChange={(e) => setNewPatterns(e.target.value)}
-                placeholder="/git/me/radbot, /work/foo (comma-separated)"
-                className="bg-bg-secondary rounded px-2 py-1 w-full"
-              />
-            </td>
-            <td className="py-2 pr-4">
-              <input
-                value={newWiki}
-                onChange={(e) => setNewWiki(e.target.value)}
-                placeholder="wiki/concepts/radbot.md"
-                className="bg-bg-secondary rounded px-2 py-1 w-full"
-              />
-            </td>
-            <td className="py-2">
-              <button
-                className="text-sm px-3 py-1 rounded bg-bg-tertiary hover:bg-bg-secondary"
-                onClick={add}
-                disabled={busy === "new" || !newName.trim()}
-              >
-                {busy === "new" ? "Adding…" : "Add"}
-              </button>
-            </td>
-          </tr>
         </tbody>
       </table>
     </div>
@@ -272,43 +212,55 @@ function ProjectTable({
 }
 
 function ProjectRow({
-  project, onChange, token, busy, onDelete,
+  project, onChange, token,
 }: {
-  project: McpProject;
+  project: TelosEntry;
   onChange: () => void | Promise<void>;
   token: string | null;
-  busy: boolean;
-  onDelete: () => void;
 }) {
   const { toast } = useAdminStore();
-  const [patterns, setPatterns] = useState(project.path_patterns.join(", "));
-  const [wiki, setWiki] = useState(project.wiki_path || "");
+  const initialPatterns = useMemo(
+    () => ((project.metadata?.path_patterns as string[] | undefined) ?? []).join(", "),
+    [project.metadata?.path_patterns],
+  );
+  const initialWiki = (project.metadata?.wiki_path as string | undefined) ?? "";
+  const [patterns, setPatterns] = useState(initialPatterns);
+  const [wiki, setWiki] = useState(initialWiki);
   const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   const save = async () => {
-    if (!token) return;
+    if (!token || !project.ref_code) return;
+    setSaving(true);
     try {
-      await adminApi.upsertMcpProject(token, {
-        name: project.name,
-        path_patterns: patterns.split(",").map((s) => s.trim()).filter(Boolean),
-        wiki_path: wiki.trim() || null,
+      await adminApi.telosUpdateEntry(token, "projects", project.ref_code, {
+        metadata_merge: {
+          path_patterns: patterns.split(",").map((s) => s.trim()).filter(Boolean),
+          wiki_path: wiki.trim() || null,
+        },
       });
       setEditing(false);
       await onChange();
-      toast(`Saved ${project.name}`, "success");
+      toast(`Saved ${project.ref_code}`, "success");
     } catch (e: any) {
       toast(`Save failed: ${e.message}`, "error");
+    } finally {
+      setSaving(false);
     }
   };
 
+  const name = (project.content || "").split("\n")[0].slice(0, 80);
+
   return (
     <tr className="border-t border-border">
-      <td className="py-2 pr-4 font-medium">{project.name}</td>
+      <td className="py-2 pr-4 font-mono text-xs">{project.ref_code}</td>
+      <td className="py-2 pr-4">{name || <span className="text-txt-secondary">—</span>}</td>
       <td className="py-2 pr-4">
         {editing ? (
           <input
             value={patterns}
             onChange={(e) => setPatterns(e.target.value)}
+            placeholder="/git/me/radbot, /work/foo (comma-separated)"
             className="bg-bg-secondary rounded px-2 py-1 w-full"
           />
         ) : (
@@ -320,6 +272,7 @@ function ProjectRow({
           <input
             value={wiki}
             onChange={(e) => setWiki(e.target.value)}
+            placeholder="wiki/concepts/radbot.md"
             className="bg-bg-secondary rounded px-2 py-1 w-full"
           />
         ) : (
@@ -329,14 +282,27 @@ function ProjectRow({
       <td className="py-2 flex gap-2 justify-end">
         {editing ? (
           <>
-            <button className="text-sm px-2 py-1 rounded bg-green-700 text-white" onClick={save}>Save</button>
-            <button className="text-sm px-2 py-1 rounded bg-bg-secondary" onClick={() => setEditing(false)}>Cancel</button>
+            <button
+              className="text-sm px-2 py-1 rounded bg-green-700 text-white disabled:opacity-50"
+              onClick={save}
+              disabled={saving}
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button
+              className="text-sm px-2 py-1 rounded bg-bg-secondary"
+              onClick={() => { setEditing(false); setPatterns(initialPatterns); setWiki(initialWiki); }}
+            >
+              Cancel
+            </button>
           </>
         ) : (
-          <>
-            <button className="text-sm px-2 py-1 rounded bg-bg-tertiary hover:bg-bg-secondary" onClick={() => setEditing(true)}>Edit</button>
-            <button className="text-sm px-2 py-1 rounded bg-red-700 text-white disabled:opacity-50" onClick={onDelete} disabled={busy}>Delete</button>
-          </>
+          <button
+            className="text-sm px-2 py-1 rounded bg-bg-tertiary hover:bg-bg-secondary"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </button>
         )}
       </td>
     </tr>

--- a/radbot/web/frontend/src/lib/admin-api.ts
+++ b/radbot/web/frontend/src/lib/admin-api.ts
@@ -298,12 +298,6 @@ export interface McpStatus {
   setup_url: string;
 }
 
-export interface McpProject {
-  name: string;
-  path_patterns: string[];
-  wiki_path: string | null;
-}
-
 export async function getMcpStatus(token: string): Promise<McpStatus> {
   return adminFetch("/api/mcp/status", { token });
 }
@@ -316,21 +310,8 @@ export async function rotateMcpToken(token: string): Promise<{ token: string; so
   return adminFetch("/api/mcp/token/rotate", { token, method: "POST" });
 }
 
-export async function listMcpProjects(token: string): Promise<McpProject[]> {
-  return adminFetch("/api/mcp/projects", { token });
-}
-
-export async function upsertMcpProject(token: string, project: McpProject): Promise<McpProject> {
-  return adminFetch("/api/mcp/projects", {
-    token,
-    method: "POST",
-    body: JSON.stringify(project),
-  });
-}
-
-export async function deleteMcpProject(token: string, name: string): Promise<{ deleted: string }> {
-  return adminFetch(`/api/mcp/projects/${encodeURIComponent(name)}`, {
-    token,
-    method: "DELETE",
-  });
-}
+// Project registry is Telos-backed — use `telosGetSection("projects")` +
+// `telosUpdateEntry` with `metadata_merge={path_patterns, wiki_path}` to
+// manage the MCP-bridge metadata on existing Telos projects. Projects are
+// created via the confirm-required `telos_add_project` agent tool, not
+// from the MCP-bridge admin panel.


### PR DESCRIPTION
## Summary

PR 1 pointed the MCP bridge's `project_*` tools at the wrong table. "Projects" in radbot have two meanings:

- **Todo projects** — the lightweight `projects` table in \`tools/todo/db/schema.py\`, registering things like \`Default\`, \`bobbi 👶\`, \`summer vacations\`, \`wedding\`
- **Telos projects** — the identity-level projects in \`telos_entries\` where \`section='projects'\`, e.g. \`PRJ1: radbot https://github.com/perrymanuk/radbot\`

The MCP bridge should bind to the second one — that's the source of truth beto already injects context from and the one the user thinks of as "the radbot project". Previous behavior registered path patterns on the wrong table, so the SessionStart hook would never have loaded real project context.

## What changes

- Rewrite \`radbot/mcp_server/tools/projects.py\` against \`telos_entries\`. Store \`path_patterns\` and \`wiki_path\` in Telos metadata JSONB. Rename \`project_register\` → \`project_set_path_patterns\` — Telos projects are created via the confirm-required \`telos_add_project\`, never free-form from this bridge. \`project_match\` returns the Telos **ref_code** (URL-safe).
- Split \`radbot/web/api/mcp.py\` into two routers. \`/api/mcp/*\` stays admin-token-gated for token management + status. New \`/api/projects/*\` is MCP-token-gated and mirrors the tool surface for shell-script consumption (the SessionStart hook calls these). **PR 1 documented URLs that didn't exist — this is the fix.**
- Drop the dead \`/api/mcp/projects\` CRUD endpoints.
- Revert the PR-1 migration that added \`wiki_path\` + \`path_patterns\` columns to \`todo.projects\`. Unused after this fix; existing DBs keep them harmlessly.
- Rewrite the admin panel (\`McpBridgePanel.tsx\`) to source projects from \`/api/telos/section/projects\` and patch via \`PUT /api/telos/entry/projects/{ref}\` with \`metadata_merge\`. No create/delete — those flow through Telos.
- Update \`docs/implementation/mcp_bridge.md\` with the Telos-backed shape and the new \`/api/projects/*\` router.

## Verified

- \`project_list\` now returns the user's real Telos projects (\`PRJ1\`, \`PRJ2\`, \`PRJ3\`)
- \`project_set_path_patterns('PRJ1', ['/git/perrymanuk/radbot'])\` writes to \`telos_entries.metadata\`
- \`project_match('/home/perry/git/perrymanuk/radbot')\` returns \`PRJ1\`
- \`project_match('/home/perry/elsewhere')\` returns empty
- \`project_get_context('PRJ1')\` and \`project_get_context('radbot')\` both resolve (lenient name match)
- All 24 existing MCP unit tests still pass
- Frontend typechecks clean

## Dependency

Pairs with perrymanuk/radbot#29 (SessionStart hook shape). Both touch setup.py but in non-overlapping regions — merging in either order will resolve trivially.

## Test plan

- [ ] Set path patterns on a Telos project from the admin panel
- [ ] \`cd\` into a matching repo from Claude Code → SessionStart hook injects project context
- [ ] \`cd\` into an unregistered repo → hook is silent (no error)
- [ ] Rotate MCP token → clients using old token 401, admin panel refreshes status

🤖 Generated with [Claude Code](https://claude.com/claude-code)