### PR TITLE
fix(worker): update Dockerfile.worker for relocated DB pool

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -89,12 +89,10 @@ RUN pip install --no-cache-dir \
 # Copy only the modules the worker needs.
 # Generate minimal __init__.py files to avoid importing agent/ADK dependencies
 # from the main app's __init__.py files.
-RUN mkdir -p radbot radbot/worker radbot/tools radbot/tools/shared \
-             radbot/tools/todo radbot/tools/todo/db \
+RUN mkdir -p radbot radbot/worker radbot/db radbot/tools radbot/tools/shared \
              radbot/tools/claude_code radbot/tools/github \
     && echo '__version__ = "0.1.0"' > radbot/__init__.py \
     && touch radbot/tools/__init__.py \
-    && touch radbot/tools/todo/__init__.py \
     && touch radbot/tools/claude_code/__init__.py \
     && touch radbot/tools/github/__init__.py
 
@@ -107,7 +105,7 @@ COPY radbot/worker/nomad_template.py radbot/worker/
 COPY radbot/config/ radbot/config/
 COPY radbot/credentials/ radbot/credentials/
 COPY radbot/tools/shared/ radbot/tools/shared/
-COPY radbot/tools/todo/db/ radbot/tools/todo/db/
+COPY radbot/db/ radbot/db/
 COPY radbot/tools/claude_code/db.py radbot/tools/claude_code/
 COPY radbot/tools/claude_code/claude_code_client.py radbot/tools/claude_code/
 COPY radbot/tools/github/github_app_client.py radbot/tools/github/


### PR DESCRIPTION
## Summary

The todo→telos refactor (PR #31) moved the shared DB pool from `radbot/tools/todo/db/connection.py` to `radbot/db/connection.py`, but `Dockerfile.worker` still copied the deleted path. Worker image build has been failing since the merge.

Fixes https://github.com/perrymanuk/radbot/actions/runs/24626736479

## Test plan

- [x] Fixed COPY target: `radbot/tools/todo/db/` → `radbot/db/`
- [x] Fixed mkdir list: replace `radbot/tools/todo/db` with `radbot/db`
- [ ] Next CI run on merge should complete the Worker image build and publish a new `worker-v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)