### PR TITLE
feat(quality-pipeline): visual regression via Claude Code CLI + rich PR comment

### DIFF
--- a/.github/workflows/quality-pipeline.yml
+++ b/.github/workflows/quality-pipeline.yml
@@ -467,22 +467,23 @@ jobs:
         working-directory: pr
         run: docker compose down -v || true
 
-      # ── Phase 3: AI compare ──────────────────────────────────────────
+      # ── Phase 3: AI compare (Claude Code CLI as judge) ───────────────
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
       - name: Compare screenshots
         id: compare
         working-directory: pr
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BUDGET_USD: ${{ env.ANTHROPIC_BUDGET_USD }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # anthropic isn't in pyproject.toml deps; only the visual-regression
-          # comparator script needs it. uv run --with creates an ephemeral
-          # venv with the dep — avoids the "externally-managed" PEP 668 error
-          # that --system would hit on Ubuntu's system Python.
-          uv run --with "anthropic>=0.40.0" python scripts/visual_regression_compare.py \
+          uv run python scripts/visual_regression_compare.py \
             --before "$GITHUB_WORKSPACE/screens/main" \
             --after "$GITHUB_WORKSPACE/screens/pr" \
             --output-json "$GITHUB_WORKSPACE/visual-result.json" \
+            --output-md "$GITHUB_WORKSPACE/visual-summary.md" \
+            --pr-context "$PR_TITLE" \
             --max-score 20 >> "$GITHUB_STEP_SUMMARY"
       - name: Upload screenshot artifacts
         if: always()
@@ -492,6 +493,7 @@ jobs:
           path: |
             screens/
             visual-result.json
+            visual-summary.md
           retention-days: 14
 
   # ──────────────────────────────────────────────────────────────────────
@@ -516,6 +518,13 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v4
+      - name: Download visual-regression artifact
+        if: needs.visual-regression.result != 'skipped'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: visual-regression-${{ github.run_id }}
+          path: visual-artifact
       - name: Compute total score
         id: tally
         env:
@@ -553,6 +562,12 @@ jobs:
             if [ "$BLOCKED" = "true" ]; then
               echo
               echo "**Auto-merge disabled** — sensitive paths touched: \`$BLOCKED_PATHS\`"
+            fi
+            if [ -f visual-artifact/visual-summary.md ]; then
+              echo
+              echo "### Visual regression details"
+              echo
+              cat visual-artifact/visual-summary.md
             fi
           } > comment.md
       - name: Post sticky comment

