### PR TITLE
test: validate quality-pipeline end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,3 +297,4 @@ See the `docs/implementation` directory for detailed documentation on each featu
 ## License
 
 MIT
+

--- a/radbot/web/frontend/e2e/specs/chat-scenarios.ts
+++ b/radbot/web/frontend/e2e/specs/chat-scenarios.ts
@@ -1,3 +1,6 @@
+// Smoke-test trigger: adding a no-op comment in an e2e file to validate
+// the pipeline path filter + workflow end-to-end. Safe to remove later.
+
 /**
  * Per-scenario rubrics consumed by chat.spec.ts. Each scenario sends a prompt,
  * waits for beto's response, and grades it via the LLM judge against `expect`.


### PR DESCRIPTION
Smoke test against main now that bootstrap-radbot-stack lives there. All 8 gates should run; visual-regression should now find the composite action on origin/main and produce a real score.

No `auto-merge-eligible` label — observation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)