### PR TITLE
fix(projects): wrap selectors in useShallow to stop React #185

### DIFF
--- a/radbot/web/frontend/src/components/projects/ExplorationsTab.tsx
+++ b/radbot/web/frontend/src/components/projects/ExplorationsTab.tsx
@@ -1,3 +1,4 @@
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import {
   selectExplorationsForProject,
@@ -10,8 +11,8 @@ interface Props {
 }
 
 export default function ExplorationsTab({ project }: Props) {
-  const explorations = useProjectsStore((s) =>
-    selectExplorationsForProject(s, project.ref_code!),
+  const explorations = useProjectsStore(
+    useShallow((s) => selectExplorationsForProject(s, project.ref_code!)),
   );
 
   if (explorations.length === 0) {

--- a/radbot/web/frontend/src/components/projects/GoalsTab.tsx
+++ b/radbot/web/frontend/src/components/projects/GoalsTab.tsx
@@ -1,3 +1,4 @@
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import {
   selectGoalsForProject,
@@ -10,8 +11,8 @@ interface Props {
 }
 
 export default function GoalsTab({ project }: Props) {
-  const goals = useProjectsStore((s) =>
-    selectGoalsForProject(s, project.ref_code!),
+  const goals = useProjectsStore(
+    useShallow((s) => selectGoalsForProject(s, project.ref_code!)),
   );
 
   if (goals.length === 0) {

--- a/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
+++ b/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import {
   bucketTasks,
@@ -16,11 +17,11 @@ interface Props {
 }
 
 export default function MilestonesTab({ project }: Props) {
-  const milestones = useProjectsStore((s) =>
-    selectMilestonesForProject(s, project.ref_code!),
+  const milestones = useProjectsStore(
+    useShallow((s) => selectMilestonesForProject(s, project.ref_code!)),
   );
-  const unmilestoned = useProjectsStore((s) =>
-    selectUnmilestonedTasks(s, project.ref_code!),
+  const unmilestoned = useProjectsStore(
+    useShallow((s) => selectUnmilestonedTasks(s, project.ref_code!)),
   );
 
   return (
@@ -72,8 +73,8 @@ function taskBucket(t: TelosEntry): string {
 function MilestoneCard({ milestone }: { milestone: TelosEntry }) {
   const [expanded, setExpanded] = useState(true);
   const [showDone, setShowDone] = useState(false);
-  const tasks = useProjectsStore((s) =>
-    selectTasksForMilestone(s, milestone.ref_code!),
+  const tasks = useProjectsStore(
+    useShallow((s) => selectTasksForMilestone(s, milestone.ref_code!)),
   );
   const buckets = bucketTasks(tasks);
   const total = tasks.length;

--- a/radbot/web/frontend/src/components/projects/OverviewTab.tsx
+++ b/radbot/web/frontend/src/components/projects/OverviewTab.tsx
@@ -1,3 +1,4 @@
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import {
   selectGoalsForProject,
@@ -13,14 +14,14 @@ interface Props {
 }
 
 export default function OverviewTab({ project }: Props) {
-  const goals = useProjectsStore((s) =>
-    selectGoalsForProject(s, project.ref_code!),
+  const goals = useProjectsStore(
+    useShallow((s) => selectGoalsForProject(s, project.ref_code!)),
   );
-  const milestones = useProjectsStore((s) =>
-    selectMilestonesForProject(s, project.ref_code!),
+  const milestones = useProjectsStore(
+    useShallow((s) => selectMilestonesForProject(s, project.ref_code!)),
   );
-  const tasks = useProjectsStore((s) =>
-    selectTasksForProject(s, project.ref_code!),
+  const tasks = useProjectsStore(
+    useShallow((s) => selectTasksForProject(s, project.ref_code!)),
   );
   const buckets = bucketTasks(tasks);
   const total = tasks.length;

--- a/radbot/web/frontend/src/components/projects/ProjectDetail.tsx
+++ b/radbot/web/frontend/src/components/projects/ProjectDetail.tsx
@@ -1,4 +1,5 @@
 import { useSearchParams } from "react-router-dom";
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import { cn } from "@/lib/utils";
 import {
@@ -32,12 +33,14 @@ export default function ProjectDetail({ project }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentTab = (searchParams.get("tab") as TabKey) || "overview";
 
-  const counts = useProjectsStore((s) => ({
-    milestones: selectMilestonesForProject(s, project.ref_code!).length,
-    tasks: selectTasksForProject(s, project.ref_code!).length,
-    explorations: selectExplorationsForProject(s, project.ref_code!).length,
-    goals: selectGoalsForProject(s, project.ref_code!).length,
-  }));
+  const counts = useProjectsStore(
+    useShallow((s) => ({
+      milestones: selectMilestonesForProject(s, project.ref_code!).length,
+      tasks: selectTasksForProject(s, project.ref_code!).length,
+      explorations: selectExplorationsForProject(s, project.ref_code!).length,
+      goals: selectGoalsForProject(s, project.ref_code!).length,
+    })),
+  );
 
   const tabCount = (key: TabKey) => {
     if (key === "milestones") return counts.milestones;

--- a/radbot/web/frontend/src/components/projects/TasksTab.tsx
+++ b/radbot/web/frontend/src/components/projects/TasksTab.tsx
@@ -1,3 +1,4 @@
+import { useShallow } from "zustand/shallow";
 import type { TelosEntry } from "@/lib/telos-api";
 import {
   bucketTasks,
@@ -11,8 +12,8 @@ interface Props {
 }
 
 export default function TasksTab({ project }: Props) {
-  const tasks = useProjectsStore((s) =>
-    selectTasksForProject(s, project.ref_code!),
+  const tasks = useProjectsStore(
+    useShallow((s) => selectTasksForProject(s, project.ref_code!)),
   );
   const buckets = bucketTasks(tasks);
 


### PR DESCRIPTION
## Summary
- Every tab/list component did `useProjectsStore((s) => selectXForY(s, ref))` — the selector allocates a new array on each call. Zustand v5 + `useSyncExternalStore` treats each new reference as a state change, loops until React bails with error #185.
- Wrap each array selector with `useShallow` (element-wise compare). Same fix for the `counts` object in `ProjectDetail`.
- Touched: `ProjectDetail`, `OverviewTab`, `MilestonesTab` (2 selectors), `TasksTab`, `ExplorationsTab`, `GoalsTab`.

## Test plan
- [ ] Deploy, load `/projects`, pick a project — no more "Something went wrong / React #185"
- [ ] Tab through Overview / Milestones / Tasks / Explorations / Goals
- [ ] Refresh button re-fetches; filter box narrows rail without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)