--- a/scripts/visual_regression_compare.py
+++ b/scripts/visual_regression_compare.py
@@ -113,13 +113,97 @@ def build_prompt(
     return "\n".join(lines)
 
 
-def run_claude(prompt: str, timeout: int) -> str:
-    """Invoke `claude -p` with a prompt on stdin and return its stdout.
+def _build_auth_env() -> dict[str, str]:
+    """Reuse the same auth pattern as radbot's claude_code_client.
 
-    Uses stdin (not -p <arg>) to sidestep shell arg-length limits for large
-    prompts. Adds --dangerously-skip-permissions because CI has no TTY to
-    approve Read tool calls.
+    Reads ANTHROPIC_API_KEY from the environment (set by the workflow from
+    the `ANTHROPIC_API_KEY` secret) and routes it by prefix:
+      - `sk-ant-api*`  → keep as ANTHROPIC_API_KEY (standard API-key flow).
+      - anything else  → treat as an OAuth / setup token: unset
+        ANTHROPIC_API_KEY (its presence disables OAuth mode in the CLI),
+        set CLAUDE_CODE_OAUTH_TOKEN, and stash the token at
+        ~/.claude/remote/.oauth_token where the CLI reads it.
+
+    This matches the behavior of `ClaudeCodeClient._run_process` at
+    radbot/tools/claude_code/claude_code_client.py — one user was pasting
+    an OAuth token into the ANTHROPIC_API_KEY secret and getting
+    "Invalid API key" because the CLI was treating it as an SDK key.
     """
+    env = os.environ.copy()
+    token = env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if not token:
+        return env
+
+    if token.startswith("sk-ant-api"):
+        env["ANTHROPIC_API_KEY"] = token
+        env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+    else:
+        # OAuth / setup token path — ANTHROPIC_API_KEY must NOT be set.
+        env.pop("ANTHROPIC_API_KEY", None)
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+        _write_oauth_token_file(token)
+
+    # Running as root in GH Actions runner; required for --dangerously-skip-permissions.
+    try:
+        if os.getuid() == 0:
+            env["IS_SANDBOX"] = "1"
+    except AttributeError:
+        pass
+    return env
+
+
+def _write_oauth_token_file(token: str) -> None:
+    """Stash the OAuth token where the CLI reads it for headless auth."""
+    try:
+        home = pathlib.Path.home()
+        remote_dir = home / ".claude" / "remote"
+        remote_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+        stale_api_key = remote_dir / ".api_key"
+        if stale_api_key.exists():
+            stale_api_key.unlink()
+        token_path = remote_dir / ".oauth_token"
+        token_path.write_text(token)
+        token_path.chmod(0o600)
+    except Exception as e:
+        sys.stderr.write(f"WARN: failed to write OAuth token file: {e}\n")
+
+
+def _ensure_onboarding_complete() -> None:
+    """Pre-set the flags that otherwise cause interactive prompts in CI."""
+    try:
+        home = pathlib.Path.home()
+        claude_json = home / ".claude.json"
+        data: dict[str, Any] = {}
+        if claude_json.exists():
+            try:
+                data = json.loads(claude_json.read_text())
+            except Exception:
+                data = {}
+        if not data.get("hasCompletedOnboarding"):
+            data["hasCompletedOnboarding"] = True
+            claude_json.write_text(json.dumps(data, indent=2))
+            claude_json.chmod(0o600)
+
+        settings_json = home / ".claude" / "settings.json"
+        settings: dict[str, Any] = {}
+        if settings_json.exists():
+            try:
+                settings = json.loads(settings_json.read_text())
+            except Exception:
+                settings = {}
+        if not settings.get("skipDangerousModePermissionPrompt"):
+            settings["skipDangerousModePermissionPrompt"] = True
+            settings_json.parent.mkdir(parents=True, exist_ok=True)
+            settings_json.write_text(json.dumps(settings, indent=2))
+    except Exception as e:
+        sys.stderr.write(f"WARN: onboarding prep failed: {e}\n")
+
+
+def run_claude(prompt: str, timeout: int) -> str:
+    """Invoke `claude -p` with a prompt on stdin and return its stdout."""
+    _ensure_onboarding_complete()
+    env = _build_auth_env()
+
     cmd = [
         "claude",
         "-p",
@@ -137,6 +221,7 @@ def run_claude(prompt: str, timeout: int) -> str:
             text=True,
             timeout=timeout,
             check=False,
+            env=env,
         )
     except FileNotFoundError:
         raise RuntimeError(
@@ -163,9 +248,19 @@ def run_claude(prompt: str, timeout: int) -> str:
 
 def _preflight() -> None:
     """Surface a clear error up-front if the CLI or API key is missing."""
-    if not os.environ.get("ANTHROPIC_API_KEY"):
+    token = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get(
+        "CLAUDE_CODE_OAUTH_TOKEN"
+    )
+    if not token:
         sys.stderr.write(
-            "WARN: ANTHROPIC_API_KEY not set. Claude CLI may fail to auth.\n"
+            "WARN: neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN set. "
+            "Claude CLI will fail to auth.\n"
+        )
+    else:
+        kind = "api_key" if token.startswith("sk-ant-api") else "oauth_token"
+        sys.stderr.write(
+            f"Auth: {kind} ({token[:10]}…), "
+            f"{'ANTHROPIC_API_KEY' if kind == 'api_key' else 'CLAUDE_CODE_OAUTH_TOKEN'} path.\n"
         )
     try:
         ver = subprocess.run(

--- a/scripts/visual_regression_compare.py
+++ b/scripts/visual_regression_compare.py
@@ -1,54 +1,73 @@
 #!/usr/bin/env python3
-"""Compare two screenshot sets via Claude vision and emit a 0-N quality score.
+"""Compare two screenshot sets via Claude Code CLI and emit a 0-N quality score.
+
+Drives the `claude` CLI via subprocess rather than the `anthropic` SDK directly.
+This lets the tool use whatever auth the Claude Code CLI supports (API key,
+subscription OAuth, custom endpoint) without the SDK's strict key format check.
 
 Inputs:
-  --before <dir>   Directory of baseline screenshots (e.g. main branch)
-  --after <dir>    Directory of candidate screenshots (e.g. PR head)
-  --output-json    Path to write structured verdict JSON
-  --max-score      Cap for the emitted score (default 20)
+  --before <dir>     Directory of baseline screenshots (e.g. main branch)
+  --after <dir>      Directory of candidate screenshots (e.g. PR head)
+  --output-json      Path to write structured verdict JSON
+  --output-md        Path to write rich markdown summary (for PR sticky comment)
+  --max-score        Cap for the emitted score (default 20)
+  --pr-context       Optional short blurb describing what the PR changes
 
 Output:
   - Writes structured JSON verdict to --output-json
+  - Writes a markdown table with per-screenshot verdicts to --output-md
   - Writes 'score=N' to GITHUB_OUTPUT (if set)
-  - Writes a markdown summary table to stdout (suitable for $GITHUB_STEP_SUMMARY)
-  - Emits 0 if any screenshot is missing on the after side (treated as broken)
+  - Writes a short summary to stdout (suitable for $GITHUB_STEP_SUMMARY)
 
-Cost: one Anthropic vision call per matched screenshot pair, capped by
-ANTHROPIC_BUDGET_USD env var (default 2.0).
+The judge classifies each pair as one of:
+  - unchanged  — pixel-equivalent or trivial anti-aliasing
+  - changed    — intentional polish (spacing, copy, accents); does NOT penalize
+  - regression — broken layout, missing elements, unexpected overlap
+  - error      — page blank / console overlay / unrenderable
+Only `regression` and `error` reduce the score. `changed` is noted but free.
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import os
 import pathlib
+import re
+import subprocess
 import sys
 from typing import Any
 
-import anthropic
+PROMPT_HEADER = """You are a senior front-end engineer doing visual-regression review.
 
-MODEL = "claude-haiku-4-5"
-SYSTEM_PROMPT = """You are a senior front-end engineer doing visual-regression review.
+You will receive a list of before/after screenshot pairs from the same pages of a web app. For each pair, Read both PNG files and classify the visual difference.
 
-You will receive a pair of screenshots from the same page of a web app:
-  - "before": baseline (origin/main)
-  - "after": the same page after a candidate PR
+For each page, return one of:
+  - "unchanged"  — pixel-identical or negligible rendering differences
+  - "changed"    — intentional visual change aligned with PR intent (does NOT reduce score)
+  - "regression" — unexpected broken layout, missing critical elements, overlap
+  - "error"      — page is blank, shows console error overlay, or is unrenderable
 
-Output ONLY a single JSON object (no prose, no markdown):
+If a page is new (no "before" file exists on disk), evaluate the "after" alone and mark it "changed" with a short note.
+
+Only "regression" and "error" reduce the score. "changed" pages should be noted in the summary but must NOT lower the score.
+
+Scoring guide (aggregate across all pairs):
+  100   no regressions, no errors
+  95    trivial unintentional diffs only
+  80    a few minor regressions
+  60    one notable regression
+  40    multiple or significant regressions
+  0     page crashes / unrenderable
+
+Respond with ONLY this JSON object (no prose, no markdown fences):
 {
-  "verdict": "no_change" | "minor" | "major" | "breaking",
-  "score_pct": <integer 0-100>,
-  "summary": "<one or two sentences explaining differences>"
+  "score": <integer 0-100>,
+  "summary": "<one-sentence overall assessment>",
+  "pages": [
+    {"name": "<screenshot-name>", "status": "unchanged|changed|regression|error", "note": "<one-line explanation>"}
+  ]
 }
-
-Scoring:
-  - 100 = pixel-equivalent or trivial anti-aliasing only
-  -  85 = minor intentional polish (spacing, colors, copy tweaks)
-  -  60 = major change (layout reflow, new section, removed element)
-  -  20 = breaking change (overlap, missing critical elements, console-level error overlay)
-  -   0 = page is unrenderable / blank / error overlay
 """
 
 
@@ -57,98 +76,313 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--before", required=True, type=pathlib.Path)
     p.add_argument("--after", required=True, type=pathlib.Path)
     p.add_argument("--output-json", required=True, type=pathlib.Path)
+    p.add_argument("--output-md", type=pathlib.Path)
     p.add_argument("--max-score", type=int, default=20)
+    p.add_argument("--pr-context", default="")
+    p.add_argument("--timeout", type=int, default=600)
     return p.parse_args()
 
 
-def load_image(path: pathlib.Path) -> dict[str, Any]:
-    data = path.read_bytes()
-    return {
-        "type": "image",
-        "source": {
-            "type": "base64",
-            "media_type": "image/png",
-            "data": base64.b64encode(data).decode("ascii"),
-        },
-    }
-
-
-def compare_pair(client: anthropic.Anthropic, name: str, before: pathlib.Path, after: pathlib.Path) -> dict[str, Any]:
-    msg = client.messages.create(
-        model=MODEL,
-        max_tokens=400,
-        temperature=0.1,
-        system=SYSTEM_PROMPT,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": f"Page: {name}. Before (main):"},
-                    load_image(before),
-                    {"type": "text", "text": "After (PR):"},
-                    load_image(after),
-                    {"type": "text", "text": "Now output the JSON verdict."},
-                ],
-            }
-        ],
+def build_prompt(
+    before_dir: pathlib.Path,
+    after_dir: pathlib.Path,
+    names: list[str],
+    before_pngs: dict[str, pathlib.Path],
+    after_pngs: dict[str, pathlib.Path],
+    pr_context: str,
+) -> str:
+    lines = [PROMPT_HEADER, ""]
+    if pr_context:
+        lines.append("## PR Context")
+        lines.append(pr_context)
+        lines.append("")
+    lines.append("## Screenshot pairs")
+    lines.append(f"Before (baseline) dir: {before_dir}")
+    lines.append(f"After (PR) dir:        {after_dir}")
+    lines.append("")
+    for name in names:
+        before = before_pngs.get(name)
+        after = after_pngs.get(name)
+        lines.append(f"### {name}")
+        lines.append(f"  Before: {before if before else '(missing — new page)'}")
+        lines.append(f"  After:  {after if after else '(missing — page removed)'}")
+    lines.append("")
+    lines.append(
+        "Use the Read tool to view each before and after PNG, then produce the JSON verdict."
     )
