### PR TITLE
feat(projects): click-to-edit task editor

### DIFF
--- a/radbot/web/api/telos.py
+++ b/radbot/web/api/telos.py
@@ -214,6 +214,34 @@ async def projects_entries(
     return {"sections": out}
 
 
+class ProjectTaskPatch(BaseModel):
+    content: Optional[str] = None
+    metadata_merge: Optional[Dict[str, Any]] = None
+    status: Optional[str] = None
+
+
+@router.patch("/projects/task/{ref_code}")
+async def patch_project_task(
+    ref_code: str,
+    body: ProjectTaskPatch,
+) -> Dict[str, Any]:
+    """Partial update of a single project_task entry. Unauth'd write, scoped
+    to the `project_tasks` section only — all other telos writes remain
+    admin-bearer-protected. Powers the inline task editor on `/projects`."""
+    if body.status is not None and body.status not in STATUS_VALUES:
+        raise HTTPException(400, f"Invalid status {body.status!r}.")
+    entry = telos_db.update_entry(
+        Section.PROJECT_TASKS,
+        ref_code,
+        content=body.content,
+        metadata_merge=body.metadata_merge,
+        status=body.status,
+    )
+    if not entry:
+        raise HTTPException(404, f"No task {ref_code}.")
+    return _serialize(entry)
+
+
 # ---------------------------------------------------------------------------
 # Admin-authed endpoints (writes + sensitive sections)
 # ---------------------------------------------------------------------------

--- a/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
+++ b/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
@@ -26,6 +26,7 @@ export default function MilestonesTab({ project }: Props) {
   const unmilestoned = useProjectsStore(
     useShallow((s) => selectUnmilestonedTasks(s, project.ref_code!)),
   );
+  const openTaskEditor = useProjectsStore((s) => s.openTaskEditor);
 
   return (
     <div
@@ -100,7 +101,7 @@ export default function MilestonesTab({ project }: Props) {
             </span>
           </div>
           {unmilestoned.map((t) => (
-            <TaskLine key={t.entry_id} task={t} accent={accent} />
+            <TaskLine key={t.entry_id} task={t} accent={accent} onClick={openTaskEditor} />
           ))}
         </div>
       )}
@@ -274,6 +275,7 @@ function TaskGroup({
   collapsedByDefault?: boolean;
 }) {
   const [open, setOpen] = useState(!collapsedByDefault);
+  const openTaskEditor = useProjectsStore((s) => s.openTaskEditor);
   if (tasks.length === 0) return null;
   return (
     <div>
@@ -307,7 +309,7 @@ function TaskGroup({
           {label} · {tasks.length}
         </span>
       </button>
-      {open && tasks.map((t) => <TaskLine key={t.entry_id} task={t} accent={accent} />)}
+      {open && tasks.map((t) => <TaskLine key={t.entry_id} task={t} accent={accent} onClick={openTaskEditor} />)}
     </div>
   );
 }

--- a/radbot/web/frontend/src/components/projects/TaskEditDialog.tsx
+++ b/radbot/web/frontend/src/components/projects/TaskEditDialog.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { entryKey } from "@/lib/telos-api";
+import { useProjectsStore } from "@/stores/projects-store";
+import PIcon from "./shared/PIcon";
+import RefCode from "./shared/RefCode";
+import { accentFor } from "./shared/projectAccent";
+import { taskBucket, type TaskStatus } from "./shared/TaskLine";
+
+const STATUS_OPTIONS: { key: TaskStatus; label: string; color: string; metaValue: string }[] = [
+  { key: "backlog", label: "Backlog", color: "var(--sky)", metaValue: "backlog" },
+  { key: "inprogress", label: "In progress", color: "var(--sunset)", metaValue: "inprogress" },
+  { key: "done", label: "Done", color: "var(--crt)", metaValue: "done" },
+];
+
+export default function TaskEditDialog() {
+  const refCode = useProjectsStore((s) => s.editingTaskRef);
+  const close = useProjectsStore((s) => s.closeTaskEditor);
+  const entries = useProjectsStore((s) => s.entries);
+  const updateTask = useProjectsStore((s) => s.updateTask);
+
+  const task = refCode ? entries[entryKey("project_tasks", refCode)] : undefined;
+  const parentProject = task ? (task.metadata || {}).parent_project : undefined;
+
+  const initialStatus = useMemo<TaskStatus>(
+    () => (task ? taskBucket(task) : "backlog"),
+    [task],
+  );
+  const initialContent = task ? task.content || "" : "";
+
+  const [content, setContent] = useState(initialContent);
+  const [status, setStatus] = useState<TaskStatus>(initialStatus);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setContent(initialContent);
+    setStatus(initialStatus);
+    setErr(null);
+  }, [refCode, initialContent, initialStatus]);
+
+  useEffect(() => {
+    if (refCode && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(
+        textareaRef.current.value.length,
+        textareaRef.current.value.length,
+      );
+    }
+  }, [refCode]);
+
+  if (!refCode || !task) return null;
+
+  const accent = parentProject ? accentFor(parentProject) : "var(--sunset)";
+  const dirty = content !== initialContent || status !== initialStatus;
+
+  const onSave = async () => {
+    if (!dirty || saving) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      const patch: { content?: string; metadata_merge?: Record<string, any> } = {};
+      if (content !== initialContent) patch.content = content;
+      if (status !== initialStatus) {
+        patch.metadata_merge = { task_status: STATUS_OPTIONS.find((s) => s.key === status)!.metaValue };
+      }
+      await updateTask(refCode, patch);
+      close();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      onSave();
+    }
+  };
+
+  return createPortal(
+    <div
+      onClick={close}
+      onKeyDown={onKeyDown}
+      role="dialog"
+      aria-modal="true"
+      data-test="projects-task-edit-dialog"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 50,
+        background: "rgba(0, 0, 0, 0.55)",
+        backdropFilter: "blur(2px)",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(640px, 100%)",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          background: "var(--surface)",
+          border: `1px solid color-mix(in oklch, ${accent} 30%, var(--p-border))`,
+          borderRadius: 10,
+          boxShadow: `0 30px 80px -20px rgba(0,0,0,0.6), 0 0 24px -8px ${accent}`,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "14px 16px",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            background: `linear-gradient(180deg, color-mix(in oklch, ${accent} 10%, var(--surface-2)), var(--surface))`,
+            borderBottom: "1px solid var(--p-border)",
+          }}
+        >
+          <RefCode code={task.ref_code || ""} color={accent} />
+          {parentProject && (
+            <span
+              style={{
+                fontFamily: "var(--p-mono)",
+                fontSize: 10,
+                color: "var(--text-dim)",
+                letterSpacing: "0.1em",
+              }}
+            >
+              in {parentProject}
+            </span>
+          )}
+          <span style={{ flex: 1 }} />
+          <button
+            onClick={close}
+            aria-label="Close"
+            style={{
+              width: 28,
+              height: 28,
+              display: "grid",
+              placeItems: "center",
+              color: "var(--text-dim)",
+              border: "1px solid var(--p-border)",
+              borderRadius: 6,
+            }}
+            data-test="projects-task-edit-close"
+          >
+            <PIcon name="close" size={12} />
+          </button>
+        </div>
+
+        <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", gap: 6 }}>
+            {STATUS_OPTIONS.map((opt) => {
+              const active = status === opt.key;
+              return (
+                <button
+                  key={opt.key}
+                  onClick={() => setStatus(opt.key)}
+                  data-test={`projects-task-edit-status-${opt.key}`}
+                  style={{
+                    padding: "6px 12px",
+                    borderRadius: 6,
+                    fontFamily: "var(--p-mono)",
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: "0.12em",
+                    color: active ? opt.color : "var(--text-mute)",
+                    background: active
+                      ? `color-mix(in oklch, ${opt.color} 14%, transparent)`
+                      : "transparent",
+                    border: `1px solid ${active ? `color-mix(in oklch, ${opt.color} 40%, transparent)` : "var(--p-border)"}`,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: opt.color,
+                      boxShadow: active && opt.key === "inprogress" ? `0 0 6px ${opt.color}` : "none",
+                    }}
+                  />
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <label
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              fontFamily: "var(--p-mono)",
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: "0.16em",
+              color: "var(--text-dim)",
+            }}
+          >
+            CONTENT
+            <textarea
+              ref={textareaRef}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onKeyDown={onKeyDown}
+              rows={10}
+              data-test="projects-task-edit-content"
+              style={{
+                width: "100%",
+                minHeight: 160,
+                padding: "10px 12px",
+                background: "var(--bg-sunk)",
+                border: "1px solid var(--p-border)",
+                borderRadius: 6,
+                fontFamily: "var(--p-mono)",
+                fontSize: 12,
+                lineHeight: 1.5,
+                color: "var(--text)",
+                resize: "vertical",
+                letterSpacing: "normal",
+                fontWeight: 400,
+              }}
+            />
+          </label>
+
+          {err && (
+            <div
+              style={{
+                padding: "8px 12px",
+                background: "color-mix(in oklch, var(--magenta) 10%, transparent)",
+                border: "1px solid color-mix(in oklch, var(--magenta) 40%, transparent)",
+                borderRadius: 6,
+                fontFamily: "var(--p-mono)",
+                fontSize: 11,
+                color: "var(--magenta)",
+              }}
+            >
+              {err}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            padding: "12px 16px",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            borderTop: "1px solid var(--p-border)",
+            background: "var(--bg-sunk)",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--p-mono)",
+              fontSize: 10,
+              color: "var(--text-dim)",
+              letterSpacing: "0.08em",
+            }}
+          >
+            <span className="kbd">⌘</span>
+            <span className="kbd" style={{ marginLeft: 3 }}>↵</span>
+            <span style={{ marginLeft: 8 }}>save</span>
+            <span style={{ marginLeft: 10 }} className="kbd">
+              esc
+            </span>
+            <span style={{ marginLeft: 6 }}>cancel</span>
+          </span>
+          <span style={{ flex: 1 }} />
+          <button
+            onClick={close}
+            disabled={saving}
+            style={{
+              padding: "6px 12px",
+              fontFamily: "var(--p-mono)",
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.1em",
+              color: "var(--text-mute)",
+              border: "1px solid var(--p-border)",
+              borderRadius: 5,
+              opacity: saving ? 0.5 : 1,
+            }}
+            data-test="projects-task-edit-cancel"
+          >
+            CANCEL
+          </button>
+          <button
+            onClick={onSave}
+            disabled={!dirty || saving}
+            data-test="projects-task-edit-save"
+            style={{
+              padding: "6px 14px",
+              fontFamily: "var(--p-mono)",
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.1em",
+              color: "var(--bg)",
+              background: accent,
+              border: `1px solid ${accent}`,
+              borderRadius: 5,
+              boxShadow: dirty && !saving ? `0 0 16px -6px ${accent}` : "none",
+              opacity: !dirty || saving ? 0.4 : 1,
+              cursor: !dirty || saving ? "not-allowed" : "pointer",
+            }}
+          >
+            {saving ? "SAVING…" : "SAVE"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/radbot/web/frontend/src/components/projects/TasksTab.tsx
+++ b/radbot/web/frontend/src/components/projects/TasksTab.tsx
@@ -21,6 +21,7 @@ export default function TasksTab({ project }: Props) {
   const tasks = useProjectsStore(
     useShallow((s) => selectTasksForProject(s, project.ref_code!)),
   );
+  const openTaskEditor = useProjectsStore((s) => s.openTaskEditor);
   const b = bucketTasks(tasks);
 
   const show =
@@ -126,7 +127,14 @@ export default function TasksTab({ project }: Props) {
             no tasks match.
           </div>
         ) : (
-          show.map((t) => <TaskLine key={t.entry_id} task={t} accent={accent} />)
+          show.map((t) => (
+            <TaskLine
+              key={t.entry_id}
+              task={t}
+              accent={accent}
+              onClick={openTaskEditor}
+            />
+          ))
         )}
       </div>
     </div>

--- a/radbot/web/frontend/src/components/projects/shared/TaskLine.tsx
+++ b/radbot/web/frontend/src/components/projects/shared/TaskLine.tsx
@@ -2,6 +2,8 @@ import type { TelosEntry } from "@/lib/telos-api";
 import RefCode from "./RefCode";
 import StatusIcon, { type TaskStatus } from "./StatusIcon";
 
+export type { TaskStatus };
+
 export function taskBucket(t: TelosEntry): TaskStatus {
   const raw = ((t.metadata || {}).task_status || "").toString().toLowerCase();
   if (raw === "inprogress" || raw === "in_progress" || raw === "in progress")
@@ -15,23 +17,50 @@ export function taskBucket(t: TelosEntry): TaskStatus {
 interface Props {
   task: TelosEntry;
   accent: string;
+  onClick?: (refCode: string) => void;
 }
 
-export default function TaskLine({ task, accent }: Props) {
+export default function TaskLine({ task, accent, onClick }: Props) {
   const bucket = taskBucket(task);
   const lines = (task.content || "").split("\n");
   const title = lines[0] || task.ref_code || "";
   const note = lines.slice(1).join(" ").trim().slice(0, 200);
   const age = formatAge(task.updated_at);
+  const clickable = !!onClick && !!task.ref_code;
+
+  const handleClick = () => {
+    if (clickable) onClick!(task.ref_code!);
+  };
 
   return (
     <div
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onClick={clickable ? handleClick : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClick();
+              }
+            }
+          : undefined
+      }
       style={{
         display: "flex",
         alignItems: "flex-start",
         gap: 10,
         padding: "9px 14px",
         borderBottom: "1px solid var(--border-soft)",
+        cursor: clickable ? "pointer" : "default",
+        transition: "background 120ms",
+      }}
+      onMouseEnter={(e) => {
+        if (clickable) e.currentTarget.style.background = "color-mix(in oklch, var(--text) 4%, transparent)";
+      }}
+      onMouseLeave={(e) => {
+        if (clickable) e.currentTarget.style.background = "";
       }}
       data-test={`projects-task-${task.ref_code}`}
     >

--- a/radbot/web/frontend/src/lib/telos-api.ts
+++ b/radbot/web/frontend/src/lib/telos-api.ts
@@ -67,3 +67,28 @@ export async function listProjectEntries(
 export function entryKey(section: string, refCode: string): string {
   return `${section}:${refCode}`;
 }
+
+export interface ProjectTaskPatch {
+  content?: string;
+  metadata_merge?: Record<string, any>;
+  status?: string;
+}
+
+export async function patchProjectTask(
+  refCode: string,
+  patch: ProjectTaskPatch,
+): Promise<TelosEntry> {
+  const res = await fetch(
+    `/api/telos/projects/task/${encodeURIComponent(refCode)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}

--- a/radbot/web/frontend/src/pages/ProjectsPage.tsx
+++ b/radbot/web/frontend/src/pages/ProjectsPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import ProjectList, { type ProjectListHandle } from "@/components/projects/ProjectList";
 import ProjectDetail from "@/components/projects/ProjectDetail";
+import TaskEditDialog from "@/components/projects/TaskEditDialog";
 import {
   selectOrphans,
   selectProject,
@@ -186,6 +187,7 @@ export default function ProjectsPage() {
           </PanelGroup>
         )}
       </div>
+      <TaskEditDialog />
     </div>
   );
 }

--- a/radbot/web/frontend/src/stores/projects-store.ts
+++ b/radbot/web/frontend/src/stores/projects-store.ts
@@ -3,9 +3,11 @@ import {
   entryKey,
   listProjectEntries,
   listProjectsSummary,
+  patchProjectTask,
   PROJECT_SECTIONS,
   type ProjectSection,
   type ProjectSummary,
+  type ProjectTaskPatch,
   type TelosEntry,
 } from "@/lib/telos-api";
 
@@ -17,7 +19,12 @@ interface ProjectsState {
   error: string | null;
   loaded: boolean;
 
+  editingTaskRef: string | null;
+
   loadAll: () => Promise<void>;
+  updateTask: (refCode: string, patch: ProjectTaskPatch) => Promise<TelosEntry>;
+  openTaskEditor: (refCode: string) => void;
+  closeTaskEditor: () => void;
 }
 
 function indexEntries(sections: Record<string, TelosEntry[]>) {
@@ -43,13 +50,17 @@ function indexEntries(sections: Record<string, TelosEntry[]>) {
   return { entries, childrenByParent };
 }
 
-export const useProjectsStore = create<ProjectsState>((set) => ({
+export const useProjectsStore = create<ProjectsState>((set, get) => ({
   entries: {},
   childrenByParent: {},
   summary: [],
   loading: false,
   error: null,
   loaded: false,
+  editingTaskRef: null,
+
+  openTaskEditor: (refCode) => set({ editingTaskRef: refCode }),
+  closeTaskEditor: () => set({ editingTaskRef: null }),
 
   loadAll: async () => {
     set({ loading: true, error: null });
@@ -64,6 +75,36 @@ export const useProjectsStore = create<ProjectsState>((set) => ({
       set({ error: e instanceof Error ? e.message : String(e) });
     } finally {
       set({ loading: false });
+    }
+  },
+
+  updateTask: async (refCode, patch) => {
+    const key = entryKey("project_tasks", refCode);
+    const prev = get().entries[key];
+    // Optimistic: merge patch into local entry immediately
+    if (prev) {
+      const nextMeta =
+        patch.metadata_merge !== undefined
+          ? { ...(prev.metadata || {}), ...patch.metadata_merge }
+          : prev.metadata;
+      const optimistic: TelosEntry = {
+        ...prev,
+        content: patch.content !== undefined ? patch.content : prev.content,
+        status: patch.status !== undefined ? patch.status : prev.status,
+        metadata: nextMeta,
+      };
+      set({ entries: { ...get().entries, [key]: optimistic } });
+    }
+    try {
+      const updated = await patchProjectTask(refCode, patch);
+      set({ entries: { ...get().entries, [key]: updated } });
+      return updated;
+    } catch (e) {
+      // Revert on error
+      if (prev) {
+        set({ entries: { ...get().entries, [key]: prev } });
+      }
+      throw e;
     }
   },
 }));


### PR DESCRIPTION
## Summary

Task rows in the Tasks and Milestones tabs are now **clickable**. Click opens a modal with:
- **Status segmented control** (Backlog / In progress / Done — matches bucketTasks classifier)
- **Content textarea** (title on first line, body below; auto-focused)
- **Save / Cancel** footer with kbd hints. `Esc` cancels, `⌘/Ctrl+Enter` saves

Saves are **optimistic** — local patch lands immediately, reverts on API error.

## Backend

New `PATCH /api/telos/projects/task/{ref_code}`. Unauth'd write **scoped to the `project_tasks` section only** — every other telos write remains admin-bearer-protected. Body: `{content?, metadata_merge?, status?}`, returns the updated entry.

## Frontend

| File | Change |
|---|---|
| `lib/telos-api.ts` | New `patchProjectTask()` helper |
| `stores/projects-store.ts` | `editingTaskRef` + `openTaskEditor`/`closeTaskEditor`; `updateTask()` with optimistic local patch + revert on error |
| `shared/TaskLine.tsx` | Accepts `onClick`; becomes keyboard-focusable (Enter/Space activates) with hover tint |
| `TaskEditDialog.tsx` (new) | Portalled modal, accent-tinted header, status pills, textarea, kbd-hinted footer |
| `TasksTab` + `MilestonesTab` + `TaskGroup` | Wire `openTaskEditor` through to `TaskLine.onClick` |
| `ProjectsPage` | Mount `<TaskEditDialog/>` at page root |

## Status canonicalization

The editor always writes `metadata.task_status = "backlog" | "inprogress" | "done"`. Legacy values (`todo`, `pending`, `complete`, etc.) continue to read correctly via the existing `bucketTasks()` tolerant classifier; the next edit normalizes them on save.

## Test plan

- [ ] Deploy; visit `/projects/<any>`, switch to Tasks tab
- [ ] Click a task row — modal opens, focus on textarea, status pill reflects current bucket
- [ ] Change status → Save → row updates immediately (optimistic) and persists after refresh
- [ ] Edit content → Save → new content reflected; multi-line body renders in the row note
- [ ] `Esc` closes without saving; click outside closes; `⌘+Enter` saves
- [ ] Milestones tab: task rows in the nested groups open the same dialog
- [ ] Disable network mid-save → error toast appears, row reverts to prior state

🤖 Generated with [Claude Code](https://claude.com/claude-code)