### PR TITLE
feat(mcp-bridge): expose Telos project-hierarchy mutations over MCP

### DIFF
--- a/docs/implementation/mcp_bridge.md
+++ b/docs/implementation/mcp_bridge.md
@@ -25,7 +25,8 @@ radbot/mcp_server/
     ├── __init__.py      # module registry — aggregates all tools() / dispatches call()
     ├── telos.py         # telos_get_full, telos_get_section, telos_get_entry, telos_search_journal
     ├── wiki.py          # wiki_read, wiki_list, wiki_search, wiki_write
-    ├── projects.py      # project_match, project_list, project_register, project_get_context
+    ├── projects.py      # project_match/list/get_context/list_children/set_path_patterns + create/update/archive/merge
+    ├── project_tasks.py # milestone_add/complete, task_add/update/complete/archive, exploration_add
     ├── tasks.py         # list_tasks, list_reminders, list_scheduled_tasks
     └── memory.py        # search_memory
 ```
@@ -58,6 +59,18 @@ Both transports serve the same `Server` instance produced by
 | `project_list()` | markdown table | ref · name · patterns · wiki_path (active Telos projects only) |
 | `project_set_path_patterns(ref_code, path_patterns, wiki_path?)` | plain confirmation | Updates `metadata` on an existing Telos project via `metadata_merge` |
 | `project_get_context(ref_or_name)` | markdown | Telos content + recent journal entries with matching `related_refs`. PR 2 replaces with full hierarchy render (milestones/tasks/explorations) |
+| `project_create(name, priority?, parent_goal?, path_patterns?, wiki_path?)` | plain confirmation | Auto-assigns `PRJ<N>` via `db.add_entry(Section.PROJECTS, ...)` |
+| `project_update(ref_code, name?, priority?, parent_goal?, path_patterns?, wiki_path?, status?)` | plain confirmation | Shallow `metadata_merge`; `name` replaces content; `path_patterns` fully replaces list |
+| `project_archive(ref_code, reason?, cascade_children?)` | markdown | Soft-delete via `db.archive_entry`; cascades to milestones / project_tasks / explorations when requested |
+| `project_merge(from_ref, into_ref, archive_reason?)` | markdown | Rebinds every active child's `parent_project` to `into_ref`, then archives `from_ref` |
+| `project_list_children(ref_code)` | markdown | Preview for cascade / merge — active milestones, tasks, explorations under a project |
+| `milestone_add(parent_project, title, deadline?, details?)` | plain confirmation | Auto-assigns `MS<N>` |
+| `milestone_complete(ref_code, resolution?)` | plain confirmation | Sets `status='completed'` + `metadata.completed_at` |
+| `task_add(parent_project, description, parent_milestone?, title?, category?, task_status?)` | plain confirmation | Auto-assigns `PT<N>`; task_status ∈ backlog/inprogress/done |
+| `task_update(ref_code, description?, title?, category?, task_status?, parent_milestone?)` | plain confirmation | Shallow metadata merge; empty string clears a field |
+| `task_complete(ref_code)` | plain confirmation | Sets `metadata.task_status='done'` + `completed_at` |
+| `task_archive(ref_code, reason?)` | plain confirmation | Soft-delete via `db.archive_entry` |
+| `exploration_add(parent_project, topic, notes?)` | plain confirmation | Auto-assigns `EX<N>` |
 | `list_tasks(status?, project?)` | markdown | Grouped by status |
 | `list_reminders(status?)` | markdown | Relative-time phrasing |
 | `list_scheduled_tasks()` | markdown table | name · cron · enabled · prompt |

--- a/docs/implementation/telos.md
+++ b/docs/implementation/telos.md
@@ -209,6 +209,19 @@ All tools return `{"status": "success" | "error", ...}` per radbot convention.
 Silent vs. confirm-required is enforced by the agent's instructions, not the
 tool signature — the tool just does what it's asked.
 
+### MCP write surface
+
+The MCP bridge (`radbot/mcp_server/tools/projects.py` + `project_tasks.py`)
+exposes a parallel set of project-hierarchy mutations — `project_create`,
+`project_update`, `project_archive`, `project_merge`, `milestone_add`,
+`milestone_complete`, `task_add`, `task_update`, `task_complete`,
+`task_archive`, `exploration_add` — that call the same
+`radbot.tools.telos.db` primitives these FunctionTools call. Confirmation is
+expected at the MCP client UI (e.g. Claude Code's per-tool approval), not at
+the server. All removal is soft (`status='archived'` + `metadata.archived_reason`)
+— no hard deletes — matching beto's behaviour. Other Telos sections
+(identity / goals / problems / wisdom / etc.) stay beto-only for now.
+
 ### Read tools
 
 | Tool | Purpose |

--- a/radbot/mcp_server/tools/__init__.py
+++ b/radbot/mcp_server/tools/__init__.py
@@ -16,9 +16,9 @@ from typing import Any
 
 from mcp import types as mcp_types
 
-from . import memory, projects, tasks, telos, wiki
+from . import memory, project_tasks, projects, tasks, telos, wiki
 
-_MODULES = [telos, wiki, projects, tasks, memory]
+_MODULES = [telos, wiki, projects, project_tasks, tasks, memory]
 
 
 def all_tools() -> list[mcp_types.Tool]:

--- a/radbot/mcp_server/tools/project_tasks.py
+++ b/radbot/mcp_server/tools/project_tasks.py
@@ -1,0 +1,438 @@
+"""Project-hierarchy MCP tools — milestones, project_tasks, explorations.
+
+Parallel surface to beto's confirm-required `telos_add_milestone`,
+`telos_add_task`, `telos_complete_milestone`, `telos_complete_task`,
+`telos_archive_task`, and `telos_add_exploration` tools. These call the
+same `radbot.tools.telos.db` primitives directly; user confirmation is
+expected at the MCP client UI layer (e.g. Claude Code approval) rather
+than enforced here.
+
+Children all live in the single `telos_entries` table in sections
+`milestones`, `project_tasks`, `explorations`. Their ownership is stored
+as `metadata.parent_project` (+ optional `metadata.parent_milestone`
+for tasks). Never hard-deletes — archive only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+_VALID_TASK_STATUSES = {"backlog", "inprogress", "done"}
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="milestone_add",
+            description=(
+                "Add a milestone under a project. Auto-assigns an `MS<N>` "
+                "ref_code. `deadline` is optional ISO date. `details` is "
+                "appended below the title in content."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "parent_project": {
+                        "type": "string",
+                        "description": "Project ref_code (e.g. `PRJ1`).",
+                    },
+                    "title": {"type": "string"},
+                    "deadline": {"type": "string"},
+                    "details": {"type": "string"},
+                },
+                "required": ["parent_project", "title"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="milestone_complete",
+            description=(
+                "Mark a milestone completed. Sets status='completed' and "
+                "stamps `metadata.completed_at`. Optional `resolution` "
+                "string is merged into metadata."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "resolution": {"type": "string"},
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="task_add",
+            description=(
+                "Create a project task under an existing project (and "
+                "optionally a milestone). Auto-assigns a `PT<N>` ref_code. "
+                "`task_status` ∈ backlog / inprogress / done, default "
+                "backlog."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "parent_project": {"type": "string"},
+                    "description": {"type": "string"},
+                    "parent_milestone": {"type": "string"},
+                    "title": {"type": "string"},
+                    "category": {"type": "string"},
+                    "task_status": {
+                        "type": "string",
+                        "enum": ["backlog", "inprogress", "done"],
+                    },
+                },
+                "required": ["parent_project", "description"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="task_update",
+            description=(
+                "Update a project task in place. `description` replaces "
+                "content; other fields shallow-merge into metadata. Pass "
+                "an empty string to clear an optional field."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "description": {"type": "string"},
+                    "title": {"type": "string"},
+                    "category": {"type": "string"},
+                    "task_status": {
+                        "type": "string",
+                        "enum": ["backlog", "inprogress", "done"],
+                    },
+                    "parent_milestone": {"type": "string"},
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="task_complete",
+            description=(
+                "Mark a project task done. Sets "
+                "`metadata.task_status='done'` and stamps "
+                "`metadata.completed_at`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"ref_code": {"type": "string"}},
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="task_archive",
+            description=(
+                "Archive (soft-delete) a project task. Stashes `reason` "
+                "into `metadata.archived_reason`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="exploration_add",
+            description=(
+                "Record an open exploration / research thread under a "
+                "project. Auto-assigns an `EX<N>` ref_code. `notes` is "
+                "appended below the topic in content."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "parent_project": {"type": "string"},
+                    "topic": {"type": "string"},
+                    "notes": {"type": "string"},
+                },
+                "required": ["parent_project", "topic"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(
+    name: str, arguments: dict[str, Any]
+) -> list[mcp_types.TextContent]:
+    if name == "milestone_add":
+        return [_do_milestone_add(
+            arguments["parent_project"],
+            arguments["title"],
+            arguments.get("deadline"),
+            arguments.get("details"),
+        )]
+    if name == "milestone_complete":
+        return [_do_milestone_complete(
+            arguments["ref_code"],
+            arguments.get("resolution"),
+        )]
+    if name == "task_add":
+        return [_do_task_add(arguments)]
+    if name == "task_update":
+        return [_do_task_update(arguments)]
+    if name == "task_complete":
+        return [_do_task_complete(arguments["ref_code"])]
+    if name == "task_archive":
+        return [_do_task_archive(
+            arguments["ref_code"],
+            arguments.get("reason"),
+        )]
+    if name == "exploration_add":
+        return [_do_exploration_add(
+            arguments["parent_project"],
+            arguments["topic"],
+            arguments.get("notes"),
+        )]
+    raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _err(msg: str) -> mcp_types.TextContent:
+    return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _require_project(ref_code: str):
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    project = telos_db.get_entry(Section.PROJECTS, ref_code)
+    if project is None:
+        return None, _err(f"No Telos project with ref_code `{ref_code}`.")
+    return project, None
+
+
+def _require_milestone(ref_code: str):
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    row = telos_db.get_entry(Section.MILESTONES, ref_code)
+    if row is None:
+        return None, _err(f"No milestone with ref_code `{ref_code}`.")
+    return row, None
+
+
+def _do_milestone_add(
+    parent_project: str, title: str, deadline: str | None, details: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    clean_title = (title or "").strip()
+    if not clean_title:
+        return _err("`title` is required and must not be whitespace.")
+    _p, err = _require_project(parent_project)
+    if err is not None:
+        return err
+
+    content = clean_title if not details else f"{clean_title}\n\n{details}"
+    metadata: dict[str, Any] = {"parent_project": parent_project}
+    if deadline:
+        metadata["deadline"] = deadline
+    row = telos_db.add_entry(Section.MILESTONES, content, metadata=metadata)
+    return mcp_types.TextContent(
+        type="text",
+        text=(
+            f"Added milestone `{row.ref_code}` under `{parent_project}` — "
+            f"{clean_title!r}"
+        ),
+    )
+
+
+def _do_milestone_complete(
+    ref_code: str, resolution: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    meta: dict[str, Any] = {"completed_at": _now_iso()}
+    if resolution:
+        meta["resolution"] = resolution
+    row = telos_db.update_entry(
+        Section.MILESTONES, ref_code, status="completed", metadata_merge=meta,
+    )
+    if row is None:
+        return _err(f"No milestone with ref_code `{ref_code}`.")
+    bits = [f"completed_at={meta['completed_at']}"]
+    if resolution:
+        bits.append(f"resolution={resolution!r}")
+    return mcp_types.TextContent(
+        type="text",
+        text=f"Completed milestone `{ref_code}` — {' · '.join(bits)}",
+    )
+
+
+def _do_task_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    description = (arguments.get("description") or "").strip()
+    parent_project = arguments["parent_project"]
+    if not description:
+        return _err("`description` is required and must not be whitespace.")
+    _p, err = _require_project(parent_project)
+    if err is not None:
+        return err
+
+    parent_milestone = arguments.get("parent_milestone") or ""
+    if parent_milestone:
+        _ms, err = _require_milestone(parent_milestone)
+        if err is not None:
+            return err
+
+    task_status = arguments.get("task_status") or "backlog"
+    if task_status not in _VALID_TASK_STATUSES:
+        return _err(
+            f"invalid task_status {task_status!r}. "
+            f"valid: {sorted(_VALID_TASK_STATUSES)}."
+        )
+
+    metadata: dict[str, Any] = {
+        "parent_project": parent_project,
+        "task_status": task_status,
+    }
+    if parent_milestone:
+        metadata["parent_milestone"] = parent_milestone
+    if arguments.get("title"):
+        metadata["title"] = arguments["title"]
+    if arguments.get("category"):
+        metadata["category"] = arguments["category"]
+
+    row = telos_db.add_entry(Section.PROJECT_TASKS, description, metadata=metadata)
+    return mcp_types.TextContent(
+        type="text",
+        text=(
+            f"Added task `{row.ref_code}` under `{parent_project}`"
+            + (f" / `{parent_milestone}`" if parent_milestone else "")
+            + f" — status={task_status}"
+        ),
+    )
+
+
+def _do_task_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ref_code = arguments["ref_code"]
+    content: str | None = None
+    description = arguments.get("description")
+    if description is not None:
+        clean = description.strip()
+        if not clean:
+            return _err("`description` must not be whitespace if provided.")
+        content = clean
+
+    meta: dict[str, Any] = {}
+    for key in ("title", "category", "task_status", "parent_milestone"):
+        if key in arguments and arguments[key] is not None:
+            value = arguments[key]
+            if key == "task_status" and value and value not in _VALID_TASK_STATUSES:
+                return _err(
+                    f"invalid task_status {value!r}. "
+                    f"valid: {sorted(_VALID_TASK_STATUSES)}."
+                )
+            # Empty string → remove key via shallow JSONB merge with null.
+            meta[key] = value if value != "" else None
+
+    if meta.get("parent_milestone"):
+        _ms, err = _require_milestone(meta["parent_milestone"])
+        if err is not None:
+            return err
+
+    row = telos_db.update_entry(
+        Section.PROJECT_TASKS,
+        ref_code,
+        content=content,
+        metadata_merge=meta or None,
+    )
+    if row is None:
+        return _err(f"No task with ref_code `{ref_code}`.")
+    bits: list[str] = []
+    if content is not None:
+        bits.append("description updated")
+    if meta:
+        bits.append(f"metadata_merge={meta}")
+    if not bits:
+        bits.append("no-op")
+    return mcp_types.TextContent(
+        type="text",
+        text=f"Updated task `{ref_code}` — {' · '.join(bits)}",
+    )
+
+
+def _do_task_complete(ref_code: str) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    row = telos_db.update_entry(
+        Section.PROJECT_TASKS,
+        ref_code,
+        metadata_merge={"task_status": "done", "completed_at": _now_iso()},
+    )
+    if row is None:
+        return _err(f"No task with ref_code `{ref_code}`.")
+    return mcp_types.TextContent(
+        type="text", text=f"Completed task `{ref_code}`."
+    )
+
+
+def _do_task_archive(ref_code: str, reason: str | None) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ok = telos_db.archive_entry(
+        Section.PROJECT_TASKS, ref_code, reason=reason or None
+    )
+    if not ok:
+        return _err(f"No task with ref_code `{ref_code}`.")
+    tail = f" (reason: {reason})" if reason else ""
+    return mcp_types.TextContent(
+        type="text", text=f"Archived task `{ref_code}`.{tail}"
+    )
+
+
+def _do_exploration_add(
+    parent_project: str, topic: str, notes: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    clean_topic = (topic or "").strip()
+    if not clean_topic:
+        return _err("`topic` is required and must not be whitespace.")
+    _p, err = _require_project(parent_project)
+    if err is not None:
+        return err
+
+    content = clean_topic if not notes else f"{clean_topic}\n\n{notes}"
+    row = telos_db.add_entry(
+        Section.EXPLORATIONS, content, metadata={"parent_project": parent_project}
+    )
+    return mcp_types.TextContent(
+        type="text",
+        text=(
+            f"Added exploration `{row.ref_code}` under `{parent_project}` — "
+            f"{clean_topic!r}"
+        ),
+    )

--- a/radbot/mcp_server/tools/projects.py
+++ b/radbot/mcp_server/tools/projects.py
@@ -6,13 +6,15 @@ optional `wiki_path` stored in its `metadata` JSONB — both are consumed
 by the Claude Code `SessionStart` hook to auto-load context when a user
 `cd`s into a matching repo.
 
-Tools in this module never *create* telos projects — that goes through
-the confirm-required `telos_add_project` agent tool. These only read
-projects and attach MCP-bridge metadata to existing ones.
+Read tools (`project_list`, `project_get_context`, `project_match`) and
+the metadata setter (`project_set_path_patterns`) are always safe.
 
-PR-1 previously backed these tools against the unrelated `projects`
-table in `tools/todo/db/schema.py` (todo-list projects, not telos
-identity projects). That layer became dead after this PR.
+Mutation tools (`project_create`, `project_update`, `project_archive`,
+`project_merge`, `project_list_children`) are a parallel surface to
+beto's confirm-required `telos_*` tools. They call the same
+`radbot.tools.telos.db` primitives directly; user confirmation is
+expected at the MCP client UI (e.g. Claude Code's per-tool approval)
+rather than enforced here. Never hard-deletes — archive only.
 """
 
 from __future__ import annotations
@@ -94,6 +96,124 @@ def tools() -> list[mcp_types.Tool]:
                 "additionalProperties": False,
             },
         ),
+        mcp_types.Tool(
+            name="project_create",
+            description=(
+                "Create a new Telos project. Auto-assigns a `PRJ<N>` "
+                "ref_code. Optional metadata: `priority`, `parent_goal` "
+                "(Goal ref_code like `G1`), `path_patterns` (list of cwd "
+                "substrings for the SessionStart hook), and `wiki_path`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Project name / title (first line of content).",
+                    },
+                    "priority": {"type": "string"},
+                    "parent_goal": {
+                        "type": "string",
+                        "description": "Optional Goal ref_code (e.g. `G1`).",
+                    },
+                    "path_patterns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "wiki_path": {"type": "string"},
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_update",
+            description=(
+                "Update an existing Telos project. `name` replaces "
+                "`content`; other fields shallow-merge into metadata. "
+                "`path_patterns` fully replaces the existing list (not "
+                "appended). Pass `status` to reactivate an archived "
+                "project. To remove a metadata key set it to empty string "
+                "or `null`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "name": {"type": "string"},
+                    "priority": {"type": "string"},
+                    "parent_goal": {"type": "string"},
+                    "path_patterns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "wiki_path": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "completed", "archived", "superseded"],
+                    },
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_archive",
+            description=(
+                "Archive (soft-delete) a Telos project. Stamps "
+                "`metadata.archived_reason` if provided. With "
+                "`cascade_children=true`, also archives every active "
+                "milestone / project_task / exploration whose "
+                "`metadata.parent_project` matches. Without cascade, active "
+                "children are left alone and listed in the response."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "reason": {"type": "string"},
+                    "cascade_children": {"type": "boolean", "default": False},
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_merge",
+            description=(
+                "Merge one Telos project into another. Rebinds every "
+                "active child (milestones, project_tasks, explorations) so "
+                "their `metadata.parent_project` points at `into_ref`, "
+                "then archives `from_ref` with an optional reason. "
+                "Both refs must exist and differ."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "from_ref": {"type": "string"},
+                    "into_ref": {"type": "string"},
+                    "archive_reason": {"type": "string"},
+                },
+                "required": ["from_ref", "into_ref"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="project_list_children",
+            description=(
+                "Return a markdown rollup of active milestones, "
+                "project_tasks, and explorations whose "
+                "`metadata.parent_project` matches the given project "
+                "ref_code. Useful to preview what `project_archive "
+                "--cascade` or `project_merge` would touch."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {"ref_code": {"type": "string"}},
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
     ]
 
 