-    text = next((b.text for b in msg.content if getattr(b, "type", None) == "text"), "").strip()
-    text = text.removeprefix("```json").removeprefix("```").removesuffix("```").strip()
-    parsed = json.loads(text)
-    parsed["_name"] = name
-    parsed["_input_tokens"] = msg.usage.input_tokens
-    parsed["_output_tokens"] = msg.usage.output_tokens
-    return parsed
+    return "\n".join(lines)
+
+
+def run_claude(prompt: str, timeout: int) -> str:
+    """Invoke `claude -p` with a prompt and return its stdout."""
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--allowed-tools",
+        "Read",
+        "--max-turns",
+        "30",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "`claude` CLI not found on PATH. Install with: "
+            "npm install -g @anthropic-ai/claude-code"
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"claude CLI timed out after {timeout}s") from e
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()[:2000]
+        raise RuntimeError(
+            f"claude CLI exited {result.returncode}: {stderr or '(no stderr)'}"
+        )
+    return result.stdout or ""
+
+
+_JSON_OBJ_RE = re.compile(
+    r"\{(?:[^{}\[\]]|\[(?:[^\[\]]|\[(?:[^\[\]])*\])*\]|\"(?:[^\"\\]|\\.)*\")*\}",
+    re.DOTALL,
+)
+
+
+def extract_verdict(text: str) -> dict[str, Any] | None:
+    """Pull a JSON object with a `score` field out of Claude's mixed output."""
+    stripped = text.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict) and "score" in obj:
+            return obj
+    except json.JSONDecodeError:
+        pass
+    for candidate in _JSON_OBJ_RE.findall(text):
+        try:
+            obj = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "score" in obj:
+            return obj
+    return None
+
+
+STATUS_ICONS = {
+    "unchanged": "✅",
+    "changed": "ℹ️",
+    "regression": "❌",
+    "error": "⚠️",
+    "added": "➕",
+    "removed": "➖",
+}
+
+
+def render_markdown(
+    score: int,
+    max_score: int,
+    overall_summary: str,
+    pages: list[dict[str, Any]],
+) -> str:
+    regressions = [p for p in pages if p.get("status") == "regression"]
+    errors = [p for p in pages if p.get("status") == "error"]
+    changed = [p for p in pages if p.get("status") in ("changed", "added", "removed")]
+    unchanged = [p for p in pages if p.get("status") == "unchanged"]
+
+    lines: list[str] = []
+    lines.append(f"**Visual regression: {score} / {max_score}**")
+    if overall_summary:
+        lines.append("")
+        lines.append(f"> {overall_summary}")
+    lines.append("")
+
+    noteworthy = regressions + errors + changed
+    if noteworthy:
+        lines.append("| Page | Status | Notes |")
+        lines.append("|---|---|---|")
+        for p in noteworthy:
+            status = p.get("status", "?")
+            icon = STATUS_ICONS.get(status, "❓")
+            note = (p.get("note", "") or "").replace("|", "\\|")[:200]
+            lines.append(f"| `{p.get('name', '?')}` | {icon} {status} | {note} |")
+        lines.append("")
+
+    if unchanged:
+        names = ", ".join(f"`{p.get('name', '?')}`" for p in unchanged)
+        lines.append(
+            f"<details><summary>{len(unchanged)} unchanged page"
+            f"{'' if len(unchanged) == 1 else 's'}</summary>\n\n{names}\n\n</details>"
+        )
+        lines.append("")
+
+    parts: list[str] = []
+    if unchanged:
+        parts.append(f"{len(unchanged)} unchanged")
+    if changed:
+        parts.append(f"{len(changed)} changed")
+    if regressions:
+        parts.append(f"{len(regressions)} regression{'s' if len(regressions) != 1 else ''}")
+    if errors:
+        parts.append(f"{len(errors)} error{'s' if len(errors) != 1 else ''}")
+    if parts:
+        lines.append(f"**Summary:** {' · '.join(parts)}")
+
+    return "\n".join(lines)
 
 
 def main() -> int:
     args = parse_args()
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        sys.stderr.write("ANTHROPIC_API_KEY not set; visual regression cannot run.\n")
-        return 1
 
