### PR TITLE
ci: short-circuit duplicate runs from multi-label PR creation

### DIFF
--- a/.github/workflows/quality-pipeline.yml
+++ b/.github/workflows/quality-pipeline.yml
@@ -30,6 +30,14 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   guard:
     runs-on: ubuntu-latest
+    # `pull_request.labeled` fires once per label added — so
+    # `gh pr create --label run-e2e --label auto-merge-eligible` triggers
+    # multiple runs that all get cancelled by the concurrency group.
+    # Only honor `labeled` when the just-added label is `run-e2e`; other
+    # label adds don't need a fresh pipeline run.
+    if: |
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'run-e2e'
     outputs:
       run: ${{ steps.decide.outputs.run }}
       reason: ${{ steps.decide.outputs.reason }}


### PR DESCRIPTION
## Summary

`pull_request.labeled` fires once per label added, so `gh pr create --label run-e2e --label auto-merge-eligible` triggers 3+ runs (1 `opened` + N `labeled`). The concurrency group cancels the older ones, leaving a trail of cancelled runs cluttering the Actions tab and spamming email.

## Fix

Job-level `if` on `guard` that short-circuits `labeled` events unless the just-added label is `run-e2e`. Other label adds (`auto-merge-eligible`, manual tagging, etc.) no longer spawn phantom runs. `opened` / `synchronize` / `reopened` trigger unconditionally as before.

## Why this is safe
- Adding `run-e2e` to a PR that didn't have it still triggers the pipeline (correct).
- Pushing to a PR with `run-e2e` already present still triggers via `synchronize` (correct).
- Adding any other label while `run-e2e` is already present used to trigger a redundant run; now it doesn't.

## Heads-up

Path-guard will block auto-merge because this touches `.github/workflows/quality-pipeline.yml` (correct — CI config is sensitive). Intentionally no `auto-merge-eligible` label. Merge manually once the pipeline passes.

## Test plan
- [ ] PR run completes (validates YAML parses)
- [ ] After merge, next PR opened with multiple `--label` flags triggers a single pipeline run instead of 3-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)