### PR TITLE
fix(scout): two scout-session blockers from prod log triage

### DIFF
--- a/radbot/config/default_configs/instructions/scout.md
+++ b/radbot/config/default_configs/instructions/scout.md
@@ -42,10 +42,14 @@ Use the full research stack. Cite everything.
 - `wiki_read(path)` — full read of a matching page.
 
 **External grounded search** — when the wiki doesn't cover it:
-- Transfer to `search_agent` for grounded Google Search. It returns a
-  synthesized answer with citations. Prefer primary sources: official docs,
-  arxiv, vendor engineering blogs, GitHub repos with activity. Ignore SEO
-  aggregators and listicles.
+- `search_agent` is a **sub-agent, not a tool**. The only way to reach it
+  is `transfer_to_agent(agent_name='search_agent')`. Never write
+  `search_agent(...)` as a function call — ADK will error with
+  "Tool 'search_agent' not found". Control returns to you automatically
+  once the grounded search completes.
+- Prefer primary sources in your query framing: official docs, arxiv,
+  vendor engineering blogs, GitHub repos with recent activity. Ignore
+  SEO aggregators and listicles.
 
 **Deep read** — for specific cited URLs the grounded search surfaces:
 - `web_fetch(url)` — strictly guardrailed (256KB cap, 10s timeout, private

--- a/radbot/config/settings.py
+++ b/radbot/config/settings.py
@@ -123,11 +123,15 @@ class ConfigManager:
         self.model_config = self._load_model_config()
 
     def apply_model_config(self, root_agent) -> None:
-        """Reload model config and apply to root_agent and its sub-agents.
+        """Reload model config and apply to every known root agent and its tree.
 
-        This is the single place where model changes are pushed onto the
-        live agent tree.  Called from web startup, CLI startup, and admin
-        hot-reload.
+        This is the single place where model changes are pushed onto live
+        agents.  Called from web startup, CLI startup, and admin hot-reload.
+
+        Walks beto (the passed root_agent) plus every entry in
+        ``ROOT_AGENTS`` — needed because scout, when used as a session root,
+        is a separate Agent instance not reachable from beto.sub_agents.
+        Without this, DB config changes silently skip scout-rooted sessions.
         """
         _logger = logging.getLogger(__name__)
         self.reload_model_config()
@@ -142,17 +146,49 @@ class ConfigManager:
             root_agent.model = new_model
             _logger.info(f"Applied model config: {old_model} -> {new_model}")
 
-        for sa in root_agent.sub_agents or []:
-            name = getattr(sa, "name", None)
-            if not name:
+        # Collect every agent we need to patch — beto + every alternate root
+        # (scout_root_agent, …) + all of their sub-agents. Deduplicate by
+        # object identity so shared sub-agents aren't patched twice.
+        try:
+            from radbot.agent.agent_core import ROOT_AGENTS
+
+            roots = list(ROOT_AGENTS.values())
+        except Exception:
+            roots = []
+
+        if root_agent not in roots:
+            roots.insert(0, root_agent)
+
+        seen_ids: set[int] = set()
+        for r in roots:
+            if id(r) in seen_ids:
                 continue
-            lookup = name if name.endswith("_agent") else f"{name}_agent"
-            new_sa_model = self.get_agent_model(lookup)
-            if sa.model != new_sa_model:
-                _logger.info(
-                    f"Applied sub-agent '{name}' model: {sa.model} -> {new_sa_model}"
-                )
-                sa.model = new_sa_model
+            seen_ids.add(id(r))
+            # Apply the alternate-root's own model using its name-derived key
+            r_name = getattr(r, "name", None)
+            if r_name and r is not root_agent:
+                r_lookup = r_name if r_name.endswith("_agent") else f"{r_name}_agent"
+                new_r_model = self.get_agent_model(r_lookup)
+                if r.model != new_r_model:
+                    _logger.info(
+                        f"Applied root '{r_name}' model: {r.model} -> {new_r_model}"
+                    )
+                    r.model = new_r_model
+
+            for sa in (getattr(r, "sub_agents", None) or []):
+                if id(sa) in seen_ids:
+                    continue
+                seen_ids.add(id(sa))
+                name = getattr(sa, "name", None)
+                if not name:
+                    continue
+                lookup = name if name.endswith("_agent") else f"{name}_agent"
+                new_sa_model = self.get_agent_model(lookup)
+                if sa.model != new_sa_model:
+                    _logger.info(
+                        f"Applied sub-agent '{name}' model: {sa.model} -> {new_sa_model}"
+                    )
+                    sa.model = new_sa_model
 
     def _load_home_assistant_config(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary

Two bugs surfaced triaging Nomad logs from the first real scout-rooted session attempt. Construction-time smoke tests pass for both — they only fire on a real user turn, which is why they slipped through the earlier PRs.

## Bug A — scout calls `search_agent` as a function

**Error seen in prod** (allocation `205386f8`, session `a34cd48c-...`, 23:02:25):

\`\`\`
ValueError: Tool 'search_agent' not found.
Available tools: search_agent_memory, store_agent_memory, wiki_list, wiki_search, wiki_read,
                  web_fetch, telos_..., critique_architecture, critique_safety, critique_feasibility,
                  critique_ux_dx, should_convene_council
\`\`\`

Scout's instruction read:

> Transfer to \`search_agent\` for grounded Google Search.

Gemini 3.1 Pro interpreted that ~50/50 between the correct `transfer_to_agent(agent_name='search_agent')` pattern and an invalid `search_agent(...)` function call. The session crashed on whichever turn it guessed wrong.

**Fix:** `scout.md` — make `transfer_to_agent(...)` the only pattern shown and explicitly warn against `search_agent(...)` as a function call.

## Bug B — scout_root_agent stuck on startup-time model (Flash, not Pro)

**Symptom:** admin UI configured scout to `gemini-3.1-pro-preview`, prod logs showed scout actually using `gemini-2.5-flash`.

**Root cause:** `ConfigManager.apply_model_config(root_agent)` walks `root_agent.sub_agents` (beto's tree only). The beto-owned scout sub-agent gets patched correctly. But `scout_root_agent` — the separate Agent instance used for scout-rooted sessions — is not reachable from beto's tree, so it's never touched. Its model is frozen at whatever `config_manager.get_agent_model(\"scout_agent\")` returned at module-load time, **before DB config loaded** → default \`gemini-2.5-flash\`.

Prod log evidence at `22:45:31`:

\`\`\`
Using model from config for scout_agent: gemini-2.5-flash    ← module load
Created scout root agent with 22 tools and 1 sub-agents      ← Flash baked in
\`\`\`

Then at `22:45:36`:

\`\`\`
Applied sub-agent 'scout' model: gemini-2.5-flash -> gemini-3.1-pro-preview
\`\`\`

^ This only patches the sub-agent instance, not `scout_root_agent`.

**Fix:** `apply_model_config` now iterates `ROOT_AGENTS.values()` plus the passed root, dedupes by `id()`, and patches each root's own model AND walks each root's sub_agents. Covers beto, scout_root_agent, and any future alternate roots with no further plumbing.

## Files

- `radbot/config/default_configs/instructions/scout.md` — unambiguous `transfer_to_agent` wording
- `radbot/config/settings.py` — `apply_model_config` traverses the registry

## Test plan

- [x] `tests/unit/test_agent_model_config.py` — 6/6 pass locally
- [ ] After redeploy, verify log shows `Applied root 'scout' model: gemini-2.5-flash -> gemini-3.1-pro-preview` at startup
- [ ] Open a scout session; verify scout doesn't call `search_agent(...)` as a tool; verify Google-Search-grounded answers arrive via `transfer_to_agent`
- [ ] Verify beto→scout detour still routes correctly (sub-agent path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)