### PR TITLE
feat(admin): redesign — scoped palette, shell primitives, categorized sidebar

### DIFF
--- a/radbot/web/frontend/index.html
+++ b/radbot/web/frontend/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>RadBot</title>
     <link
-      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300;400;500;600;700&family=Press+Start+2P&family=Inter:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&family=VT323&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300;400;500;600;700&family=Press+Start+2P&family=Inter:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=VT323&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/radbot/web/frontend/src/components/admin/FormFields.tsx
+++ b/radbot/web/frontend/src/components/admin/FormFields.tsx
@@ -1,8 +1,24 @@
-/** Reusable admin form controls matching the legacy FormBuilder (FB). */
+/**
+ * Reusable admin form controls.
+ *
+ * These are thin wrappers around the shell primitives in
+ * `components/admin/shell/primitives.tsx`. Every existing panel imports from
+ * this module, so restyling here re-skins every panel automatically without
+ * touching panel code.
+ */
+import type { ReactNode } from "react";
+import {
+  Button,
+  Field,
+  SectionCard,
+  Select,
+  StatusPill,
+  TextArea,
+  TextInput,
+  Toggle,
+  type PanelStatus,
+} from "@/components/admin/shell";
 import { cn } from "@/lib/utils";
-
-const fieldBase =
-  "w-full p-2 border border-border rounded-md bg-bg-primary text-txt-primary text-sm outline-none focus:border-radbot-sunset transition-colors";
 
 // ── Text / Password / Number ─────────────────────────────
 interface InputProps {
@@ -18,27 +34,36 @@ interface InputProps {
 }
 
 export function FormInput({
-  label, value, onChange, type = "text", placeholder, hint, readOnly, datalist, className,
+  label,
+  value,
+  onChange,
+  type = "text",
+  placeholder,
+  hint,
+  readOnly,
+  datalist,
+  className,
 }: InputProps) {
   const listId = datalist ? `dl-${label.replace(/\s/g, "-").toLowerCase()}` : undefined;
   return (
-    <div className={cn("mb-3", className)}>
-      <label className="block text-xs text-txt-secondary mb-1 font-medium">{label}</label>
-      <input
-        type={type}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        readOnly={readOnly}
-        list={listId}
-        className={cn(fieldBase, readOnly && "opacity-60 cursor-not-allowed")}
-      />
-      {datalist && (
-        <datalist id={listId}>
-          {datalist.map((v) => <option key={v} value={v} />)}
-        </datalist>
-      )}
-      {hint && <div className="text-[0.72rem] text-txt-secondary/60 mt-0.5">{hint}</div>}
+    <div className={cn("mb-3", className)} style={{ display: "flex", flexDirection: "column" }}>
+      <Field label={label} hint={hint}>
+        <TextInput
+          value={String(value ?? "")}
+          onChange={onChange}
+          type={type}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          list={listId}
+        />
+        {datalist && (
+          <datalist id={listId}>
+            {datalist.map((v) => (
+              <option key={v} value={v} />
+            ))}
+          </datalist>
+        )}
+      </Field>
     </div>
   );
 }
@@ -52,23 +77,16 @@ interface ToggleProps {
 
 export function FormToggle({ label, checked, onChange }: ToggleProps) {
   return (
-    <div className="flex items-center gap-2.5 mb-3">
-      <button
-        type="button"
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+      <Toggle value={checked} onChange={onChange} />
+      <span
+        style={{
+          fontSize: 13,
+          color: "var(--text)",
+          cursor: "pointer",
+        }}
         onClick={() => onChange(!checked)}
-        className={cn(
-          "relative w-[38px] h-5 rounded-[10px] transition-colors flex-shrink-0 cursor-pointer border-none p-0",
-          checked ? "bg-terminal-green" : "bg-radbot-sunset",
-        )}
       >
-        <span
-          className={cn(
-            "absolute left-0 w-3.5 h-3.5 rounded-full transition-transform top-[3px]",
-            checked ? "translate-x-[21px] bg-white" : "translate-x-[3px] bg-txt-secondary",
-          )}
-        />
-      </button>
-      <span className="text-sm text-txt-secondary cursor-pointer" onClick={() => onChange(!checked)}>
         {label}
       </span>
     </div>
@@ -87,12 +105,9 @@ interface DropdownProps {
 export function FormDropdown({ label, value, onChange, options, className }: DropdownProps) {
   return (
     <div className={cn("mb-3", className)}>
-      <label className="block text-xs text-txt-secondary mb-1 font-medium">{label}</label>
-      <select value={value} onChange={(e) => onChange(e.target.value)} className={cn(fieldBase, "cursor-pointer")}>
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>{o.label}</option>
-        ))}
-      </select>
+      <Field label={label}>
+        <Select value={value} onChange={onChange} options={options} />
+      </Field>
     </div>
   );
 }
@@ -108,14 +123,16 @@ interface TextareaProps {
 
 export function FormTextarea({ label, value, onChange, placeholder, large }: TextareaProps) {
   return (
-    <div className="mb-3">
-      <label className="block text-xs text-txt-secondary mb-1 font-medium">{label}</label>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        className={cn(fieldBase, "resize-y font-mono text-[0.8rem]", large ? "min-h-[200px]" : "min-h-[80px]")}
-      />
+    <div style={{ marginBottom: 12 }}>
+      <Field label={label}>
+        <TextArea
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          rows={large ? 12 : 4}
+          mono
+        />
+      </Field>
     </div>
   );
 }
@@ -132,47 +149,76 @@ interface SliderProps {
 
 export function FormSlider({ label, value, onChange, min, max, step }: SliderProps) {
   return (
-    <div className="mb-3">
-      <label className="block text-xs text-txt-secondary mb-1 font-medium">{label}</label>
-      <div className="flex items-center gap-3">
-        <input
-          type="range"
-          value={value}
-          onChange={(e) => onChange(parseFloat(e.target.value))}
-          min={min}
-          max={max}
-          step={step}
-          className="flex-1 accent-radbot-sunset"
-        />
-        <span className="min-w-[3em] text-right text-sm text-txt-secondary font-mono">{value}</span>
-      </div>
+    <div style={{ marginBottom: 12 }}>
+      <Field label={label}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <input
+            type="range"
+            value={value}
+            onChange={(e) => onChange(parseFloat(e.target.value))}
+            min={min}
+            max={max}
+            step={step}
+            style={{ flex: 1, accentColor: "var(--sunset)" }}
+          />
+          <span
+            style={{
+              minWidth: "3em",
+              textAlign: "right",
+              fontSize: 12,
+              fontFamily: "var(--mono)",
+              color: "var(--text-mute)",
+            }}
+          >
+            {value}
+          </span>
+        </div>
+      </Field>
     </div>
   );
 }
 
 // ── Form Row (grid) ──────────────────────────────────────
-export function FormRow({ children, cols = 2 }: { children: React.ReactNode; cols?: 2 | 3 }) {
+export function FormRow({ children, cols = 2 }: { children: ReactNode; cols?: 2 | 3 }) {
   return (
-    <div className={cn("grid gap-3", cols === 3 ? "grid-cols-3" : "grid-cols-2")}>
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+        gap: 12,
+      }}
+    >
       {children}
     </div>
   );
 }
 
 // ── Card ─────────────────────────────────────────────────
-export function Card({ title, children }: { title?: string; children: React.ReactNode }) {
+export function Card({ title, children }: { title?: string; children: ReactNode }) {
   return (
-    <div className="bg-bg-secondary border border-border rounded-lg p-4 mb-4">
-      {title && <h3 className="text-sm mb-3 text-radbot-sunset">{title}</h3>}
-      {children}
+    <div style={{ marginBottom: 16 }}>
+      <SectionCard title={title} accent="var(--sunset)">
+        {children}
+      </SectionCard>
     </div>
   );
 }
 
 // ── Note ─────────────────────────────────────────────────
-export function Note({ children }: { children: React.ReactNode }) {
+export function Note({ children }: { children: ReactNode }) {
   return (
-    <div className="bg-bg-tertiary border border-border rounded-md px-3 py-2.5 text-[0.8rem] text-txt-secondary mb-4">
+    <div
+      style={{
+        padding: "10px 12px",
+        borderRadius: 6,
+        background: "color-mix(in oklch, var(--sky) 6%, var(--surface))",
+        border: "1px solid color-mix(in oklch, var(--sky) 22%, var(--border))",
+        color: "var(--text-mute)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        marginBottom: 14,
+      }}
+    >
       {children}
     </div>
   );
@@ -189,30 +235,36 @@ interface ActionBarProps {
 
 export function ActionBar({ onSave, onTest, testResult, testing, saving }: ActionBarProps) {
   return (
-    <div className="flex items-center gap-2.5 mt-5 pt-3.5 border-t border-border">
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        marginTop: 18,
+        paddingTop: 14,
+        borderTop: "1px solid var(--border-soft)",
+      }}
+    >
       {onTest && (
-        <button
-          onClick={onTest}
-          disabled={testing}
-          className="px-3 py-2 bg-bg-tertiary text-txt-primary border border-border rounded-md text-sm font-medium hover:border-radbot-sunset transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {testing ? "Testing..." : "Test Connection"}
-        </button>
+        <Button onClick={onTest} disabled={testing} variant="default">
+          {testing ? "Testing…" : "Test Connection"}
+        </Button>
       )}
       {testResult && (
-        <span className={cn("text-sm", testResult.status === "ok" ? "text-terminal-green" : "text-terminal-red")}>
+        <span
+          style={{
+            fontSize: 12,
+            color: testResult.status === "ok" ? "var(--crt)" : "var(--magenta)",
+          }}
+        >
           {testResult.message}
         </span>
       )}
-      <span className="flex-1" />
+      <span style={{ flex: 1 }} />
       {onSave && (
-        <button
-          onClick={onSave}
-          disabled={saving}
-          className="px-4 py-2 bg-radbot-sunset text-bg-primary rounded-md text-sm font-medium hover:bg-radbot-sunset/80 transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {saving ? "Saving..." : "Save"}
-        </button>
+        <Button onClick={onSave} disabled={saving} variant="primary" icon="check">
+          {saving ? "Saving…" : "Save"}
+        </Button>
       )}
     </div>
   );
@@ -220,19 +272,11 @@ export function ActionBar({ onSave, onTest, testResult, testing, saving }: Actio
 
 // ── Badge ────────────────────────────────────────────────
 export function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    ok: "bg-terminal-green/15 text-terminal-green",
-    error: "bg-terminal-red/15 text-terminal-red",
-    unconfigured: "bg-bg-tertiary text-txt-secondary/60",
+  const map: Record<string, PanelStatus> = {
+    ok: "connected",
+    error: "error",
+    unconfigured: "disconnected",
   };
-  const labels: Record<string, string> = {
-    ok: "Connected",
-    error: "Error",
-    unconfigured: "Not Configured",
-  };
-  return (
-    <span className={cn("text-xs px-2.5 py-0.5 rounded-full font-semibold", styles[status] || styles.unconfigured)}>
-      {labels[status] || status}
-    </span>
-  );
+  const panelStatus: PanelStatus = map[status] ?? "neutral";
+  return <StatusPill status={panelStatus} />;
 }

--- a/radbot/web/frontend/src/components/admin/shell/PanelHeader.tsx
+++ b/radbot/web/frontend/src/components/admin/shell/PanelHeader.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+import { AIcon } from "./icons";
+import { StatusPill, type PanelStatus } from "./primitives";
+import type { CatalogPanel, CatalogCategory } from "./catalog";
+
+interface PanelHeaderProps {
+  panel: CatalogPanel;
+  category: CatalogCategory;
+  status: PanelStatus;
+  actions?: ReactNode;
+}
+
+export function PanelHeader({ panel, category, status, actions }: PanelHeaderProps) {
+  return (
+    <div
+      style={{
+        padding: "18px 26px 14px",
+        borderBottom: "1px solid var(--border)",
+        background: "linear-gradient(180deg, var(--surface-2), var(--surface))",
+        flex: "none",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: "0.18em",
+          color: "var(--text-dim)",
+          marginBottom: 4,
+        }}
+      >
+        ADMIN · {category.label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            flex: "none",
+            borderRadius: 7,
+            background: "color-mix(in oklch, var(--sunset) 16%, var(--surface))",
+            border: "1px solid color-mix(in oklch, var(--sunset) 38%, transparent)",
+            color: "var(--sunset)",
+            display: "grid",
+            placeItems: "center",
+          }}
+        >
+          <AIcon name={panel.icon} size={16} />
+        </div>
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: "var(--sans)",
+            fontSize: 22,
+            fontWeight: 700,
+            color: "var(--text)",
+            lineHeight: 1.15,
+          }}
+        >
+          {panel.label}
+        </h1>
+        <StatusPill status={status} />
+        <span style={{ flex: 1 }} />
+        {actions}
+      </div>
+    </div>
+  );
+}

--- a/radbot/web/frontend/src/components/admin/shell/Sidebar.tsx
+++ b/radbot/web/frontend/src/components/admin/shell/Sidebar.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from "react";
+import { AIcon } from "./icons";
+import { StatusDot } from "./primitives";
+import { PANEL_CATEGORIES, mapStatus, totalPanelCount } from "./catalog";
+import type { IntegrationStatus } from "@/lib/admin-api";
+
+interface SidebarProps {
+  active: string;
+  setActive: (id: string) => void;
+  status: IntegrationStatus;
+}
+
+export function AdminSidebar({ active, setActive, status }: SidebarProps) {
+  const [q, setQ] = useState("");
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const qLower = q.trim().toLowerCase();
+
+  const groups = useMemo(
+    () =>
+      PANEL_CATEGORIES.map((cat) => {
+        const panels = qLower
+          ? cat.panels.filter((p) => (p.label + " " + p.id).toLowerCase().includes(qLower))
+          : cat.panels;
+        return { ...cat, panels };
+      }).filter((cat) => !qLower || cat.panels.length > 0),
+    [qLower],
+  );
+
+  return (
+    <aside
+      data-test="admin-sidebar"
+      style={{
+        width: 230,
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--bg-sunk)",
+        borderRight: "1px solid var(--border)",
+        flex: "none",
+      }}
+    >
+      {/* Search */}
+      <div style={{ padding: "10px 12px", borderBottom: "1px solid var(--border-soft)" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "6px 9px",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 5,
+          }}
+        >
+          <span style={{ color: "var(--text-dim)" }}>
+            <AIcon name="search" size={12} />
+          </span>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="filter panels…"
+            style={{
+              flex: 1,
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+              color: "var(--text)",
+              background: "transparent",
+              border: "none",
+              outline: "none",
+              minWidth: 0,
+            }}
+          />
+        </div>
+      </div>
+
+      <nav style={{ flex: 1, overflowY: "auto", padding: "6px 0" }}>
+        {groups.map((cat) => {
+          const isCollapsed = !!collapsed[cat.key] && !qLower;
+          return (
+            <div
+              key={cat.key}
+              data-test={`admin-group-${cat.key}`}
+            >
+              <button
+                type="button"
+                onClick={() =>
+                  setCollapsed((c) => ({ ...c, [cat.key]: !c[cat.key] }))
+                }
+                style={{
+                  width: "100%",
+                  padding: "8px 14px 4px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "inherit",
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--text-dim)",
+                    transition: "transform 120ms",
+                    transform: `rotate(${isCollapsed ? 0 : 90}deg)`,
+                    display: "inline-flex",
+                  }}
+                >
+                  <AIcon name="chev" size={9} />
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: "0.18em",
+                    color: "var(--text-dim)",
+                  }}
+                >
+                  {cat.label}
+                </span>
+                <span style={{ flex: 1 }} />
+                <span style={{ fontFamily: "var(--mono)", fontSize: 9, color: "var(--text-dim)" }}>
+                  {cat.panels.length}
+                </span>
+              </button>
+              {!isCollapsed &&
+                cat.panels.map((p) => {
+                  const isActive = p.id === active;
+                  const dotStatus = mapStatus(p.statusKey ? status[p.statusKey] : undefined);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => setActive(p.id)}
+                      data-test={`admin-nav-${p.id}`}
+                      data-status={dotStatus}
+                      style={{
+                        width: "100%",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        padding: "6px 14px 6px 22px",
+                        textAlign: "left",
+                        color: isActive ? "var(--text)" : "var(--text-mute)",
+                        background: isActive
+                          ? "linear-gradient(90deg, color-mix(in oklch, var(--sunset) 14%, transparent), transparent 70%)"
+                          : "transparent",
+                        borderLeft: isActive
+                          ? "2px solid var(--sunset)"
+                          : "2px solid transparent",
+                        borderTop: "none",
+                        borderRight: "none",
+                        borderBottom: "none",
+                        marginLeft: -1,
+                        cursor: "pointer",
+                      }}
+                    >
+                      <StatusDot status={dotStatus} size={6} />
+                      <span
+                        style={{
+                          fontFamily: "var(--sans)",
+                          fontSize: 12,
+                          fontWeight: isActive ? 600 : 500,
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          flex: 1,
+                          minWidth: 0,
+                        }}
+                      >
+                        {p.label}
+                      </span>
+                    </button>
+                  );
+                })}
+            </div>
+          );
+        })}
+      </nav>
+
+      <div
+        style={{
+          padding: "8px 14px",
+          borderTop: "1px solid var(--border-soft)",
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          color: "var(--text-dim)",
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: "var(--crt)",
+            boxShadow: "0 0 6px var(--crt)",
+          }}
+        />
+        <span>{totalPanelCount()} panels</span>
+      </div>
+    </aside>
+  );
+}