-    before_pngs = {p.name: p for p in args.before.glob("*.png")} if args.before.exists() else {}
-    after_pngs = {p.name: p for p in args.after.glob("*.png")} if args.after.exists() else {}
+    before_pngs = (
+        {p.name: p for p in args.before.glob("*.png")} if args.before.exists() else {}
+    )
+    after_pngs = (
+        {p.name: p for p in args.after.glob("*.png")} if args.after.exists() else {}
+    )
+    names = sorted(set(before_pngs) | set(after_pngs))
 
-    all_names = sorted(set(before_pngs) | set(after_pngs))
-    if not all_names:
+    if not names:
         sys.stderr.write("No screenshots found in either directory; emitting 0.\n")
-        args.output_json.write_text(json.dumps({"score": 0, "pairs": [], "reason": "no screenshots"}, indent=2))
-        print("# Visual regression\nNo screenshots captured (gate=0).")
+        args.output_json.write_text(
+            json.dumps(
+                {
+                    "score": 0,
+                    "max_score": args.max_score,
+                    "pairs": [],
+                    "reason": "no screenshots",
+                },
+                indent=2,
+            )
+        )
+        if args.output_md:
+            args.output_md.write_text(
+                f"**Visual regression: 0 / {args.max_score}**\n\nNo screenshots captured.\n"
+            )
+        print(f"# Visual regression\nNo screenshots captured — score 0/{args.max_score}.")
         _write_gh_output("score", "0")
         return 0
 
