### PR TITLE
fix(scout): root agent must use mode='chat' (ADK 2.0 requirement)

### DIFF
--- a/radbot/agent/research_agent/agent.py
+++ b/radbot/agent/research_agent/agent.py
@@ -49,6 +49,7 @@ class ResearchAgent:
         enable_google_search: bool = False,
         enable_code_execution: bool = False,
         app_name: str = "beto",
+        mode: str = "task",
     ):
         """
         Initialize the ResearchAgent.
@@ -91,7 +92,10 @@ class ResearchAgent:
             tools = get_research_tools()
             logger.info(f"Using default research tools: {len(tools)} tools loaded")
 
-        # Create the LlmAgent instance
+        # Create the LlmAgent instance. ``mode`` defaults to "task" to preserve
+        # the existing sub-agent behavior; callers constructing scout as a
+        # session root must pass ``mode="chat"`` — ADK 2.0's Runner rejects a
+        # root LlmAgent that isn't in chat mode.
         self.agent = LlmAgent(
             name=name,
             model=model,
@@ -99,7 +103,7 @@ class ResearchAgent:
             description=description,
             tools=tools,
             output_key=output_key,
-            mode="task",
+            mode=mode,
         )
 
         # Store app_name for reference (not used by LlmAgent but needed for Runner)

--- a/radbot/agent/research_agent/factory.py
+++ b/radbot/agent/research_agent/factory.py
@@ -125,7 +125,12 @@ def create_research_agent(
     if tools:
         toolkit.extend(tools)
 
-    # Create the research agent with explicit name and app_name
+    # Create the research agent with explicit name and app_name.
+    # ADK 2.0 requires the Runner's root LlmAgent to be in "chat" mode — the
+    # sub-agent default ``mode="task"`` triggers a startup error on the first
+    # real turn. When scout is being constructed as a session root, swap to
+    # "chat"; sub-agent usage keeps "task" so we don't disturb the existing
+    # beto→scout transfer path.
     research_agent = ResearchAgent(
         name=name,
         model=model,
@@ -135,6 +140,7 @@ def create_research_agent(
         enable_google_search=enable_google_search,
         enable_code_execution=enable_code_execution,
         app_name=app_name,  # Should match the root agent's name
+        mode="chat" if as_root else "task",
     )
 
     adk_agent = research_agent.get_adk_agent()

--- a/tests/unit/test_agent_model_config.py
+++ b/tests/unit/test_agent_model_config.py
@@ -128,6 +128,33 @@ class TestAgentModelConfig(unittest.TestCase):
         self.assertTrue(call_kwargs["enable_sequential_thinking"])
         self.assertFalse(call_kwargs["enable_google_search"])
         self.assertFalse(call_kwargs["enable_code_execution"])
+        # sub-agent scout stays in "task" mode (matches beto's routing tree)
+        self.assertEqual(call_kwargs.get("mode"), "task")
+
+    @patch("radbot.agent.research_agent.factory.config_manager")
+    @patch("radbot.agent.research_agent.factory.ResearchAgent")
+    def test_scout_as_root_uses_chat_mode(self, mock_research_agent, mock_config_manager):
+        """Scout built as a session root must use mode='chat'.
+
+        ADK 2.0's Runner rejects a root LlmAgent with any mode other than
+        'chat' ("LlmAgent as root agent must have mode='chat', but got
+        mode='task'"). This is the regression guard for that path — without
+        it, the bug only surfaces on the first real user turn in a scout-
+        rooted session, past every construction-time smoke test.
+        """
+        mock_config_manager.get_agent_model.return_value = "gemini-2.5-pro-latest"
+        mock_config_manager.get_main_model.return_value = "gemini-2.5-pro"
+
+        mock_instance = MagicMock()
+        mock_instance.get_adk_agent.return_value = MagicMock()
+        mock_research_agent.return_value = mock_instance
+
+        create_research_agent(as_subagent=False, as_root=True)
+
+        mock_research_agent.assert_called_once()
+        call_kwargs = mock_research_agent.call_args.kwargs
+        self.assertEqual(call_kwargs.get("mode"), "chat")
+        self.assertEqual(call_kwargs["app_name"], "scout")
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary

Scout sessions failed on the first user turn with a hard error from ADK's Runner:

```
ValueError: LlmAgent as root agent must have mode='chat', but got mode='task'.
  File \"radbot/web/api/session/session_runner.py\", line 301, in process_message
    async for event in self.runner.run_async(...)
  File \"google/adk/runners.py\", line 821, in run_async
    raise ValueError(...)
```

Phase 1 (#49) introduced `as_root=True` for scout but `ResearchAgent` hardcodes `mode='task'` — which is a no-op for the existing sub-agent path but rejected by ADK when scout is the session root. My construction-time smoke tests never exercised a real turn, so the bug slipped past.

Confirmed in prod logs (Nomad alloc `9dcf2768-...`, first scout session at `22:31:17`). Detected via the stdout trace; the WS-level view showed only "connection open / connection closed" because the error fired inside `runner.run_async`.

## Fix

- Thread a `mode` kwarg through `ResearchAgent.__init__` (default `"task"` preserves the sub-agent behavior — beto→scout transfer is untouched)
- Pass `mode="chat"` from the factory when `as_root=True`

## Regression guard

New test `test_scout_as_root_uses_chat_mode` asserts `mode="chat"` is passed when `as_root=True`. Without this, the bug only surfaces on a real user turn — past every construction-time check.

## Files

- `radbot/agent/research_agent/agent.py` — added `mode` param
- `radbot/agent/research_agent/factory.py` — pick `chat` or `task` based on `as_root`
- `tests/unit/test_agent_model_config.py` — regression test + mode assertion on existing sub-agent test

## Test plan

- [x] `test_agent_model_config.py` — 6 pass (5 existing + 1 new)
- [ ] After merge + redeploy, start a new scout session, send "hi"; verify no `ValueError` in logs
- [ ] Verify beto→scout transfer in a beto-rooted session still works (mode='task' path unchanged)

## Separate observation from the same log trace

Scout is currently on `gemini-2.5-flash` in prod — the `gemini-3.1-pro-preview` setting is only local. Worth bumping in the DB config (`config:agent` → `scout_agent`) after this merge so her reasoning on plans is in line with the Phase 1 / Phase 2 design assumptions. Not fixed in this PR since it's a config change, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)