--- a/radbot/web/frontend/src/components/admin/shell/catalog.ts
+++ b/radbot/web/frontend/src/components/admin/shell/catalog.ts
@@ -1,0 +1,130 @@
+import type { AIconName } from "./icons";
+import type { PanelStatus } from "./primitives";
+
+export interface CatalogPanel {
+  id: string;
+  label: string;
+  icon: AIconName;
+  statusKey?: string;
+}
+
+export interface CatalogCategory {
+  key: string;
+  label: string;
+  panels: CatalogPanel[];
+}
+
+// Panel ids match the existing PANEL_MAP keys in AdminPage so the admin-store
+// activePanel value survives the redesign. Icons + categories come from the
+// handoff design.
+export const PANEL_CATEGORIES: CatalogCategory[] = [
+  {
+    key: "core",
+    label: "CORE",
+    panels: [
+      { id: "google", label: "Google AI", icon: "sparkle", statusKey: "google" },
+      { id: "agent_models", label: "Agent & Models", icon: "cpu" },
+      { id: "web_server", label: "Web Server", icon: "server" },
+      { id: "logging", label: "Logging", icon: "list" },
+      { id: "cost_tracking", label: "Cost Tracking", icon: "chart" },
+    ],
+  },
+  {
+    key: "personal",
+    label: "PERSONAL",
+    panels: [{ id: "telos", label: "Telos", icon: "compass" }],
+  },
+  {
+    key: "connections",
+    label: "CONNECTIONS",
+    panels: [
+      { id: "gmail", label: "Gmail", icon: "mail", statusKey: "gmail" },
+      { id: "calendar", label: "Calendar", icon: "calendar", statusKey: "calendar" },
+      { id: "jira", label: "Jira", icon: "jira", statusKey: "jira" },
+      { id: "overseerr", label: "Overseerr", icon: "play", statusKey: "overseerr" },
+      { id: "lidarr", label: "Lidarr", icon: "music", statusKey: "lidarr" },
+      { id: "home_assistant", label: "Home Assistant", icon: "home", statusKey: "home_assistant" },
+      { id: "picnic", label: "Picnic", icon: "cart", statusKey: "picnic" },
+      { id: "youtube", label: "YouTube", icon: "video", statusKey: "youtube" },
+      { id: "kideo", label: "Kideo", icon: "clap", statusKey: "kideo" },
+      { id: "filesystem", label: "Filesystem", icon: "folder" },
+    ],
+  },
+  {
+    key: "infra",
+    label: "INFRASTRUCTURE",
+    panels: [
+      { id: "postgresql", label: "PostgreSQL", icon: "db", statusKey: "postgresql" },
+      { id: "qdrant", label: "Qdrant", icon: "vec", statusKey: "qdrant" },
+      { id: "nomad", label: "Nomad", icon: "nomad", statusKey: "nomad" },
+    ],
+  },
+  {
+    key: "media",
+    label: "MEDIA & VOICE",
+    panels: [
+      { id: "tts", label: "Text-to-Speech", icon: "speaker", statusKey: "tts" },
+      { id: "stt", label: "Speech-to-Text", icon: "mic", statusKey: "stt" },
+    ],
+  },
+  {
+    key: "notifs",
+    label: "NOTIFICATIONS",
+    panels: [{ id: "ntfy", label: "Push Notifications", icon: "bell", statusKey: "ntfy" }],
+  },
+  {
+    key: "automation",
+    label: "AUTOMATION",
+    panels: [
+      { id: "scheduler", label: "Scheduler", icon: "clock" },
+      { id: "webhooks", label: "Webhooks", icon: "link" },
+      { id: "alertmanager", label: "Alertmanager", icon: "alert", statusKey: "alertmanager" },
+    ],
+  },
+  {
+    key: "developer",
+    label: "DEVELOPER",
+    panels: [
+      { id: "github_app", label: "GitHub App", icon: "git", statusKey: "github" },
+      { id: "claude_code", label: "Claude Code", icon: "anchor", statusKey: "claude_code" },
+    ],
+  },
+  {
+    key: "security",
+    label: "SECURITY",
+    panels: [{ id: "sanitization", label: "Sanitization", icon: "shield" }],
+  },
+  {
+    key: "advanced",
+    label: "ADVANCED",
+    panels: [
+      { id: "mcp_bridge", label: "MCP Bridge", icon: "bridge" },
+      { id: "mcp_servers", label: "MCP Servers", icon: "stack" },
+      { id: "credentials", label: "Credentials", icon: "key" },
+      { id: "raw_config", label: "Raw Config", icon: "code" },
+    ],
+  },
+];
+
+export function findPanel(id: string): { panel: CatalogPanel; category: CatalogCategory } | null {
+  for (const cat of PANEL_CATEGORIES) {
+    const panel = cat.panels.find((p) => p.id === id);
+    if (panel) return { panel, category: cat };
+  }
+  return null;
+}
+
+export function totalPanelCount(): number {
+  return PANEL_CATEGORIES.reduce((n, c) => n + c.panels.length, 0);
+}
+
+// Map raw admin-store IntegrationStatus (ok / error / unconfigured) to the
+// design system's PanelStatus enum. Panels without a statusKey fall back to
+// "neutral".
+export function mapStatus(raw?: { status?: string } | undefined): PanelStatus {
+  const s = raw?.status;
+  if (s === "ok") return "connected";
+  if (s === "error") return "error";
+  if (s === "unconfigured") return "disconnected";
+  return "neutral";
+}