-    client = anthropic.Anthropic(api_key=api_key)
-    pairs: list[dict[str, Any]] = []
-    pcts: list[int] = []
-    for name in all_names:
+    prompt = build_prompt(
+        args.before, args.after, names, before_pngs, after_pngs, args.pr_context
+    )
+
+    sys.stderr.write(f"Evaluating {len(names)} screenshot(s) via claude CLI…\n")
+    try:
+        raw = run_claude(prompt, args.timeout)
+    except RuntimeError as e:
+        sys.stderr.write(f"Claude CLI failed: {e}\n")
+        error_msg = str(e)[:500]
+        args.output_json.write_text(
+            json.dumps(
+                {
+                    "score": 0,
+                    "max_score": args.max_score,
+                    "error": error_msg,
+                    "pairs": [],
+                },
+                indent=2,
+            )
+        )
+        if args.output_md:
+            args.output_md.write_text(
+                f"**Visual regression: 0 / {args.max_score}** — judge failed\n\n"
+                f"```\n{error_msg}\n```\n"
+            )
+        print(f"# Visual regression\nJudge error — score 0/{args.max_score}:\n\n{error_msg}")
+        _write_gh_output("score", "0")
+        return 0
+
+    verdict = extract_verdict(raw)
+    if verdict is None:
+        sys.stderr.write("No valid JSON found in Claude output.\n")
+        preview = raw.strip()[:500]
+        args.output_json.write_text(
+            json.dumps(
+                {
+                    "score": 0,
+                    "max_score": args.max_score,
+                    "error": "no JSON in response",
+                    "raw_preview": preview,
+                    "pairs": [],
+                },
+                indent=2,
+            )
+        )
+        if args.output_md:
+            args.output_md.write_text(
+                f"**Visual regression: 0 / {args.max_score}** — judge produced no JSON\n\n"
+                f"<details><summary>Raw response preview</summary>\n\n"
+                f"```\n{preview}\n```\n\n</details>\n"
+            )
+        print(f"# Visual regression\nNo JSON in judge response — score 0/{args.max_score}.")
+        _write_gh_output("score", "0")
+        return 0
+
+    raw_score = verdict.get("score")
+    if not isinstance(raw_score, (int, float)):
+        raw_score = 0
+    score_pct = max(0, min(100, int(raw_score)))
+    score = round(score_pct / 100 * args.max_score)
+
+    pages_raw = verdict.get("pages") if isinstance(verdict.get("pages"), list) else []
+    pages: list[dict[str, Any]] = []
+    seen = set()
+    for p in pages_raw:
+        if not isinstance(p, dict):
+            continue
+        name = str(p.get("name") or "")
+        status = str(p.get("status") or "").strip().lower() or "changed"
+        if status not in {"unchanged", "changed", "regression", "error", "added", "removed"}:
+            status = "changed"
+        note = str(p.get("note") or "")
+        pages.append({"name": name, "status": status, "note": note})
+        seen.add(name)
+
+    # Synthesize entries for any screenshot names the judge skipped
+    for name in names:
+        if name in seen:
+            continue
         if name not in before_pngs:
