### PR TITLE
fix(scout): skip TRANSFER_INSTRUCTIONS on scout-as-root

### DIFF
--- a/radbot/agent/research_agent/factory.py
+++ b/radbot/agent/research_agent/factory.py
@@ -161,8 +161,14 @@ def create_research_agent(
     # for any agent that is part of a sub_agents tree. Adding it explicitly causes
     # a "Duplicate function declaration" error from the Gemini API.
 
-    # Append completion instructions (task or transfer depending on V1/V2 mode)
-    if hasattr(adk_agent, "instruction") and adk_agent.instruction:
+    # Append completion instructions (task or transfer depending on V1/V2 mode).
+    # Root agents don't transfer — they ARE the root, the next agent on the
+    # receiving end is the user, and ADK doesn't auto-inject
+    # ``transfer_to_agent`` unless the agent has sub-agents. Appending
+    # TRANSFER_INSTRUCTIONS on a root would tell the model to call a tool
+    # that isn't registered → "Tool 'transfer_to_agent' not found" on the
+    # first turn that tries to "return control." Skip entirely for as_root.
+    if not as_root and hasattr(adk_agent, "instruction") and adk_agent.instruction:
         try:
             from google.adk.features import FeatureName, is_feature_enabled
             v2_active = not is_feature_enabled(FeatureName.V1_LLM_AGENT)


### PR DESCRIPTION
## Symptom

Scout session crashed mid-plan (alloc \`a3d702a0\`, 23:40:06) with:

\`\`\`
ValueError: Tool 'transfer_to_agent' not found.
Available tools: search_agent_memory, store_agent_memory, wiki_list, wiki_search, wiki_read,
                  grounded_search, web_fetch, telos_..., critique_..., should_convene_council
\`\`\`

The failure came AFTER a fully successful multi-turn research flow — four `grounded_search` calls returned answers with 6–11 citations each, conversation proceeded to plan-drafting — and only then did scout try to "return control" and error.

**Good news:** `grounded_search` works. The search-hop bug from #54 is fixed.

## Root cause

`radbot/agent/shared.py`'s `TRANSFER_INSTRUCTIONS` appends:

> CRITICAL RULE — Returning control:
> 1. Complete your task and compose your full text response with the results.
> 2. Then, call `transfer_to_agent(agent_name='beto')` to return control to the main agent.

The factory appended this to scout's prompt **regardless of mode**.

- **Sub-agent mode** (scout under beto): beto has sub-agents → ADK auto-injects the `transfer_to_agent` tool. Directive and tool agree. Works.
- **Root mode** (scout-as-session-root): scout has zero sub-agents (removed in #54 to fix the search hang) → ADK doesn't auto-inject the tool. But the directive still tells her to call it. First time she tries to "return control" → `ValueError: Tool 'transfer_to_agent' not found`.

## Fix

Branch on `as_root` in the factory's completion-instruction append. Root agents don't return to anyone — the next thing up in the tree is the user. Skip the append entirely when `as_root=True`.

\`\`\`diff
- if hasattr(adk_agent, "instruction") and adk_agent.instruction:
+ if not as_root and hasattr(adk_agent, "instruction") and adk_agent.instruction:
      adk_agent.instruction += TASK_FINISH_INSTRUCTIONS if v2_active else TRANSFER_INSTRUCTIONS
\`\`\`

## Verified locally

\`\`\`
scout ROOT instruction mentions transfer_to_agent: False
sub-agent scout instruction mentions transfer_to_agent: True   ← beto's tree still gets the directive
\`\`\`

## Test plan

- [x] `tests/unit/test_agent_model_config.py` — 6/6 pass
- [ ] After deploy: complete a full scout session (research → plan → Telos write) without crashes
- [ ] Verify beto→scout detour still works (sub-agent path unchanged — scout-as-subagent still has the transfer directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)