--- a/radbot/web/frontend/src/components/admin/shell/icons.tsx
+++ b/radbot/web/frontend/src/components/admin/shell/icons.tsx
@@ -1,0 +1,266 @@
+import type { ReactNode } from "react";
+
+export type AIconName =
+  | "sparkle" | "cpu" | "server" | "list" | "chart" | "compass"
+  | "mail" | "calendar" | "jira" | "play" | "music" | "home"
+  | "cart" | "video" | "clap" | "folder" | "db" | "vec" | "nomad"
+  | "speaker" | "mic" | "bell" | "clock" | "link" | "alert"
+  | "git" | "anchor" | "shield" | "bridge" | "stack" | "key"
+  | "code" | "search" | "chev" | "chev-d" | "plus" | "close"
+  | "check" | "copy" | "ext" | "refresh" | "play-t" | "pause"
+  | "edit" | "trash" | "eye";
+
+interface AIconProps {
+  name: AIconName;
+  size?: number;
+}
+
+// 16x16 viewBox, consistent stroke. Ported from admin-shell.jsx handoff.
+export function AIcon({ name, size = 14 }: AIconProps) {
+  const p = {
+    stroke: "currentColor",
+    strokeWidth: 1.4,
+    fill: "none",
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+  const svg = (paths: ReactNode) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" aria-hidden>
+      {paths}
+    </svg>
+  );
+  switch (name) {
+    case "sparkle":
+      return svg(<path {...p} d="M8 2v4M8 10v4M2 8h4M10 8h4M4 4l2 2M10 10l2 2M12 4l-2 2M4 12l2-2" />);
+    case "cpu":
+      return svg(
+        <>
+          <rect {...p} x="3.5" y="3.5" width="9" height="9" rx="1" />
+          <rect {...p} x="6" y="6" width="4" height="4" />
+          <path {...p} d="M6 1.5V3.5M10 1.5V3.5M6 12.5V14.5M10 12.5V14.5M1.5 6H3.5M1.5 10H3.5M12.5 6H14.5M12.5 10H14.5" />
+        </>,
+      );
+    case "server":
+      return svg(
+        <>
+          <rect {...p} x="2.5" y="3" width="11" height="4" rx="0.5" />
+          <rect {...p} x="2.5" y="9" width="11" height="4" rx="0.5" />
+          <circle cx="4.5" cy="5" r="0.7" fill="currentColor" />
+          <circle cx="4.5" cy="11" r="0.7" fill="currentColor" />
+        </>,
+      );
+    case "list":
+      return svg(
+        <>
+          <path {...p} d="M4 4h9M4 8h9M4 12h9" />
+          <circle cx="2.5" cy="4" r="0.5" fill="currentColor" />
+          <circle cx="2.5" cy="8" r="0.5" fill="currentColor" />
+          <circle cx="2.5" cy="12" r="0.5" fill="currentColor" />
+        </>,
+      );
+    case "chart":
+      return svg(<path {...p} d="M2.5 13.5h11M4 12V8M7 12V4M10 12V9M13 12V6" />);
+    case "compass":
+      return svg(
+        <>
+          <circle {...p} cx="8" cy="8" r="5.5" />
+          <path {...p} d="M6 10l1.5-3.5L10 6l-1.5 3.5z" fill="currentColor" />
+        </>,
+      );
+    case "mail":
+      return svg(
+        <>
+          <rect {...p} x="2" y="3.5" width="12" height="9" rx="1" />
+          <path {...p} d="M2.5 4.5l5.5 4 5.5-4" />
+        </>,
+      );
+    case "calendar":
+      return svg(
+        <>
+          <rect {...p} x="2.5" y="3.5" width="11" height="10" rx="1" />
+          <path {...p} d="M2.5 6.5h11M5 2v3M11 2v3" />
+        </>,
+      );
+    case "jira":
+      return svg(<path {...p} d="M4 4h3l5 5v3L7 7H4zM4 7v3h3" />);
+    case "play":
+      return svg(
+        <>
+          <circle {...p} cx="8" cy="8" r="5.5" />
+          <path d="M6.8 5.8v4.4L10.4 8z" fill="currentColor" />
+        </>,
+      );
+    case "music":
+      return svg(
+        <>
+          <path {...p} d="M6 11V3.5l6-1.5v8" />
+          <circle {...p} cx="5" cy="11" r="1.5" />
+          <circle {...p} cx="11" cy="10" r="1.5" />
+        </>,
+      );
+    case "home":
+      return svg(<path {...p} d="M2.5 8L8 3l5.5 5M4 7.5V13h8V7.5" />);
+    case "cart":
+      return svg(
+        <>
+          <path {...p} d="M2 3h2l1.5 7.5h7L14 5.5H5" />
+          <circle {...p} cx="6.5" cy="13" r="0.8" />
+          <circle {...p} cx="11.5" cy="13" r="0.8" />
+        </>,
+      );
+    case "video":
+      return svg(
+        <>
+          <rect {...p} x="2" y="4.5" width="8" height="7" rx="1" />
+          <path {...p} d="M10 7.5L14 5.5v5l-4-2z" />
+        </>,
+      );
+    case "clap":
+      return svg(
+        <>
+          <rect {...p} x="2" y="6.5" width="12" height="7" rx="0.8" />
+          <path {...p} d="M2.4 6.5l1.5-2.5 2 1.5-1 2M5.4 6.5l1.2-2.5 2 1.5-1 2M8.6 6.5l1.2-2.5 2 1.5-1 2" />
+        </>,
+      );
+    case "folder":
+      return svg(
+        <path
+          {...p}
+          d="M2 4.5A1.5 1.5 0 013.5 3h3l1.5 1.5h5A1.5 1.5 0 0114.5 6v6A1.5 1.5 0 0113 13.5H3A1.5 1.5 0 011.5 12V4.5z"
+        />,
+      );
+    case "db":
+      return svg(
+        <>
+          <ellipse {...p} cx="8" cy="4" rx="5" ry="1.8" />
+          <path {...p} d="M3 4v8c0 1 2.2 1.8 5 1.8s5-.8 5-1.8V4M3 8c0 1 2.2 1.8 5 1.8s5-.8 5-1.8" />
+        </>,
+      );
+    case "vec":
+      return svg(<path {...p} d="M8 3v10M8 3l-3 3M8 3l3 3M8 13l-3-3M8 13l3-3M3 8h10" />);
+    case "nomad":
+      return svg(<path {...p} d="M8 2l5 3v6l-5 3-5-3V5l5-3zM8 2v5M8 13V8M3 5l5 3M13 5l-5 3" />);
+    case "speaker":
+      return svg(
+        <path
+          {...p}
+          d="M3 6v4h2l3 2.5v-9L5 6H3M10 5.5a3.5 3.5 0 010 5M12 3.5a6 6 0 010 9"
+        />,
+      );
+    case "mic":
+      return svg(
+        <>
+          <rect {...p} x="6" y="2" width="4" height="7" rx="2" />
+          <path {...p} d="M3.5 8a4.5 4.5 0 009 0M8 12.5V14" />
+        </>,
+      );
+    case "bell":
+      return svg(<path {...p} d="M4 11h8l-1-1.5V7a3 3 0 00-6 0v2.5L4 11zM6.5 12.5a1.5 1.5 0 003 0" />);
+    case "clock":
+      return svg(
+        <>
+          <circle {...p} cx="8" cy="8" r="5.5" />
+          <path {...p} d="M8 5v3l2 1.5" />
+        </>,
+      );
+    case "link":
+      return svg(
+        <path
+          {...p}
+          d="M7 10a3 3 0 004 0l2-2a3 3 0 10-4-4l-1 1M9 6a3 3 0 00-4 0L3 8a3 3 0 104 4l1-1"
+        />,
+      );
+    case "alert":
+      return svg(
+        <>
+          <path {...p} d="M8 2l6.5 11.5h-13z" />
+          <path {...p} d="M8 6v3M8 11v0.5" />
+        </>,
+      );
+    case "git":
+      return svg(
+        <>
+          <circle {...p} cx="4" cy="4" r="1.5" />
+          <circle {...p} cx="4" cy="12" r="1.5" />
+          <circle {...p} cx="12" cy="8" r="1.5" />
+          <path {...p} d="M4 5.5v5M10.5 8H8a3 3 0 01-3-3" />
+        </>,
+      );
+    case "anchor":
+      return svg(
+        <>
+          <circle {...p} cx="8" cy="3.5" r="1.2" />
+          <path {...p} d="M8 4.7V13M5 8h6M4 10.5a4 4 0 004 3 4 4 0 004-3" />
+        </>,
+      );
+    case "shield":
+      return svg(
+        <path {...p} d="M8 2l5 2v4.5c0 3-2.5 4.7-5 5.5-2.5-.8-5-2.5-5-5.5V4l5-2z" />,
+      );
+    case "bridge":
+      return svg(<path {...p} d="M2.5 6.5h11M3 6.5v5M13 6.5v5M5.5 6.5L3 10M10.5 6.5L13 10M8 6.5v5" />);
+    case "stack":
+      return svg(<path {...p} d="M8 2.5l5.5 2.5L8 7.5 2.5 5 8 2.5zM2.5 8L8 10.5 13.5 8M2.5 11L8 13.5 13.5 11" />);
+    case "key":
+      return svg(
+        <>
+          <circle {...p} cx="5" cy="8" r="2.5" />
+          <path {...p} d="M7.5 8h6l-1 1.5M11 8v2" />
+        </>,
+      );
+    case "code":
+      return svg(<path {...p} d="M5 4L2 8l3 4M11 4l3 4-3 4M9.5 3.5l-3 9" />);
+    case "search":
+      return svg(
+        <>
+          <circle {...p} cx="7" cy="7" r="4.5" />
+          <path {...p} d="M10.5 10.5l3 3" />
+        </>,
+      );
+    case "chev":
+      return svg(<path {...p} d="M6 4l4 4-4 4" />);
+    case "chev-d":
+      return svg(<path {...p} d="M4 6l4 4 4-4" />);
+    case "plus":
+      return svg(<path {...p} d="M8 3v10M3 8h10" />);
+    case "close":
+      return svg(<path {...p} strokeWidth={1.6} d="M4 4l8 8M12 4l-8 8" />);
+    case "check":
+      return svg(<path {...p} strokeWidth={1.8} d="M3 8.5l3 3 7-7" />);
+    case "copy":
+      return svg(
+        <>
+          <rect {...p} x="5" y="5" width="8.5" height="8.5" rx="1" />
+          <path {...p} d="M10 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v6a1 1 0 001 1h2" />
+        </>,
+      );
+    case "ext":
+      return svg(<path {...p} d="M7 3H3v10h10V9M9 3h4v4M13 3l-6 6" />);
+    case "refresh":
+      return svg(
+        <path {...p} d="M13 3v4h-4M3 13v-4h4M13 7A5 5 0 003.5 6M3 9a5 5 0 009.5 1" />,
+      );
+    case "play-t":
+      return svg(<path d="M4 3v10l9-5z" fill="currentColor" />);
+    case "pause":
+      return svg(
+        <>
+          <rect x="4" y="3" width="3" height="10" fill="currentColor" />
+          <rect x="9" y="3" width="3" height="10" fill="currentColor" />
+        </>,
+      );
+    case "edit":
+      return svg(<path {...p} d="M11 3l2 2-7 7H4v-2l7-7zM9.5 4.5l2 2" />);
+    case "trash":
+      return svg(<path {...p} d="M3 5h10M6 5V3h4v2M4.5 5l1 8h5l1-8" />);
+    case "eye":
+      return svg(
+        <>
+          <path {...p} d="M1.5 8s2.5-5 6.5-5 6.5 5 6.5 5-2.5 5-6.5 5-6.5-5-6.5-5z" />
+          <circle {...p} cx="8" cy="8" r="2" />
+        </>,
+      );
+    default:
+      return svg(<circle {...p} cx="8" cy="8" r="4" />);
+  }
+}

