### PR TITLE
fix(e2e): admin nav active-state assertion post-redesign

### DIFF
--- a/radbot/web/frontend/e2e/specs/admin.spec.ts
+++ b/radbot/web/frontend/e2e/specs/admin.spec.ts
@@ -51,9 +51,13 @@ test.describe("admin (authenticated)", () => {
     await page.locator('[data-test="admin-nav-postgresql"]').click();
     // The Content area swaps to the selected panel; assertion is loose because
     // the panel implementation may vary — we just confirm the click registered
-    // by checking the active-state class on the nav item.
-    await expect(page.locator('[data-test="admin-nav-postgresql"]')).toHaveClass(
-      /border-l-radbot-sunset/,
+    // by checking the active-state marker on the nav item. (Styling moved to
+    // inline CSS custom properties in the admin redesign, so the old
+    // `border-l-radbot-sunset` Tailwind class no longer exists; the button
+    // now carries `data-active="true"` when selected.)
+    await expect(page.locator('[data-test="admin-nav-postgresql"]')).toHaveAttribute(
+      "data-active",
+      "true",
     );
   });
 });

--- a/radbot/web/frontend/src/components/admin/shell/Sidebar.tsx
+++ b/radbot/web/frontend/src/components/admin/shell/Sidebar.tsx
@@ -135,6 +135,7 @@ export function AdminSidebar({ active, setActive, status }: SidebarProps) {
                       onClick={() => setActive(p.id)}
                       data-test={`admin-nav-${p.id}`}
                       data-status={dotStatus}
+                      data-active={isActive ? "true" : "false"}
                       style={{
                         width: "100%",
                         display: "flex",


### PR DESCRIPTION
## Summary

After the admin redesign, nav item styling moved from Tailwind classes to inline CSS custom properties (`borderLeft: "2px solid var(--sunset)"`), so the button's `className` is empty string. The existing e2e spec was still asserting `/border-l-radbot-sunset/` which no longer exists:

```
Expected pattern: /border-l-radbot-sunset/
Received string:  ""
```

## Fix

- Add `data-active={isActive ? "true" : "false"}` to the nav button in `Sidebar.tsx`.
- Update spec to assert `toHaveAttribute("data-active", "true")` instead of scraping styling.

This is more robust: the redesign is free to refactor styling without breaking e2e, and the assertion now matches the test's stated intent ("we just confirm the click registered by checking the active-state marker").

## Test plan
- [ ] Run e2e locally or in CI → `admin.spec.ts:47` passes
- [ ] Click a nav item in `/admin` UI → DOM inspector shows `data-active="true"` on the active button and `"false"` on the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)