### PR TITLE
feat(mcp): exploration_update + exploration_archive tools

### DIFF
--- a/radbot/mcp_server/tools/project_tasks.py
+++ b/radbot/mcp_server/tools/project_tasks.py
@@ -162,6 +162,46 @@ def tools() -> list[mcp_types.Tool]:
                 "additionalProperties": False,
             },
         ),
+        mcp_types.Tool(
+            name="exploration_update",
+            description=(
+                "Update an exploration in place. `content` (required) "
+                "replaces the exploration's body — typically the full "
+                "5-role plan markdown, often with a `## Council Review` "
+                "trailer. Other fields shallow-merge into metadata. Pass "
+                "empty string to clear an optional field."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "content": {"type": "string"},
+                    "parent_project": {"type": "string"},
+                    "parent_milestone": {"type": "string"},
+                },
+                "required": ["ref_code", "content"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="exploration_archive",
+            description=(
+                "Archive (soft-delete) an exploration. Used when a research "
+                "thread is closed — either because the plan it captured has "
+                "been implemented or because the question is no longer "
+                "relevant. Stashes `reason` into `metadata.archived_reason`. "
+                "Never hard-deletes."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
     ]
 
 
@@ -196,6 +236,13 @@ async def call(
             arguments["parent_project"],
             arguments["topic"],
             arguments.get("notes"),
+        )]
+    if name == "exploration_update":
+        return [_do_exploration_update(arguments)]
+    if name == "exploration_archive":
+        return [_do_exploration_archive(
+            arguments["ref_code"],
+            arguments.get("reason"),
         )]
     raise KeyError(name)
 
@@ -435,4 +482,63 @@ def _do_exploration_add(
             f"Added exploration `{row.ref_code}` under `{parent_project}` — "
             f"{clean_topic!r}"
         ),
+    )
+
+
+def _do_exploration_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ref_code = arguments["ref_code"]
+    content = (arguments.get("content") or "").strip()
+    if not content:
+        return _err("`content` is required and must not be whitespace.")
+
+    meta: dict[str, Any] = {}
+    for key in ("parent_project", "parent_milestone"):
+        if key in arguments and arguments[key] is not None:
+            # Empty string → remove key via shallow JSONB merge with null.
+            meta[key] = arguments[key] if arguments[key] != "" else None
+
+    # Validate parent refs if being set (non-empty)
+    if meta.get("parent_project"):
+        _p, err = _require_project(meta["parent_project"])
+        if err is not None:
+            return err
+    if meta.get("parent_milestone"):
+        _ms, err = _require_milestone(meta["parent_milestone"])
+        if err is not None:
+            return err
+
+    row = telos_db.update_entry(
+        Section.EXPLORATIONS,
+        ref_code,
+        content=content,
+        metadata_merge=meta or None,
+    )
+    if row is None:
+        return _err(f"No exploration with ref_code `{ref_code}`.")
+    bits = ["content updated"]
+    if meta:
+        bits.append(f"metadata_merge={meta}")
+    return mcp_types.TextContent(
+        type="text",
+        text=f"Updated exploration `{ref_code}` — {' · '.join(bits)}",
+    )
+
+
+def _do_exploration_archive(
+    ref_code: str, reason: str | None
+) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ok = telos_db.archive_entry(
+        Section.EXPLORATIONS, ref_code, reason=reason or None
+    )
+    if not ok:
+        return _err(f"No exploration with ref_code `{ref_code}`.")
+    tail = f" (reason: {reason})" if reason else ""
+    return mcp_types.TextContent(
+        type="text", text=f"Archived exploration `{ref_code}`.{tail}"
     )

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -360,7 +360,7 @@ Exposes **radbot itself** as an MCP server so external clients (primarily Claude
 - **stdio**: `uv run python -m radbot.mcp_server` (local, no auth)
 - **HTTP/SSE**: `GET /mcp/sse` + `POST /mcp/messages/` mounted on the FastAPI app (bearer token)
 
-**Tool surface** (28, all returning markdown `TextContent`):
+**Tool surface** (30, all returning markdown `TextContent`):
 
 | Group | Tools |
 |---|---|
@@ -368,7 +368,7 @@ Exposes **radbot itself** as an MCP server so external clients (primarily Claude
 | Wiki (at `$RADBOT_WIKI_PATH`) | `wiki_read`, `wiki_list`, `wiki_search`, `wiki_write` (strict path sanitization) |
 | Projects (read) | `project_match(cwd)`, `project_list`, `project_get_context`, `project_list_children`, `project_set_path_patterns` |
 | Projects (mutate) | `project_create`, `project_update`, `project_archive(cascade_children?)`, `project_merge(from_ref, into_ref)` |
-| Project hierarchy (mutate) | `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add` |
+| Project hierarchy (mutate) | `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add`, `exploration_update`, `exploration_archive` |
 | Tasks / schedule | `list_tasks`, `list_reminders`, `list_scheduled_tasks` |
 | Memory | `search_memory` (Qdrant, default scope=`beto`, pass `agent_scope="all"` to widen) |
 


### PR DESCRIPTION
## Summary

The MCP bridge exposed `exploration_add` but no way to update or archive an exploration. This gap surfaced the first time we wanted to close EX1 via MCP (after the scout → Telos → Claude Code workflow it originally proposed was implemented). Only path was going through beto's full Telos tool surface (web UI), which breaks the MCP-only Claude Code lifecycle.

This PR adds two tools mirroring the existing `task_update` / `task_archive` pattern, using the same `telos_db.update_entry` / `archive_entry` primitives.

## What's new

| Tool | Signature | Purpose |
|---|---|---|
| `exploration_update` | `(ref_code, content, parent_project?, parent_milestone?)` | Replace body — typically a full 5-role plan with optional `## Council Review` trailer. Parent refs shallow-merge into metadata. |
| `exploration_archive` | `(ref_code, reason?)` | Soft-delete with optional reason; stashes in `metadata.archived_reason`. Never hard-deletes. |

Content validation matches the other mutate tools (required, non-whitespace). Empty-string clears optional metadata fields.

## Tool surface count: 28 → 30

`specs/tools.md` bumped in the same commit.

## Unblocks

- Closing EX1 cleanly (the original exploration proposing this workflow is now implemented)
- Future scout plan lifecycle: scout writes `exploration_add` → Claude Code picks it up via MCP + implements the `project_tasks` under it → flips them `done` via `task_complete` → marks the exploration `archived` via the new `exploration_archive` once the plan is fully executed

## Test plan

- [x] Both tools register cleanly in `tools()` output (9 tools total in `project_tasks.py`, was 7)
- [x] `ruff check` clean
- [ ] After deploy, use `exploration_update(ref_code='EX1', content='…')` to replace EX1's content with the scout-not-axel closure note, then `exploration_archive(ref_code='EX1', reason='…')` to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)