--- a/radbot/web/frontend/src/components/admin/shell/index.ts
+++ b/radbot/web/frontend/src/components/admin/shell/index.ts
@@ -1,0 +1,5 @@
+export * from "./icons";
+export * from "./primitives";
+export * from "./catalog";
+export { AdminSidebar } from "./Sidebar";
+export { PanelHeader } from "./PanelHeader";

--- a/radbot/web/frontend/src/components/admin/shell/primitives.tsx
+++ b/radbot/web/frontend/src/components/admin/shell/primitives.tsx
@@ -1,0 +1,524 @@
+import type { CSSProperties, ReactNode } from "react";
+import { AIcon, type AIconName } from "./icons";
+
+export type PanelStatus = "connected" | "configured" | "disconnected" | "error" | "neutral";
+
+export function StatusDot({ status, size = 7 }: { status: PanelStatus; size?: number }) {
+  const colors: Record<PanelStatus, string> = {
+    connected: "var(--crt)",
+    configured: "var(--crt)",
+    disconnected: "var(--text-dim)",
+    error: "var(--magenta)",
+    neutral: "var(--text-dim)",
+  };
+  const c = colors[status] ?? colors.neutral;
+  return (
+    <span
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: c,
+        boxShadow: status === "connected" || status === "configured" ? `0 0 6px ${c}` : "none",
+        flex: "none",
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+export function StatusPill({ status, label }: { status: PanelStatus; label?: string }) {
+  const cfg: Record<PanelStatus, { c: string; label: string }> = {
+    connected: { c: "var(--crt)", label: label || "CONNECTED" },
+    configured: { c: "var(--crt)", label: label || "CONFIGURED" },
+    disconnected: { c: "var(--text-dim)", label: label || "DISCONNECTED" },
+    error: { c: "var(--magenta)", label: label || "ERROR" },
+    neutral: { c: "var(--text-dim)", label: label || "—" },
+  };
+  const s = cfg[status] ?? cfg.neutral;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        padding: "2px 7px",
+        borderRadius: 3,
+        fontFamily: "var(--mono)",
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: "0.12em",
+        color: s.c,
+        background: `color-mix(in oklch, ${s.c} 12%, transparent)`,
+        border: `1px solid color-mix(in oklch, ${s.c} 30%, transparent)`,
+      }}
+    >
+      <StatusDot status={status} size={5} />
+      {s.label}
+    </span>
+  );
+}
+
+interface SectionCardProps {
+  title?: string;
+  accent?: string;
+  right?: ReactNode;
+  children: ReactNode;
+  padding?: string;
+  noHeader?: boolean;
+  className?: string;
+}
+
+export function SectionCard({
+  title,
+  accent = "var(--sunset)",
+  right,
+  children,
+  padding = "16px 18px",
+  noHeader,
+  className,
+}: SectionCardProps) {
+  return (
+    <div
+      className={className}
+      style={{
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        overflow: "hidden",
+      }}
+    >
+      {!noHeader && title && (
+        <div
+          style={{
+            padding: "11px 18px",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            borderBottom: "1px solid var(--border-soft)",
+            background: `color-mix(in oklch, ${accent} 4%, var(--surface-2))`,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.14em",
+              color: accent,
+              textTransform: "uppercase",
+            }}
+          >
+            {title}
+          </span>
+          <span style={{ flex: 1 }} />
+          {right}
+        </div>
+      )}
+      <div style={{ padding }}>{children}</div>
+    </div>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  hint?: ReactNode;
+  children: ReactNode;
+  span?: number;
+}
+
+export function Field({ label, hint, children, span = 1 }: FieldProps) {
+  return (
+    <label
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        gridColumn: `span ${span}`,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          color: "var(--text-mute)",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </span>
+      {children}
+      {hint && <span style={{ fontSize: 11, color: "var(--text-dim)", lineHeight: 1.4 }}>{hint}</span>}
+    </label>
+  );
+}
+
+const inputBase: CSSProperties = {
+  padding: "8px 11px",
+  borderRadius: 6,
+  background: "var(--bg-sunk)",
+  border: "1px solid var(--border)",
+  color: "var(--text)",
+  fontSize: 13,
+  width: "100%",
+  outline: "none",
+};
+
+interface TextInputProps {
+  value: string | number | undefined;
+  onChange?: (v: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+  type?: "text" | "password" | "number" | "email";
+  readOnly?: boolean;
+  list?: string;
+  disabled?: boolean;
+}
+
+export function TextInput({
+  value,
+  onChange,
+  placeholder,
+  mono,
+  type = "text",
+  readOnly,
+  list,
+  disabled,
+}: TextInputProps) {
+  return (
+    <input
+      type={type}
+      value={value ?? ""}
+      onChange={(e) => onChange?.(e.target.value)}
+      placeholder={placeholder}
+      readOnly={readOnly}
+      disabled={disabled}
+      list={list}
+      style={{
+        ...inputBase,
+        fontFamily: mono ? "var(--mono)" : "var(--sans)",
+        opacity: disabled || readOnly ? 0.7 : 1,
+      }}
+    />
+  );
+}
+
+interface TextAreaProps {
+  value: string | undefined;
+  onChange?: (v: string) => void;
+  placeholder?: string;
+  rows?: number;
+  mono?: boolean;
+}
+
+export function TextArea({ value, onChange, placeholder, rows = 4, mono = true }: TextAreaProps) {
+  return (
+    <textarea
+      value={value ?? ""}
+      onChange={(e) => onChange?.(e.target.value)}
+      placeholder={placeholder}
+      rows={rows}
+      style={{
+        ...inputBase,
+        padding: "10px 12px",
+        fontFamily: mono ? "var(--mono)" : "var(--sans)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        resize: "vertical",
+      }}
+    />
+  );
+}
+
+type SelectOption = string | { value: string; label: string };
+
+interface SelectProps {
+  value: string | undefined;
+  onChange?: (v: string) => void;
+  options: SelectOption[];
+  disabled?: boolean;
+}
+
+export function Select({ value, onChange, options, disabled }: SelectProps) {
+  return (
+    <select
+      value={value ?? ""}
+      onChange={(e) => onChange?.(e.target.value)}
+      disabled={disabled}
+      style={{
+        ...inputBase,
+        fontFamily: "var(--mono)",
+        fontSize: 12,
+        appearance: "none",
+        backgroundImage:
+          "linear-gradient(45deg, transparent 50%, var(--text-dim) 50%)," +
+          "linear-gradient(135deg, var(--text-dim) 50%, transparent 50%)",
+        backgroundPosition: "calc(100% - 14px) 50%, calc(100% - 10px) 50%",
+        backgroundSize: "4px 4px, 4px 4px",
+        backgroundRepeat: "no-repeat",
+        paddingRight: 28,
+        cursor: disabled ? "not-allowed" : "pointer",
+      }}
+    >
+      {options.map((o) =>
+        typeof o === "string" ? (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ) : (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ),
+      )}
+    </select>
+  );
+}
+
+interface ToggleProps {
+  value: boolean;
+  onChange?: (v: boolean) => void;
+  label?: string;
+}
+
+export function Toggle({ value, onChange, label }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange?.(!value)}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "6px 10px 6px 6px",
+        borderRadius: 22,
+        background: value
+          ? "color-mix(in oklch, var(--sunset) 18%, var(--bg-sunk))"
+          : "var(--bg-sunk)",
+        border: `1px solid ${value ? "var(--sunset)" : "var(--border)"}`,
+        transition: "all 120ms",
+        cursor: "pointer",
+      }}
+    >
+      <span
+        style={{
+          position: "relative",
+          width: 26,
+          height: 14,
+          borderRadius: 7,
+          background: value ? "var(--sunset)" : "var(--border)",
+          boxShadow: value
+            ? "0 0 10px color-mix(in oklch, var(--sunset) 55%, transparent)"
+            : "none",
+          transition: "all 120ms",
+          display: "inline-block",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute",
+            top: 1,
+            left: value ? 13 : 1,
+            width: 12,
+            height: 12,
+            borderRadius: "50%",
+            background: "var(--bg)",
+            transition: "left 140ms",
+          }}
+        />
+      </span>
+      {label && (
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: "0.06em",
+            color: value ? "var(--sunset)" : "var(--text-mute)",
+            textTransform: "uppercase",
+          }}
+        >
+          {label}
+        </span>
+      )}
+    </button>
+  );
+}
+
+interface ButtonProps {
+  children: ReactNode;
+  variant?: "primary" | "default" | "ghost" | "danger";
+  size?: "sm" | "md" | "lg";
+  icon?: AIconName;
+  onClick?: () => void;
+  disabled?: boolean;
+  type?: "button" | "submit";
+}
+
+export function Button({
+  children,
+  variant = "default",
+  size = "md",
+  icon,
+  onClick,
+  disabled,
+  type = "button",
+}: ButtonProps) {
+  const sizes = {
+    sm: { padding: "5px 9px", fontSize: 10 },
+    md: { padding: "7px 12px", fontSize: 11 },
+    lg: { padding: "9px 16px", fontSize: 12 },
+  }[size];
+  const variants: Record<NonNullable<ButtonProps["variant"]>, CSSProperties> = {
+    primary: {
+      color: "var(--bg)",
+      background: "var(--sunset)",
+      border: "1px solid var(--sunset)",
+      boxShadow: "0 0 16px -4px color-mix(in oklch, var(--sunset) 50%, transparent)",
+    },
+    default: {
+      color: "var(--text)",
+      background: "var(--surface)",
+      border: "1px solid var(--border)",
+    },
+    ghost: {
+      color: "var(--text-mute)",
+      background: "transparent",
+      border: "1px solid transparent",
+    },
+    danger: {
+      color: "var(--magenta)",
+      background: "color-mix(in oklch, var(--magenta) 12%, transparent)",
+      border: "1px solid color-mix(in oklch, var(--magenta) 40%, transparent)",
+    },
+  };
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        borderRadius: 5,
+        fontFamily: "var(--mono)",
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? "not-allowed" : "pointer",
+        ...sizes,
+        ...variants[variant],
+      }}
+    >
+      {icon && <AIcon name={icon} size={size === "sm" ? 10 : 12} />}
+      {children}
+    </button>
+  );
+}
+
+export function RefCode({ code, color = "var(--sunset)" }: { code: string; color?: string }) {
+  return (
+    <span
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        color,
+        padding: "1px 5px",
+        borderRadius: 3,
+        background: `color-mix(in oklch, ${color} 14%, transparent)`,
+        border: `1px solid color-mix(in oklch, ${color} 30%, transparent)`,
+      }}
+    >
+      {code}
+    </span>
+  );
+}
+
+export function Empty({
+  icon = "sparkle",
+  title,
+  subtitle,
+  cta,
+}: {
+  icon?: AIconName;
+  title: string;
+  subtitle?: ReactNode;
+  cta?: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        padding: "60px 24px",
+        textAlign: "center",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <div
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: 11,
+          background: "var(--surface)",
+          border: "1px dashed var(--border)",
+          color: "var(--text-dim)",
+          display: "grid",
+          placeItems: "center",
+        }}
+      >
+        <AIcon name={icon} size={22} />
+      </div>
+      <div style={{ fontFamily: "var(--sans)", fontSize: 14, fontWeight: 600, color: "var(--text)" }}>
+        {title}
+      </div>
+      {subtitle && (
+        <div style={{ fontSize: 12, color: "var(--text-mute)", maxWidth: 360, lineHeight: 1.5 }}>
+          {subtitle}
+        </div>
+      )}
+      {cta}
+    </div>
+  );
+}
+
+export function FieldGrid({ cols = 2, children }: { cols?: number; children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+        gap: 14,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Note({ children, tone = "neutral" }: { children: ReactNode; tone?: "neutral" | "warning" | "info" }) {
+  const color =
+    tone === "warning" ? "var(--amber)" : tone === "info" ? "var(--sky)" : "var(--text-mute)";
+  return (
+    <div
+      style={{
+        padding: "10px 12px",
+        borderRadius: 6,
+        background: `color-mix(in oklch, ${color} 8%, transparent)`,
+        border: `1px solid color-mix(in oklch, ${color} 26%, transparent)`,
+        color: "var(--text)",
+        fontSize: 12,
+        lineHeight: 1.5,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/radbot/web/frontend/src/globals.css
+++ b/radbot/web/frontend/src/globals.css
@@ -125,6 +125,91 @@
     border-top: 1px dashed rgba(48, 64, 80, 0.6);
   }
 
+  /* ── Admin page — design tokens (ported from admin redesign handoff) ─── */
+  .admin-scope {
+    --bg: #0b0e12;
+    --bg-sunk: #070a0e;
+    --surface: #11161c;
+    --surface-2: #161c24;
+    --border: #2a333e;
+    --border-soft: #1a222c;
+    --text: #e6ecf2;
+    --text-mute: #9aa7b5;
+    --text-dim: #5c6b7a;
+    --sunset: #ff7849;
+    --amber: #ffb347;
+    --magenta: #ff3d7f;
+    --violet: #a884ff;
+    --sky: #5ec0ff;
+    --crt: #7dffb5;
+    --sans: "Inter", system-ui, sans-serif;
+    --mono: "JetBrains Mono", "Geist Mono", ui-monospace, monospace;
+    --pixel: "VT323", monospace;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .admin-scope button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+  }
+
+  .admin-scope input,
+  .admin-scope textarea,
+  .admin-scope select {
+    font: inherit;
+    color: inherit;
+  }
+  .admin-scope input:focus,
+  .admin-scope textarea:focus,
+  .admin-scope select:focus {
+    outline: none;
+    border-color: var(--sunset) !important;
+  }
+
+  .admin-scope a {
+    color: var(--sky);
+    text-decoration: none;
+  }
+  .admin-scope a:hover {
+    text-decoration: underline;
+  }
+
+  .admin-scope .kbd {
+    display: inline-block;
+    padding: 0 5px;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-dim);
+    background: var(--bg-sunk);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    line-height: 1.4;
+  }
+
+  .admin-scope ::selection {
+    background: color-mix(in oklch, var(--sunset) 35%, transparent);
+    color: var(--text);
+  }
+
+  /* Mobile tweaks: reclaim horizontal space and avoid iOS auto-zoom. */
+  @media (max-width: 767px) {
+    .admin-scope .admin-sidebar-wrap {
+      display: none !important;
+    }
+    .admin-scope textarea,
+    .admin-scope input {
+      font-size: 16px !important;
+    }
+  }
+
   /* ── Projects page — design tokens (ported from prototype) ─── */
   .projects-scope {
     --bg: #0b0e12;

--- a/radbot/web/frontend/src/pages/AdminPage.tsx
+++ b/radbot/web/frontend/src/pages/AdminPage.tsx
@@ -2,7 +2,16 @@ import { useEffect, useState } from "react";
 import { useAdminStore } from "@/stores/admin-store";
 import { cn } from "@/lib/utils";
 
-// Panel imports
+import {
+  AdminSidebar,
+  PanelHeader,
+  findPanel,
+  mapStatus,
+  PANEL_CATEGORIES,
+} from "@/components/admin/shell";
+
+// Panel imports — unchanged from legacy AdminPage; the visual refresh comes
+// from the shared primitives in FormFields.tsx which every panel uses.
 import { GooglePanel, AgentModelsPanel, WebServerPanel, LoggingPanel } from "@/components/admin/panels/CorePanels";
 import { GmailPanel, CalendarPanel, JiraPanel, OverseerrPanel, LidarrPanel, HomeAssistantPanel, FilesystemPanel, PicnicPanel, YouTubePanel, KideoPanel } from "@/components/admin/panels/ConnectionPanels";
 import { PostgresqlPanel, QdrantPanel } from "@/components/admin/panels/InfrastructurePanels";
@@ -19,60 +28,6 @@ import { CostTrackingPanel } from "@/components/admin/panels/TelemetryPanels";
 import { TelosPanel } from "@/components/admin/panels/TelosPanel";
 import { McpBridgePanel } from "@/components/admin/panels/McpBridgePanel";
 
-// ── Navigation definition ──────────────────────────────────
-interface NavItem {
-  id: string;
-  label: string;
-  group: string;
-  statusKey?: string; // key into IntegrationStatus for sidebar dot
-}
-
-const NAV_ITEMS: NavItem[] = [
-  // Core
-  { id: "google", label: "Google AI", group: "Core", statusKey: "google" },
-  { id: "agent_models", label: "Agent & Models", group: "Core" },
-  { id: "web_server", label: "Web Server", group: "Core" },
-  { id: "logging", label: "Logging", group: "Core" },
-  { id: "cost_tracking", label: "Cost Tracking", group: "Core" },
-  // Personal
-  { id: "telos", label: "Telos", group: "Personal" },
-  // Connections
-  { id: "gmail", label: "Gmail", group: "Connections", statusKey: "gmail" },
-  { id: "calendar", label: "Calendar", group: "Connections", statusKey: "calendar" },
-  { id: "jira", label: "Jira", group: "Connections", statusKey: "jira" },
-  { id: "overseerr", label: "Overseerr", group: "Connections", statusKey: "overseerr" },
-  { id: "lidarr", label: "Lidarr", group: "Connections", statusKey: "lidarr" },
-  { id: "home_assistant", label: "Home Assistant", group: "Connections", statusKey: "home_assistant" },
-  { id: "picnic", label: "Picnic", group: "Connections", statusKey: "picnic" },
-  { id: "youtube", label: "YouTube", group: "Connections", statusKey: "youtube" },
-  { id: "kideo", label: "Kideo", group: "Connections", statusKey: "kideo" },
-  { id: "filesystem", label: "Filesystem", group: "Connections" },
-  // Infrastructure
-  { id: "postgresql", label: "PostgreSQL", group: "Infrastructure", statusKey: "postgresql" },
-  { id: "qdrant", label: "Qdrant", group: "Infrastructure", statusKey: "qdrant" },
-  { id: "nomad", label: "Nomad", group: "Infrastructure", statusKey: "nomad" },
-  // Media & Voice
-  { id: "tts", label: "Text-to-Speech", group: "Media & Voice", statusKey: "tts" },
-  { id: "stt", label: "Speech-to-Text", group: "Media & Voice", statusKey: "stt" },
-  // Notifications
-  { id: "ntfy", label: "Push Notifications", group: "Notifications", statusKey: "ntfy" },
-  // Automation
-  { id: "scheduler", label: "Scheduler", group: "Automation" },
-  { id: "webhooks", label: "Webhooks", group: "Automation" },
-  { id: "alertmanager", label: "Alertmanager", group: "Automation", statusKey: "alertmanager" },
-  // Developer
-  { id: "github_app", label: "GitHub App", group: "Developer", statusKey: "github" },
-  { id: "claude_code", label: "Claude Code", group: "Developer", statusKey: "claude_code" },
-  // Security
-  { id: "sanitization", label: "Sanitization", group: "Security" },
-  // Advanced
-  { id: "mcp_bridge", label: "MCP Bridge", group: "Advanced" },
-  { id: "mcp_servers", label: "MCP Servers", group: "Advanced" },
-  { id: "credentials", label: "Credentials", group: "Advanced" },
-  { id: "raw_config", label: "Raw Config", group: "Advanced" },
-];
-
-// Panel component mapping
 const PANEL_MAP: Record<string, React.ComponentType> = {
   google: GooglePanel,
   agent_models: AgentModelsPanel,
@@ -108,7 +63,6 @@ const PANEL_MAP: Record<string, React.ComponentType> = {
   raw_config: RawConfigPanel,
 };
 
-// ── Main Admin Page ────────────────────────────────────────
 export default function AdminPage() {
   const authenticated = useAdminStore((s) => s.authenticated);
   const token = useAdminStore((s) => s.token);
@@ -120,13 +74,16 @@ export default function AdminPage() {
       if (s.authenticated || !s.token) setChecking(false);
     });
     const t = setTimeout(() => setChecking(false), 3000);
-    return () => { unsub(); clearTimeout(t); };
+    return () => {
+      unsub();
+      clearTimeout(t);
+    };
   }, [checking]);
 
   if (checking) {
     return (
-      <div className="fixed inset-0 bg-bg-primary z-[1000] flex items-center justify-center">
-        <div className="text-txt-secondary text-sm">Authenticating…</div>
+      <div className="admin-scope fixed inset-0 z-[1000] flex items-center justify-center">
+        <div style={{ color: "var(--text-mute)", fontSize: 13 }}>Authenticating…</div>
       </div>
     );
   }
@@ -135,12 +92,14 @@ export default function AdminPage() {
 
   return (
     <div
-      className="h-screen flex flex-col bg-bg-primary text-txt-primary font-sans"
+      className="admin-scope h-screen flex flex-col"
       data-test="admin-dashboard"
     >
-      <Header />
+      <TopChrome />
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar />
+        <div className="admin-sidebar-wrap" style={{ display: "flex", flex: "none" }}>
+          <SidebarContainer />
+        </div>
         <Content />
       </div>
       <ToastContainer />
@@ -148,7 +107,32 @@ export default function AdminPage() {
   );
 }
 
-// ── Auth Overlay ───────────────────────────────────────────
+function SidebarContainer() {
+  const activePanel = useAdminStore((s) => s.activePanel);
+  const setActivePanel = useAdminStore((s) => s.setActivePanel);
+  const status = useAdminStore((s) => s.status);
+  const loadStatus = useAdminStore((s) => s.loadStatus);
+  const loadLiveConfig = useAdminStore((s) => s.loadLiveConfig);
+
+  useEffect(() => {
+    loadStatus();
+    loadLiveConfig();
+  }, [loadStatus, loadLiveConfig]);
+
+  return (
+    <AdminSidebar
+      active={activePanel}
+      setActive={(id) => {
+        setActivePanel(id);
+        const url = new URL(window.location.href);
+        url.searchParams.set("panel", id);
+        window.history.replaceState({}, "", url.toString());
+      }}
+      status={status}
+    />
+  );
+}
+
 function AuthOverlay() {
   const [input, setInput] = useState("");
   const setToken = useAdminStore((s) => s.setToken);
@@ -163,21 +147,66 @@ function AuthOverlay() {
 
   return (
     <div
-      className="fixed inset-0 bg-bg-primary z-[1000] flex items-center justify-center"
+      className="admin-scope fixed inset-0 z-[1000] flex items-center justify-center"
       data-test="admin-login-prompt"
     >
-      <form onSubmit={handleSubmit} className="bg-bg-secondary border border-border rounded-xl p-8 w-[380px]">
-        <h2 className="text-xl font-semibold mb-1">Admin Access</h2>
-        <p className="text-txt-secondary text-sm mb-6">Enter your admin token</p>
-        {error && <div className="text-terminal-red text-sm mb-3" data-test="admin-login-error">{error}</div>}
-        <input
-          type="text"
-          name="username"
-          autoComplete="username"
-          value="admin"
-          readOnly
-          hidden
-        />
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          padding: 28,
+          width: 380,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 10,
+            marginBottom: 4,
+          }}
+        >
+          <h2
+            style={{
+              fontFamily: "var(--pixel)",
+              fontSize: 26,
+              color: "var(--text)",
+              letterSpacing: "0.04em",
+              textShadow: "0 0 10px color-mix(in oklch, var(--sunset) 40%, transparent)",
+            }}
+          >
+            RADBOT
+          </h2>
+          <span
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.14em",
+              color: "var(--sunset)",
+              padding: "1px 6px",
+              borderRadius: 3,
+              background: "color-mix(in oklch, var(--sunset) 14%, transparent)",
+              border: "1px solid color-mix(in oklch, var(--sunset) 30%, transparent)",
+            }}
+          >
+            ADMIN
+          </span>
+        </div>
+        <p style={{ color: "var(--text-mute)", fontSize: 13, marginBottom: 22 }}>
+          Enter your admin token
+        </p>
+        {error && (
+          <div
+            style={{ color: "var(--magenta)", fontSize: 12, marginBottom: 12 }}
+            data-test="admin-login-error"
+          >
+            {error}
+          </div>
+        )}
+        <input type="text" name="username" autoComplete="username" value="admin" readOnly hidden />
         <input
           type="password"
           name="password"
@@ -186,14 +215,37 @@ function AuthOverlay() {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Token"
-          className="w-full p-2.5 border border-border rounded-md bg-bg-primary text-txt-primary text-sm mb-4 outline-none focus:border-radbot-sunset"
           autoFocus
           data-test="admin-token-input"
+          style={{
+            width: "100%",
+            padding: "10px 12px",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            background: "var(--bg-sunk)",
+            color: "var(--text)",
+            fontSize: 13,
+            marginBottom: 16,
+            outline: "none",
+          }}
         />
         <button
           type="submit"
-          className="w-full py-2.5 bg-radbot-sunset text-bg-primary rounded-md font-medium text-sm hover:bg-radbot-sunset/80 transition-colors cursor-pointer"
           data-test="admin-token-submit"
+          style={{
+            width: "100%",
+            padding: "10px",
+            background: "var(--sunset)",
+            color: "var(--bg)",
+            borderRadius: 6,
+            fontFamily: "var(--mono)",
+            fontWeight: 700,
+            fontSize: 12,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            boxShadow: "0 0 18px -4px color-mix(in oklch, var(--sunset) 50%, transparent)",
+            cursor: "pointer",
+          }}
         >
           Authenticate
         </button>
@@ -202,131 +254,146 @@ function AuthOverlay() {
   );
 }
 
-// ── Header ─────────────────────────────────────────────────
-function Header() {
+function TopChrome() {
   const logout = useAdminStore((s) => s.logout);
 
   return (
-    <div className="scanlines h-[50px] bg-bg-secondary border-b border-border flex items-center justify-between px-4 flex-shrink-0 relative z-10">
-      <div className="flex items-center gap-3 min-w-0">
+    <header
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "8px 16px",
+        background: "var(--bg-sunk)",
+        borderBottom: "1px solid var(--border)",
+        flex: "none",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
         <div
           aria-hidden
-          className="mascot-sticker hidden sm:block w-[34px] h-[34px] flex-none rounded-md border-2 border-[#ff9966] bg-cover"
           style={{
-            backgroundImage: "url(/static/dist/radbot.png)",
-            backgroundSize: "260%",
-            backgroundPosition: "60% 30%",
+            width: 28,
+            height: 28,
+            borderRadius: 6,
+            background:
+              "linear-gradient(135deg, var(--sunset), var(--magenta))",
+            boxShadow:
+              "0 0 14px -3px color-mix(in oklch, var(--sunset) 60%, transparent)",
+            display: "grid",
+            placeItems: "center",
+            flex: "none",
           }}
-        />
-        <div className="flex items-baseline gap-2">
-          <h1 className="pixel-font text-[18px] text-txt-primary m-0 leading-none">RADBOT</h1>
-          <span className="inline-flex text-[9px] font-mono font-semibold tracking-[0.15em] text-radbot-sunset px-1.5 py-0.5 rounded-sm border border-radbot-sunset/40 bg-radbot-sunset/10">
-            ADMIN
+        >
+          <span
+            style={{
+              fontFamily: "var(--pixel)",
+              fontSize: 16,
+              color: "var(--bg)",
+              fontWeight: 700,
+            }}
+          >
+            R
           </span>
         </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <a
-          href="/"
-          className="font-mono text-[0.7rem] uppercase tracking-wider text-txt-secondary border border-border px-2.5 py-1 rounded-sm hover:border-radbot-sunset hover:text-txt-primary no-underline transition-colors"
+        <span
+          style={{
+            fontFamily: "var(--pixel)",
+            fontSize: 18,
+            letterSpacing: "0.04em",
+            color: "var(--text)",
+            textShadow: "0 0 6px color-mix(in oklch, var(--sunset) 35%, transparent)",
+          }}
         >
-          Chat UI
-        </a>
-        <button
-          onClick={logout}
-          className="font-mono text-[0.7rem] uppercase tracking-wider text-txt-secondary border border-border px-2.5 py-1 rounded-sm hover:border-radbot-sunset hover:text-txt-primary cursor-pointer transition-colors bg-transparent"
+          RADBOT
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: "0.14em",
+            color: "var(--sunset)",
+            padding: "1px 6px",
+            borderRadius: 3,
+            background: "color-mix(in oklch, var(--sunset) 14%, transparent)",
+            border: "1px solid color-mix(in oklch, var(--sunset) 30%, transparent)",
+          }}
         >
-          Logout
-        </button>
+          ADMIN
+        </span>
       </div>
-    </div>
+      <span style={{ flex: 1 }} />
+      <a
+        href="/"
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          color: "var(--text-mute)",
+          border: "1px solid var(--border)",
+          padding: "5px 10px",
+          borderRadius: 4,
+        }}
+      >
+        Chat UI
+      </a>
+      <button
+        type="button"
+        onClick={logout}
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          color: "var(--text-mute)",
+          border: "1px solid var(--border)",
+          padding: "5px 10px",
+          borderRadius: 4,
+          cursor: "pointer",
+          background: "transparent",
+        }}
+      >
+        Logout
+      </button>
+    </header>
   );
 }
 