-            pairs.append({"_name": name, "verdict": "added", "score_pct": 80, "summary": "New screenshot (no baseline)"})
-            pcts.append(80)
-            continue
-        if name not in after_pngs:
-            pairs.append({"_name": name, "verdict": "removed", "score_pct": 0, "summary": "Screenshot disappeared in PR (page broke?)"})
-            pcts.append(0)
-            continue
-        try:
-            verdict = compare_pair(client, name, before_pngs[name], after_pngs[name])
-        except Exception as e:
-            verdict = {"_name": name, "verdict": "error", "score_pct": 0, "summary": f"Compare failed: {e}"}
-        pairs.append(verdict)
-        pcts.append(int(verdict.get("score_pct", 0)))
+            pages.append(
+                {"name": name, "status": "added", "note": "new screenshot (no baseline)"}
+            )
+        elif name not in after_pngs:
+            pages.append(
+                {"name": name, "status": "removed", "note": "screenshot disappeared in PR"}
+            )
+        else:
+            pages.append(
+                {"name": name, "status": "changed", "note": "not reviewed by judge"}
+            )
 
-    avg_pct = sum(pcts) / len(pcts) if pcts else 0
-    score = round(avg_pct / 100 * args.max_score)
+    summary_text = str(verdict.get("summary") or "")
 
