### PR TITLE
feat(projects): mobile support + mobile nav link

### DIFF
--- a/radbot/web/frontend/src/components/chat/ChatHeader.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatHeader.tsx
@@ -221,13 +221,14 @@ export default function ChatHeader() {
                 aria-label="Open projects"
                 data-test="chat-header-projects-link"
                 className={cn(
-                  "hidden sm:flex px-2 sm:px-2.5 py-1.5 sm:py-1 text-[0.72rem] sm:text-[0.7rem] font-mono uppercase tracking-wider transition-all cursor-pointer no-underline",
-                  "items-center gap-1.5 sm:gap-1 min-h-[40px] sm:min-h-0",
+                  "flex px-1.5 sm:px-2.5 py-1 sm:py-1 text-[0.68rem] sm:text-[0.7rem] font-mono uppercase tracking-wider transition-all cursor-pointer no-underline",
+                  "items-center gap-1 min-h-[32px] sm:min-h-0",
                   "text-accent-blue hover:bg-accent-blue/15 hover:text-accent-blue",
                   "focus:outline-none focus:ring-1 focus:ring-accent-blue",
                 )}
               >
-                PROJ
+                <span className="hidden sm:inline">PROJ</span>
+                <span className="sm:hidden">P</span>
               </a>
 
               <a

--- a/radbot/web/frontend/src/components/projects/DetailHeader.tsx
+++ b/radbot/web/frontend/src/components/projects/DetailHeader.tsx
@@ -45,6 +45,7 @@ export default function DetailHeader({ project, onRefresh, refreshing }: Props) 
 
   return (
     <div
+      className="projects-detail-header"
       style={{
         padding: "14px 20px 0",
         borderBottom: "1px solid var(--p-border)",
@@ -169,6 +170,7 @@ export default function DetailHeader({ project, onRefresh, refreshing }: Props) 
       </div>
 
       <div
+        className="projects-detail-stats"
         style={{
           display: "flex",
           gap: 16,
@@ -186,7 +188,10 @@ export default function DetailHeader({ project, onRefresh, refreshing }: Props) 
         <MiniStat label="DONE" value={stats.done} color="var(--crt)" />
         <MiniStat label="MILESTONES" value={stats.milestones} color="var(--violet)" />
         <div style={{ flex: 1, minWidth: 80 }} />
-        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 180 }}>
+        <div
+          className="projects-detail-completion"
+          style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 180 }}
+        >
           <span
             style={{
               fontSize: 9,

--- a/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
+++ b/radbot/web/frontend/src/components/projects/MilestonesTab.tsx
@@ -30,6 +30,7 @@ export default function MilestonesTab({ project }: Props) {
 
   return (
     <div
+      className="projects-milestones-tab"
       style={{
         padding: "18px 22px",
         display: "flex",

--- a/radbot/web/frontend/src/components/projects/TabBar.tsx
+++ b/radbot/web/frontend/src/components/projects/TabBar.tsx
@@ -17,6 +17,7 @@ interface Props {
 export default function TabBar({ tabs, active, setActive, accent }: Props) {
   return (
     <div
+      className="projects-tab-bar"
       style={{
         display: "flex",
         borderBottom: "1px solid var(--p-border)",
@@ -24,6 +25,7 @@ export default function TabBar({ tabs, active, setActive, accent }: Props) {
         padding: "0 20px",
         flex: "none",
         gap: 0,
+        overflowX: "auto",
       }}
     >
       {tabs.map((t) => {
@@ -73,6 +75,7 @@ export default function TabBar({ tabs, active, setActive, accent }: Props) {
       })}
       <div style={{ flex: 1, borderBottom: "1px solid var(--p-border)", marginBottom: -1 }} />
       <div
+        className="projects-tab-kbd-hint"
         style={{
           display: "flex",
           alignItems: "center",

--- a/radbot/web/frontend/src/components/projects/TaskEditDialog.tsx
+++ b/radbot/web/frontend/src/components/projects/TaskEditDialog.tsx
@@ -99,7 +99,7 @@ export default function TaskEditDialog() {
         backdropFilter: "blur(2px)",
         display: "grid",
         placeItems: "center",
-        padding: 24,
+        padding: "clamp(8px, 2vw, 24px)",
       }}
     >
       <div
@@ -144,8 +144,8 @@ export default function TaskEditDialog() {
             onClick={close}
             aria-label="Close"
             style={{
-              width: 28,
-              height: 28,
+              minWidth: 44,
+              minHeight: 44,
               display: "grid",
               placeItems: "center",
               color: "var(--text-dim)",
@@ -154,7 +154,7 @@ export default function TaskEditDialog() {
             }}
             data-test="projects-task-edit-close"
           >
-            <PIcon name="close" size={12} />
+            <PIcon name="close" size={14} />
           </button>
         </div>
 
@@ -168,10 +168,11 @@ export default function TaskEditDialog() {
                   onClick={() => setStatus(opt.key)}
                   data-test={`projects-task-edit-status-${opt.key}`}
                   style={{
-                    padding: "6px 12px",
+                    padding: "10px 14px",
+                    minHeight: 44,
                     borderRadius: 6,
                     fontFamily: "var(--p-mono)",
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: 700,
                     letterSpacing: "0.12em",
                     color: active ? opt.color : "var(--text-mute)",
@@ -285,9 +286,10 @@ export default function TaskEditDialog() {
             onClick={close}
             disabled={saving}
             style={{
-              padding: "6px 12px",
+              padding: "10px 16px",
+              minHeight: 44,
               fontFamily: "var(--p-mono)",
-              fontSize: 10,
+              fontSize: 11,
               fontWeight: 700,
               letterSpacing: "0.1em",
               color: "var(--text-mute)",
@@ -304,9 +306,10 @@ export default function TaskEditDialog() {
             disabled={!dirty || saving}
             data-test="projects-task-edit-save"
             style={{
-              padding: "6px 14px",
+              padding: "10px 18px",
+              minHeight: 44,
               fontFamily: "var(--p-mono)",
-              fontSize: 10,
+              fontSize: 11,
               fontWeight: 700,
               letterSpacing: "0.1em",
               color: "var(--bg)",

--- a/radbot/web/frontend/src/components/projects/TasksTab.tsx
+++ b/radbot/web/frontend/src/components/projects/TasksTab.tsx
@@ -86,6 +86,7 @@ export default function TasksTab({ project }: Props) {
       data-test="projects-tasks-tab"
     >
       <div
+        className="projects-tasks-chiprow"
         style={{
           display: "flex",
           alignItems: "center",

--- a/radbot/web/frontend/src/globals.css
+++ b/radbot/web/frontend/src/globals.css
@@ -208,4 +208,64 @@
     background: color-mix(in oklch, var(--sunset) 35%, transparent);
     color: var(--text);
   }
+
+  /* Responsive helpers for the projects page (inline styles can't express
+   * media queries, so a handful of overrides live here). */
+  .projects-overview-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 20px;
+    padding: 18px 22px;
+  }
+
+  @media (max-width: 767px) {
+    .projects-overview-grid {
+      grid-template-columns: 1fr;
+      gap: 16px;
+      padding: 14px 12px;
+    }
+
+    .projects-scope h1 {
+      font-size: 17px !important;
+    }
+
+    .projects-detail-header {
+      padding: 10px 12px 0 !important;
+    }
+
+    .projects-detail-stats {
+      gap: 10px !important;
+      font-size: 10px !important;
+    }
+
+    .projects-detail-completion {
+      min-width: 100% !important;
+      flex-basis: 100%;
+    }
+
+    .projects-tab-bar {
+      padding: 0 8px !important;
+    }
+
+    .projects-tab-bar button {
+      padding: 10px 10px !important;
+      font-size: 10px !important;
+    }
+
+    .projects-milestones-tab,
+    .projects-tasks-chiprow {
+      padding-left: 12px !important;
+      padding-right: 12px !important;
+    }
+
+    /* iOS zooms on input when font-size < 16px; bump textareas up */
+    .projects-scope textarea {
+      font-size: 16px !important;
+    }
+
+    /* Kbd hints are dead weight on touch */
+    .projects-tab-kbd-hint {
+      display: none !important;
+    }
+  }
 }

--- a/radbot/web/frontend/src/pages/ProjectsPage.tsx
+++ b/radbot/web/frontend/src/pages/ProjectsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import ProjectList, { type ProjectListHandle } from "@/components/projects/ProjectList";
 import ProjectDetail from "@/components/projects/ProjectDetail";
 import TaskEditDialog from "@/components/projects/TaskEditDialog";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   selectOrphans,
   selectProject,
@@ -12,6 +13,7 @@ import {
 
 export default function ProjectsPage() {
   const { refCode } = useParams<{ refCode?: string }>();
+  const isMobile = useIsMobile();
   const loadAll = useProjectsStore((s) => s.loadAll);
   const loading = useProjectsStore((s) => s.loading);
   const loaded = useProjectsStore((s) => s.loaded);
@@ -41,10 +43,13 @@ export default function ProjectsPage() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  // Default-select first active project if nothing in URL
+  // Default-select first active project if nothing in URL.
+  // On mobile we skip this so the user lands on the list view, not the
+  // detail view of a project they didn't pick.
   const effectiveProject = (() => {
     if (project) return project;
     if (refCode) return undefined;
+    if (isMobile) return undefined;
     const first = summary.find((p) => p.status === "active") ?? summary[0];
     return first ? entries[`projects:${first.ref_code}`] : undefined;
   })();
@@ -153,6 +158,47 @@ export default function ProjectsPage() {
           >
             Loading projects…
           </div>
+        ) : isMobile ? (
+          // Mobile: stacked — either the list OR the detail, never both.
+          // Selecting a project navigates to /projects/<ref>; the back link
+          // in the detail header returns to the list view.
+          effectiveProject ? (
+            <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+              <div
+                style={{
+                  padding: "8px 12px",
+                  borderBottom: "1px solid var(--border-soft)",
+                  background: "var(--bg-sunk)",
+                }}
+              >
+                <Link
+                  to="/projects"
+                  style={{
+                    fontFamily: "var(--p-mono)",
+                    fontSize: 11,
+                    color: "var(--text-dim)",
+                    textDecoration: "none",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    minHeight: 32,
+                  }}
+                  data-test="projects-mobile-back"
+                >
+                  &lt; ALL PROJECTS
+                </Link>
+              </div>
+              <div style={{ flex: 1, overflow: "hidden" }}>
+                <ProjectDetail
+                  project={effectiveProject}
+                  onRefresh={() => loadAll()}
+                  refreshing={loading}
+                />
+              </div>
+            </div>
+          ) : (
+            <ProjectList ref={listRef} />
+          )
         ) : (
           <PanelGroup direction="horizontal">
             <Panel defaultSize={25} minSize={18} maxSize={40}>


### PR DESCRIPTION
## Summary

Makes `/projects` usable on phones and surfaces a link to it in the mobile chat header (was desktop-only).

### Chat header
`PROJ` link previously had `hidden sm:flex` — invisible below 640px. Now always visible, short `P` label on mobile matching the SESS/EVT/NOTIF pattern.

### Projects page layout
- **Under 768px**: stacked — `/projects` landing shows the list full-width; tap a project to navigate to `/projects/<ref>` which shows the detail view with a `< ALL PROJECTS` back link at top.
- **Desktop**: unchanged resizable two-pane split.
- Default-select-first-project is skipped on mobile so users land on the list, not an opaque detail view of a project they didn't pick.

### Responsive polish
Scoped CSS overrides in `globals.css` under `.projects-scope`:

| Surface | Mobile change |
|---|---|
| OverviewTab | 1.5fr/1fr grid → single column |
| DetailHeader | Mini-stats row wraps, completion bar gets its own line, H1 shrinks 22px → 17px |
| TabBar | Shrunk padding + font size, overflow-x-auto; `TAB 1-5` kbd hint hidden (dead weight on touch) |
| MilestonesTab + TasksTab chip row | Padding 22px → 12px |
| Textareas | Bumped to ≥16px to stop iOS zoom-on-focus |

### TaskEditDialog touch ergonomics
- Backdrop padding uses `clamp(8px, 2vw, 24px)`
- Close button, status pills, Save/Cancel ≥ 44px tap targets (WCAG touch minimum)

## Test plan
- [ ] DevTools mobile emulation 375px: chat header shows `P` button; tap opens `/projects`
- [ ] `/projects` renders list full-width; tap a row navigates to detail
- [ ] Detail view has `< ALL PROJECTS` back link; tapping returns to list
- [ ] OverviewTab stacks to one column; DetailHeader stats/completion wrap
- [ ] TabBar scrolls horizontally when overflowed; keyboard hint gone
- [ ] TaskEditDialog: tapping a task opens modal sized for phone; textarea doesn't zoom on iOS focus; buttons are finger-friendly

🤖 Generated with [Claude Code](https://claude.com/claude-code)