-// ── Sidebar ────────────────────────────────────────────────
-function Sidebar() {
+function Content() {
   const activePanel = useAdminStore((s) => s.activePanel);
-  const setActivePanel = useAdminStore((s) => s.setActivePanel);
   const status = useAdminStore((s) => s.status);
-  const loadStatus = useAdminStore((s) => s.loadStatus);
-  const loadLiveConfig = useAdminStore((s) => s.loadLiveConfig);
+  const found = findPanel(activePanel);
+  const PanelComponent = PANEL_MAP[activePanel];
 
-  // Load status and config on mount
-  useEffect(() => {
-    loadStatus();
-    loadLiveConfig();
-  }, [loadStatus, loadLiveConfig]);
-
-  // Group nav items
-  const groups = new Map<string, NavItem[]>();
-  NAV_ITEMS.forEach((item) => {
-    const arr = groups.get(item.group) ?? [];
-    arr.push(item);
-    groups.set(item.group, arr);
-  });
+  const statusKey = found?.panel.statusKey;
+  const panelStatus = mapStatus(statusKey ? status[statusKey] : undefined);
 
   return (
     <div
-      className="w-[220px] min-w-[220px] bg-bg-secondary border-r border-border overflow-y-auto py-2 flex-shrink-0"
-      data-test="admin-sidebar"
+      style={{
+        flex: 1,
+        overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
+        minWidth: 0,
+      }}
     >
-      {Array.from(groups.entries()).map(([group, items]) => (
-        <div key={group} data-test={`admin-group-${group.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}>
-          <div className="text-[0.65rem] font-bold tracking-wider uppercase text-txt-secondary/60 px-4 pt-3 pb-1">
-            {group}
-          </div>
-          {items.map((item) => {
-            const s = item.statusKey ? status[item.statusKey] : undefined;
-            return (
-              <div
-                key={item.id}
-                onClick={() => setActivePanel(item.id)}
-                data-test={`admin-nav-${item.id}`}
-                data-status={s?.status ?? "unknown"}
-                className={cn(
-                  "flex items-center gap-2 px-4 py-1.5 cursor-pointer text-sm text-txt-secondary transition-all border-l-[3px] border-transparent",
-                  "hover:bg-bg-tertiary hover:text-txt-primary",
-                  activePanel === item.id && "bg-bg-tertiary text-txt-primary border-l-radbot-sunset",
-                )}
-              >
-                {/* Status dot */}
-                {item.statusKey && (
-                  <span
-                    className={cn(
-                      "w-2 h-2 rounded-full flex-shrink-0",
-                      s?.status === "ok" ? "bg-terminal-green" :
-                      s?.status === "error" ? "bg-terminal-red" :
-                      "bg-txt-secondary/40",
-                    )}
-                    title={s?.message || s?.status || "unknown"}
-                  />
-                )}
-                <span className="truncate">{item.label}</span>
-              </div>
-            );
-          })}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ── Content ────────────────────────────────────────────────
-function Content() {
-  const activePanel = useAdminStore((s) => s.activePanel);
-  const PanelComponent = PANEL_MAP[activePanel];
-
-  return (
-    <div className="flex-1 overflow-y-auto p-6">
-      <div className="max-w-[800px]">
+      {found && (
+        <PanelHeader panel={found.panel} category={found.category} status={panelStatus} />
+      )}
+      <div style={{ padding: "22px 26px", maxWidth: 1100, width: "100%" }}>
         {PanelComponent ? (
           <PanelComponent />
         ) : (
-          <div>
-            <h2 className="text-lg font-semibold mb-4">
-              {NAV_ITEMS.find((i) => i.id === activePanel)?.label ?? activePanel}
-            </h2>
-            <p className="text-txt-secondary text-sm">Panel not found.</p>
+          <div style={{ color: "var(--text-mute)", fontSize: 13 }}>
+            Panel not found. Available:{" "}
+            {PANEL_CATEGORIES.flatMap((c) => c.panels)
+              .map((p) => p.id)
+              .join(", ")}
           </div>
         )}
       </div>
@@ -334,7 +401,6 @@ function Content() {
   );
 }
 
-// ── Toast Container ────────────────────────────────────────
 function ToastContainer() {
   const toasts = useAdminStore((s) => s.toasts);
   const dismissToast = useAdminStore((s) => s.dismissToast);
@@ -342,22 +408,51 @@ function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-5 right-5 flex flex-col gap-2 z-[9999]">
-      {toasts.map((t) => (
-        <div
-          key={t.id}
-          onClick={() => dismissToast(t.id)}
-          className={cn(
-            "px-4 py-3 rounded-lg shadow-lg text-sm font-medium cursor-pointer transition-all animate-[slideIn_0.3s_ease-out]",
-            "max-w-[400px] break-words",
-            t.type === "success"
-              ? "bg-terminal-green/15 border border-terminal-green/30 text-terminal-green"
-              : "bg-terminal-red/15 border border-terminal-red/30 text-terminal-red",
-          )}
-        >
-          {t.message}
-        </div>
-      ))}
+    <div
+      style={{
+        position: "fixed",
+        bottom: 20,
+        right: 20,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        zIndex: 9999,
+      }}
+    >
+      {toasts.map((t) => {
+        const color = t.type === "success" ? "var(--crt)" : "var(--magenta)";
+        return (
+          <div
+            key={t.id}
+            onClick={() => dismissToast(t.id)}
+            className={cn("animate-[slideIn_0.3s_ease-out]")}
+            style={{
+              padding: "12px 16px",
+              borderRadius: 8,
+              background: `color-mix(in oklch, ${color} 14%, var(--surface))`,
+              border: `1px solid color-mix(in oklch, ${color} 40%, transparent)`,
+              color,
+              fontSize: 13,
+              fontWeight: 500,
+              maxWidth: 400,
+              wordBreak: "break-word",
+              cursor: "pointer",
+              boxShadow: "0 8px 30px -10px rgba(0,0,0,0.5)",
+            }}
+          >
+            {t.message}
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+// URL ↔ store sync: read ?panel= on mount.
+if (typeof window !== "undefined") {
+  const p = new URLSearchParams(window.location.search).get("panel");
+  if (p && PANEL_MAP[p]) {
+    // Defer to next tick so Zustand has initialized.
+    queueMicrotask(() => useAdminStore.setState({ activePanel: p }));
+  }
 }

--- a/specs/web.md
+++ b/specs/web.md
@@ -237,7 +237,44 @@ Flat panel structure (no more grouping superclasses).
 | `CredentialsPanel.tsx` | `CredentialsPanel` |
 | `RawConfigPanel.tsx` | `RawConfigPanel` |
 
-Registered in `pages/AdminPage.tsx` via `NAV_ITEMS` + `PANEL_MAP`.
+Registered in `pages/AdminPage.tsx` via `PANEL_MAP`. The sidebar nav catalog
+(categories + icons + status keys) lives in
+`components/admin/shell/catalog.ts` as `PANEL_CATEGORIES`, decoupled from the
+panel registry.
+
+### Admin Shell (`components/admin/shell/`, 2026-04-19 redesign)
+
+The admin area uses a scoped design system (class `admin-scope` on the page
+root) with its own palette/font tokens (`--bg`, `--surface`, `--sunset`,
+`--crt`, `--mono` = JetBrains Mono, `--pixel` = VT323) defined in
+`globals.css`. The shell module exports:
+
+- `icons.tsx` — `<AIcon name=… size={…}/>` with a 46-glyph set (sparkle, cpu,
+  server, chart, compass, mail, cart, db, nomad, speaker, mic, bell, alert,
+  git, anchor, shield, stack, key, code, plus/close/check/copy/ext/refresh/
+  play/pause/edit/trash/eye + chevrons).
+- `primitives.tsx` — `SectionCard`, `Field`, `FieldGrid`, `TextInput`,
+  `TextArea`, `Select`, `Toggle`, `Button` (primary|default|ghost|danger,
+  sm|md|lg), `RefCode`, `StatusDot`, `StatusPill`
+  (connected|configured|disconnected|error|neutral), `Empty`, `Note` (info|
+  warning|neutral).
+- `catalog.ts` — `PANEL_CATEGORIES` (10 groups: CORE, PERSONAL, CONNECTIONS,
+  INFRASTRUCTURE, MEDIA & VOICE, NOTIFICATIONS, AUTOMATION, DEVELOPER,
+  SECURITY, ADVANCED), `findPanel`, `mapStatus` (maps admin-store raw
+  `ok|error|unconfigured` → design-system `PanelStatus`).
+- `Sidebar.tsx` — categorized `<AdminSidebar>` with collapsible groups,
+  live filter (`filter panels…`), per-panel status dot, active highlight.
+- `PanelHeader.tsx` — panel chrome (crumb, icon tile, title, status pill,
+  actions slot).
+
+`FormFields.tsx` remains the import surface for panels (`FormInput`,
+`FormToggle`, `FormDropdown`, `FormTextarea`, `FormSlider`, `FormRow`,
+`Card`, `Note`, `ActionBar`, `StatusBadge`); its internals now delegate to
+the shell primitives so restyling flows through every panel automatically.
+
+`AdminPage.tsx` syncs `activePanel` to the `?panel=<id>` query param for
+deep-linking. On mobile (<768px) the sidebar is hidden via `.admin-scope
+.admin-sidebar-wrap { display: none }`.
 
 ### Chat Components (post-refresh 2026-04-18)
 


### PR DESCRIPTION
## Summary
- New admin design language ported from the handoff zip (`/home/perry/Downloads/radbot (4).zip`): scoped `.admin-scope` palette (sunset / crt / magenta / violet / sky on four dark surfaces), JetBrains Mono + VT323 fonts, and a reusable shell module (`components/admin/shell/`).
- Categorized sidebar (10 groups — CORE, PERSONAL, CONNECTIONS, INFRASTRUCTURE, MEDIA & VOICE, NOTIFICATIONS, AUTOMATION, DEVELOPER, SECURITY, ADVANCED) with collapsibles, live filter, per-panel status dot. Replaces the flat `NAV_ITEMS` list.
- `FormFields.tsx` now delegates to shell primitives (`SectionCard`, `Field`, `TextInput`, `Toggle`, `Button`, `StatusPill`). Every existing panel (14 modules) re-skins automatically with no panel code changes.
- Deep-link sync: the active panel is mirrored to `?panel=<id>`.

## What's *not* in this PR (on purpose)
- **Cost panel mocks**: the handoff's Cost panel uses static chart data and references `/api/cost/summary` + `/api/cost/requests` endpoints that don't exist. Kept the existing `CostTrackingPanel` intact rather than regressing real wiring to mocks. Worth a follow-up initiative.
- **Tweaks panel**: handoff explicitly marks it design-time-only — dropped per its own guidance.
- **`AVAILABLE_MODELS` hardcoded list**: the existing `AgentModelsPanel` already pulls from `/api/models` via `useModelOptions()` — better than the handoff's static list.

## Scope preserved
- No backend changes. `admin-store`, `admin-api` client, panel ids, `data-test` attributes (`admin-sidebar`, `admin-nav-<id>`, `admin-group-<key>`, `admin-login-prompt`, etc.) all intact.
- Spec updated: `specs/web.md` now documents the shell module, catalog, and design tokens.

## Test plan
- [ ] `make dev-frontend` → walk through every panel (Google AI, Agent & Models, Gmail, Calendar, Jira, Overseerr, Lidarr, Home Assistant, Picnic, YouTube, Kideo, Filesystem, Postgres, Qdrant, Nomad, TTS, STT, Push, Scheduler, Webhooks, Alertmanager, GitHub App, Claude Code, Sanitization, MCP Bridge, MCP Servers, Credentials, Raw Config, Cost Tracking, Telos, Web Server, Logging).
- [ ] Sidebar filter box narrows categories correctly.
- [ ] Sidebar status dots reflect `/api/admin/status` (green=connected, red=error, dim=disconnected).
- [ ] `?panel=gmail` deep link loads the Gmail panel directly.
- [ ] Auth overlay renders in the new palette; logout works.
- [ ] Mobile (<768px): sidebar collapses away, content fills width.
- [ ] Save + Test buttons on Google AI panel still hit real endpoints.
- [ ] Playwright specs using `admin-*` `data-test` selectors still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)