-    args.output_json.write_text(json.dumps({"score": score, "max_score": args.max_score, "avg_pct": avg_pct, "pairs": pairs}, indent=2))
+    args.output_json.write_text(
+        json.dumps(
+            {
+                "score": score,
+                "max_score": args.max_score,
+                "score_pct": score_pct,
+                "summary": summary_text,
+                "pages": pages,
+            },
+            indent=2,
+        )
+    )
 
+    md = render_markdown(score, args.max_score, summary_text, pages)
+    if args.output_md:
+        args.output_md.write_text(md + "\n")
+
+    # Short stdout for $GITHUB_STEP_SUMMARY
     print("# Visual regression")
-    print(f"Score: **{score} / {args.max_score}** (avg {avg_pct:.0f}%)\n")
-    print("| Page | Verdict | % | Notes |")
-    print("|---|---|---:|---|")
-    for p in pairs:
-        print(f"| {p['_name']} | {p.get('verdict', '?')} | {p.get('score_pct', 0)} | {p.get('summary', '')[:120]} |")
+    print()
+    print(md)
 
     _write_gh_output("score", str(score))
     return 0

--- a/scripts/visual_regression_compare.py
+++ b/scripts/visual_regression_compare.py
@@ -114,19 +114,25 @@ def build_prompt(
 
 
 def run_claude(prompt: str, timeout: int) -> str:
-    """Invoke `claude -p` with a prompt and return its stdout."""
+    """Invoke `claude -p` with a prompt on stdin and return its stdout.
+
+    Uses stdin (not -p <arg>) to sidestep shell arg-length limits for large
+    prompts. Adds --dangerously-skip-permissions because CI has no TTY to
+    approve Read tool calls.
+    """
     cmd = [
         "claude",
         "-p",
-        prompt,
         "--allowed-tools",
         "Read",
         "--max-turns",
         "30",
+        "--dangerously-skip-permissions",
     ]
     try:
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -141,11 +147,42 @@ def run_claude(prompt: str, timeout: int) -> str:
         raise RuntimeError(f"claude CLI timed out after {timeout}s") from e
 
     if result.returncode != 0:
+        # Claude CLI often writes diagnostic info to stdout even on failure
         stderr = (result.stderr or "").strip()[:2000]
-        raise RuntimeError(
-            f"claude CLI exited {result.returncode}: {stderr or '(no stderr)'}"
-        )
+        stdout = (result.stdout or "").strip()[:2000]
+        parts: list[str] = [f"claude CLI exited {result.returncode}"]
+        if stderr:
+            parts.append(f"stderr: {stderr}")
+        if stdout:
+            parts.append(f"stdout: {stdout}")
+        if not stderr and not stdout:
+            parts.append("(no output on either stream)")
+        raise RuntimeError(" — ".join(parts))
     return result.stdout or ""
+
+
+def _preflight() -> None:
+    """Surface a clear error up-front if the CLI or API key is missing."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        sys.stderr.write(
+            "WARN: ANTHROPIC_API_KEY not set. Claude CLI may fail to auth.\n"
+        )
+    try:
+        ver = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        sys.stderr.write(f"claude CLI: {(ver.stdout or ver.stderr).strip()[:200]}\n")
+    except FileNotFoundError:
+        sys.stderr.write(
+            "ERROR: `claude` CLI not found on PATH. "
+            "Install with: npm install -g @anthropic-ai/claude-code\n"
+        )
+    except Exception as e:
+        sys.stderr.write(f"WARN: claude --version failed: {e}\n")
 
 
 _JSON_OBJ_RE = re.compile(
@@ -271,7 +308,11 @@ def main() -> int:
         args.before, args.after, names, before_pngs, after_pngs, args.pr_context
     )
 
-    sys.stderr.write(f"Evaluating {len(names)} screenshot(s) via claude CLI…\n")
+    _preflight()
+    sys.stderr.write(
+        f"Evaluating {len(names)} screenshot(s) via claude CLI "
+        f"(prompt {len(prompt)} chars, timeout {args.timeout}s)…\n"
+    )
     try:
         raw = run_claude(prompt, args.timeout)
     except RuntimeError as e:


### PR DESCRIPTION
## Summary

Two fixes in one, both driven by the #41 sticky comment showing `Visual regression | 3/20` with no per-screenshot explanation:

1. **Swap anthropic SDK for `claude -p` subprocess** — the SDK's strict `sk-ant-api03` key validation was rejecting valid credentials; the CLI accepts whatever auth is configured (API key, subscription OAuth, custom endpoint).
2. **Rich per-screenshot details in the PR sticky comment** — was a single gate-row number; now includes verdict table, status icons, notes, and unchanged pages collapsed in `<details>`.

## Judge output

New 4-status classifier (ported from `partner-suite/.quality-pipeline/visual-regression.ts`):

| Status | Penalty? | Meaning |
|---|---|---|
| `unchanged` ✅ | no | pixel-identical / trivial anti-alias |
| `changed` ℹ️ | **no** | intentional PR-aligned polish |
| `regression` ❌ | yes | broken layout / missing elements |
| `error` ⚠️ | yes | page blank / console overlay |

Only regressions + errors reduce the score. Intentional UI polish is noted in the summary but free. Scoring guide calibrated: 100 = no regressions · 60 = one notable · 40 = multiple significant · 0 = page crash.

## New artifacts

- `visual-result.json` (unchanged) — structured verdict for programs.
- `visual-summary.md` (NEW) — markdown table with per-screenshot verdict icons + notes. Uploaded to the `visual-regression-<run_id>` artifact and downloaded by the aggregate job for inclusion in the sticky PR comment.

## Workflow changes

- Install `@anthropic-ai/claude-code` globally before compare step.
- Drop the `uv run --with anthropic>=0.40.0` inline dep.
- Pass `$PR_TITLE` as `--pr-context` so the judge can distinguish intentional polish from regressions.
- Aggregate job downloads visual artifact and appends `### Visual regression details` + `visual-summary.md` to `comment.md`.

## Test plan

- [ ] Open a cosmetic-only PR with this branch merged — verify sticky comment shows per-screenshot verdict table
- [ ] Verify `unchanged` pages score in the 95-100 band (no regressions)
- [ ] Kill the Anthropic key in the environment — verify graceful error path produces a 0/20 with the error shown in the comment rather than crashing the workflow
- [ ] `visual-summary.md` artifact present alongside `visual-result.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)