### PR TITLE
fix(web): SPA fallback routes for /projects

### DIFF
--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -777,6 +777,13 @@ async def terminal_page(request: Request):
     return await index(request)
 
 
+@app.get("/projects")
+@app.get("/projects/{ref_code}")
+async def projects_page(request: Request, ref_code: str | None = None):
+    """Serve React SPA for the projects page (react-router handles the ref_code)."""
+    return await index(request)
+
+
 @app.get("/healthz")
 async def healthz_check():
     """Healthz endpoint."""


### PR DESCRIPTION
## Summary
- Adds explicit `GET /projects` and `GET /projects/{ref_code}` SPA fallback routes in `radbot/web/app.py`. Without them FastAPI returns `{"detail":"Not Found"}` for client-side react-router paths.
- Mirrors existing fallbacks for `/notifications`, `/admin`, `/terminal`.
- Follow-up to #37 (which merged without these routes).

## Test plan
- [ ] Deploy, visit `https://radbot.demonsafe.com/projects` — should render the page instead of a 404 JSON
- [ ] `https://radbot.demonsafe.com/projects/PRJ-1?tab=milestones` — also renders
- [ ] `PROJ` link in chat header navigates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)