@@ -112,6 +232,30 @@ async def call(
         )]
     if name == "project_get_context":
         return [_do_get_context(arguments["ref_or_name"])]
+    if name == "project_create":
+        return [_do_create(
+            arguments["name"],
+            arguments.get("priority"),
+            arguments.get("parent_goal"),
+            arguments.get("path_patterns"),
+            arguments.get("wiki_path"),
+        )]
+    if name == "project_update":
+        return [_do_update(arguments)]
+    if name == "project_archive":
+        return [_do_archive(
+            arguments["ref_code"],
+            arguments.get("reason"),
+            bool(arguments.get("cascade_children", False)),
+        )]
+    if name == "project_merge":
+        return [_do_merge(
+            arguments["from_ref"],
+            arguments["into_ref"],
+            arguments.get("archive_reason"),
+        )]
+    if name == "project_list_children":
+        return [_do_list_children(arguments["ref_code"])]
     raise KeyError(name)
 
 
@@ -278,4 +422,252 @@ def _do_get_context(ref_or_name: str) -> mcp_types.TextContent:
     if len(lines) <= 2:
         lines.append("_No recent activity recorded for this project._")
 
+    return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())
+
+
+# ---------------------------------------------------------------------------
+# Mutation helpers
+# ---------------------------------------------------------------------------
+
+
+_CHILD_SECTIONS = ("MILESTONES", "PROJECT_TASKS", "EXPLORATIONS")
+
+
+def _clean_patterns(patterns: list[str] | None) -> list[str] | None:
+    if patterns is None:
+        return None
+    return [p.strip() for p in patterns if p and p.strip()]
+
+
+def _project_meta_from(
+    priority: str | None,
+    parent_goal: str | None,
+    path_patterns: list[str] | None,
+    wiki_path: str | None,
+) -> dict[str, Any]:
+    """Build a project metadata dict. Empty-string / None values are
+    interpreted as "remove this key" (stored as JSON null so the shallow
+    JSONB merge clears them)."""
+    meta: dict[str, Any] = {}
+    if priority is not None:
+        meta["priority"] = priority.strip() or None
+    if parent_goal is not None:
+        meta["parent_goal"] = parent_goal.strip() or None
+    if path_patterns is not None:
+        meta["path_patterns"] = _clean_patterns(path_patterns) or []
+    if wiki_path is not None:
+        meta["wiki_path"] = wiki_path.strip() or None
+    return meta
+
+
+def _active_children(ref_code: str) -> dict[str, list]:
+    """Return active children of a project keyed by section name."""
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    out: dict[str, list] = {}
+    for sec_name in _CHILD_SECTIONS:
+        sec = getattr(Section, sec_name)
+        rows = telos_db.list_section(sec, status="active")
+        out[sec_name] = [
+            r for r in rows
+            if (r.metadata or {}).get("parent_project") == ref_code
+        ]
+    return out
+
+
+def _do_create(
+    name: str,
+    priority: str | None,
+    parent_goal: str | None,
+    path_patterns: list[str] | None,
+    wiki_path: str | None,
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    clean_name = (name or "").strip()
+    if not clean_name:
+        return _err("`name` is required and must not be whitespace.")
+
+    raw = _project_meta_from(priority, parent_goal, path_patterns, wiki_path)
+    metadata = {k: v for k, v in raw.items() if v is not None and v != []}
+
+    entry = telos_db.add_entry(Section.PROJECTS, clean_name, metadata=metadata)
+    bits = [f"ref=`{entry.ref_code}`", f"name={clean_name!r}"]
+    if metadata:
+        bits.append(f"metadata={metadata}")
+    return mcp_types.TextContent(
+        type="text", text=f"Created project — {' · '.join(bits)}"
+    )
+
+
+def _do_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ref_code = arguments["ref_code"]
+    new_name = arguments.get("name")
+    status = arguments.get("status")
+
+    metadata_merge = _project_meta_from(
+        arguments.get("priority"),
+        arguments.get("parent_goal"),
+        arguments.get("path_patterns"),
+        arguments.get("wiki_path"),
+    )
+
+    content: str | None = None
+    if new_name is not None:
+        clean_name = new_name.strip()
+        if not clean_name:
+            return _err("`name` must not be whitespace if provided.")
+        content = clean_name
+
+    entry = telos_db.update_entry(
+        Section.PROJECTS,
+        ref_code,
+        content=content,
+        metadata_merge=metadata_merge or None,
+        status=status,
+    )
+    if entry is None:
+        return _err(f"No Telos project with ref_code `{ref_code}`.")
+
+    bits: list[str] = []
+    if content is not None:
+        bits.append(f"name={content!r}")
+    if metadata_merge:
+        bits.append(f"metadata_merge={metadata_merge}")
+    if status is not None:
+        bits.append(f"status={status}")
+    if not bits:
+        bits.append("no-op")
+    return mcp_types.TextContent(
+        type="text",
+        text=f"Updated project `{ref_code}` — {' · '.join(bits)}",
+    )
+
+
+def _do_archive(
+    ref_code: str, reason: str | None, cascade_children: bool
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    existing = telos_db.get_entry(Section.PROJECTS, ref_code)
+    if existing is None:
+        return _err(f"No Telos project with ref_code `{ref_code}`.")
+
+    children = _active_children(ref_code)
+    archived_counts: dict[str, int] = {}
+    cascade_reason = reason or f"parent {ref_code} archived"
+
+    if cascade_children:
+        for sec_name, rows in children.items():
+            sec = getattr(Section, sec_name)
+            count = 0
+            for row in rows:
+                if telos_db.archive_entry(sec, row.ref_code, reason=cascade_reason):
+                    count += 1
+            archived_counts[sec_name] = count
+
+    ok = telos_db.archive_entry(Section.PROJECTS, ref_code, reason=reason or None)
+    if not ok:
+        return _err(f"Failed to archive project `{ref_code}`.")
+
+    lines = [f"Archived project `{ref_code}`."]
+    if reason:
+        lines.append(f"Reason: {reason}")
+    if cascade_children and archived_counts:
+        summary = ", ".join(
+            f"{sec_name.lower()}={n}" for sec_name, n in archived_counts.items() if n
+        )
+        lines.append(f"Cascaded: {summary or 'none'}.")
+    elif not cascade_children:
+        orphan = {k: len(v) for k, v in children.items() if v}
+        if orphan:
+            summary = ", ".join(f"{k.lower()}={n}" for k, n in orphan.items())
+            lines.append(
+                f"**Warning:** left active children unbound ({summary}). "
+                f"Re-run with `cascade_children=true` to archive them."
+            )
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _do_merge(
+    from_ref: str, into_ref: str, archive_reason: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    if from_ref == into_ref:
+        return _err("`from_ref` and `into_ref` must differ.")
+    src = telos_db.get_entry(Section.PROJECTS, from_ref)
+    if src is None:
+        return _err(f"No Telos project with ref_code `{from_ref}`.")
+    dst = telos_db.get_entry(Section.PROJECTS, into_ref)
+    if dst is None:
+        return _err(f"No Telos project with ref_code `{into_ref}`.")
+
+    children = _active_children(from_ref)
+    rebound: dict[str, int] = {}
+    for sec_name, rows in children.items():
+        sec = getattr(Section, sec_name)
+        count = 0
+        for row in rows:
+            updated = telos_db.update_entry(
+                sec, row.ref_code,
+                metadata_merge={"parent_project": into_ref},
+            )
+            if updated is not None:
+                count += 1
+        rebound[sec_name] = count
+
+    reason = archive_reason or f"merged into {into_ref}"
+    telos_db.archive_entry(Section.PROJECTS, from_ref, reason=reason)
+
+    lines = [f"Merged `{from_ref}` → `{into_ref}`."]
+    summary = ", ".join(
+        f"{sec_name.lower()}={n}" for sec_name, n in rebound.items() if n
+    )
+    lines.append(f"Rebound children: {summary or 'none'}.")
+    lines.append(f"Archived `{from_ref}` (reason: {reason}).")
+    return mcp_types.TextContent(type="text", text="\n".join(lines))
+
+
+def _do_list_children(ref_code: str) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    if telos_db.get_entry(Section.PROJECTS, ref_code) is None:
+        return _err(f"No Telos project with ref_code `{ref_code}`.")
+
+    children = _active_children(ref_code)
+    lines = [f"# Active children of `{ref_code}`", ""]
+    any_rows = False
+    labels = {
+        "MILESTONES": "## Milestones",
+        "PROJECT_TASKS": "## Project tasks",
+        "EXPLORATIONS": "## Explorations",
+    }
+    for sec_name, rows in children.items():
+        if not rows:
+            continue
+        any_rows = True
+        lines.append(labels[sec_name])
+        lines.append("")
+        for r in rows:
+            first = (r.content or "").splitlines()[0][:120]
+            meta = r.metadata or {}
+            extra = []
+            if meta.get("task_status"):
+                extra.append(f"status={meta['task_status']}")
+            if meta.get("parent_milestone"):
+                extra.append(f"ms={meta['parent_milestone']}")
+            tail = f" ({', '.join(extra)})" if extra else ""
+            lines.append(f"- `{r.ref_code}` — {first}{tail}")
+        lines.append("")
+    if not any_rows:
+        lines.append("_No active children._")
     return mcp_types.TextContent(type="text", text="\n".join(lines).rstrip())

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -356,15 +356,19 @@ Exposes **radbot itself** as an MCP server so external clients (primarily Claude
 - **stdio**: `uv run python -m radbot.mcp_server` (local, no auth)
 - **HTTP/SSE**: `GET /mcp/sse` + `POST /mcp/messages/` mounted on the FastAPI app (bearer token)
 
-**Tool surface** (16, all returning markdown `TextContent`):
+**Tool surface** (28, all returning markdown `TextContent`):
 
 | Group | Tools |
 |---|---|
-| Telos | `telos_get_full`, `telos_get_section`, `telos_get_entry`, `telos_search_journal` |
+| Telos (read) | `telos_get_full`, `telos_get_section`, `telos_get_entry`, `telos_search_journal` |
 | Wiki (at `$RADBOT_WIKI_PATH`) | `wiki_read`, `wiki_list`, `wiki_search`, `wiki_write` (strict path sanitization) |
-| Projects | `project_match(cwd)`, `project_list`, `project_register`, `project_get_context` |
+| Projects (read) | `project_match(cwd)`, `project_list`, `project_get_context`, `project_list_children`, `project_set_path_patterns` |
+| Projects (mutate) | `project_create`, `project_update`, `project_archive(cascade_children?)`, `project_merge(from_ref, into_ref)` |
+| Project hierarchy (mutate) | `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add` |
 | Tasks / schedule | `list_tasks`, `list_reminders`, `list_scheduled_tasks` |
 | Memory | `search_memory` (Qdrant, default scope=`beto`, pass `agent_scope="all"` to widen) |
+
+Project-hierarchy mutations are a parallel surface to beto's confirm-required `telos_*` tools — they call the same `radbot.tools.telos.db` primitives; user confirmation is expected at the MCP client UI layer (e.g. Claude Code's per-tool approval) rather than enforced server-side. All removal is soft (`status='archived'`, `metadata.archived_reason`) — no hard deletes.
 
 **Return convention:** markdown for any structured output, plain single-line text for primitives (`project_match` → name) and action confirmations (`wiki_write` → `Wrote N bytes to <path>`). Never JSON to the LLM — JSON consumers hit the REST API at `/api/*`.
 


### PR DESCRIPTION
## Summary

- Adds 12 new MCP tools so Claude Code can curate Telos projects directly (no round-trip through beto for routine bookkeeping like "create a project for this new repo", "archive the stale one", "merge this duplicate into that one").
- New tools in `radbot/mcp_server/tools/projects.py`: `project_create`, `project_update`, `project_archive` (with `cascade_children`), `project_merge` (rebinds children then archives source), `project_list_children` (preview helper).
- New module `radbot/mcp_server/tools/project_tasks.py`: `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add`.
- All call the same `radbot.tools.telos.db` primitives (`add_entry`, `update_entry`, `archive_entry`) as beto's confirm-required `telos_*` FunctionTools — no schema changes, no new DB code. Confirmation is expected at the MCP client UI (Claude Code's per-tool approval) rather than server-side, matching the pattern called out in `telos_tools.py` and `docs/implementation/telos.md`.
- No hard deletes — removal stays soft (`status='archived'`, `metadata.archived_reason`).

## Specs updated

- `specs/tools.md` — MCP bridge tool count 16 → 28, new tool groups listed, confirmation policy documented.
- `docs/implementation/mcp_bridge.md` — structure diagram + full tool table updated with all 12 new tools and their signatures.
- `docs/implementation/telos.md` — new "MCP write surface" subsection noting parity with beto's primitives and confirmation-at-UI semantics.

## Test plan

- [x] `all_tools()` registers 28 MCP tools (was 16; +12 new, plus `project_set_path_patterns` already in place).
- [x] `make test-unit` MCP unit tests pass (`test_mcp_tools`, `test_mcp_server_auth`, `test_mcp_wiki_sanitization` — 28 passed).
- [x] End-to-end round-trip via `dispatch()` against the dev DB: `project_create` → `project_update` → `milestone_add` → `task_add` → `project_list_children` → `project_archive(cascade_children=true)` all succeed, children archived with correct `archived_reason`.
- [x] `project_merge(PRJ8 → PRJ1)` used to clean up a real duplicate project — 11 legacy `project_tasks` rebound to `PRJ1.parent_project`, `PRJ8` archived with `archived_reason='duplicate of PRJ1'`. `project_list` now shows a clean single `PRJ1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)