### PR TITLE
feat(memory): EX4 memory_class taxonomy on Qdrant points

### DIFF
--- a/radbot/memory/qdrant_memory.py
+++ b/radbot/memory/qdrant_memory.py
@@ -172,6 +172,18 @@ class QdrantMemoryService(BaseMemoryService):
                             )
                         except Exception as idx_err:
                             logger.debug("source_agent index already exists or failed: %s", idx_err)
+                        # Ensure memory_class index exists on existing collections
+                        try:
+                            self.client.create_payload_index(
+                                collection_name=self.collection_name,
+                                field_name="memory_class",
+                                field_schema=models.PayloadSchemaType.KEYWORD,
+                            )
+                            logger.info(
+                                "Created memory_class index on existing collection"
+                            )
+                        except Exception as idx_err:
+                            logger.debug("memory_class index already exists or failed: %s", idx_err)
                         return
 
                 # Create the collection
@@ -208,6 +220,12 @@ class QdrantMemoryService(BaseMemoryService):
                 self.client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name="source_agent",
+                    field_schema=models.PayloadSchemaType.KEYWORD,
+                )
+
+                self.client.create_payload_index(
+                    collection_name=self.collection_name,
+                    field_name="memory_class",
                     field_schema=models.PayloadSchemaType.KEYWORD,
                 )
 
@@ -372,12 +390,17 @@ class QdrantMemoryService(BaseMemoryService):
         current_time = datetime.datetime.now().isoformat()
 
         # Create basic payload
+        # memory_class is the EX4 taxonomy tag (episodic/implicit/explicit) —
+        # orthogonal to memory_type (which remains a content-category).
         payload = {
             "user_id": user_id,
             "text": text,
             "timestamp": current_time,
             "memory_type": (
                 metadata.get("memory_type", "general") if metadata else "general"
+            ),
+            "memory_class": (
+                metadata.get("memory_class", "episodic") if metadata else "episodic"
             ),
         }
 
@@ -446,6 +469,23 @@ class QdrantMemoryService(BaseMemoryService):
                         )
                     )
 
+                if "memory_class" in filter_conditions:
+                    mc_val = filter_conditions["memory_class"]
+                    if isinstance(mc_val, (list, tuple, set)):
+                        must_conditions.append(
+                            models.FieldCondition(
+                                key="memory_class",
+                                match=models.MatchAny(any=list(mc_val)),
+                            )
+                        )
+                    else:
+                        must_conditions.append(
+                            models.FieldCondition(
+                                key="memory_class",
+                                match=models.MatchValue(value=mc_val),
+                            )
+                        )
+
                 if "min_timestamp" in filter_conditions:
                     must_conditions.append(
                         models.FieldCondition(
@@ -481,10 +521,13 @@ class QdrantMemoryService(BaseMemoryService):
                 payload = result.payload
 
                 # Create a result entry with the score
+                # Backward compat: points written before memory_class existed
+                # default to 'episodic' per EX4.
                 entry = {
                     "text": payload.get("text", ""),
                     "relevance_score": result.score,
                     "memory_type": payload.get("memory_type", "general"),
+                    "memory_class": payload.get("memory_class", "episodic"),
                     "timestamp": payload.get("timestamp"),
                 }
 

--- a/radbot/tools/memory/agent_memory_factory.py
+++ b/radbot/tools/memory/agent_memory_factory.py
@@ -7,10 +7,12 @@ polluting other agents' memory spaces.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
+
+from radbot.tools.memory.memory_tools import VALID_MEMORY_CLASSES
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +64,7 @@ def create_agent_memory_tools(agent_name: str) -> List[FunctionTool]:
         time_window_days: Optional[int] = None,
         tool_context: Optional[ToolContext] = None,
         memory_type: Optional[str] = None,
+        memory_class: Optional[Union[str, List[str]]] = None,
     ) -> Dict[str, Any]:
         """
         Search memories stored by this agent.
@@ -103,6 +106,13 @@ def create_agent_memory_tools(agent_name: str) -> List[FunctionTool]:
             if memory_type and memory_type.lower() != "all":
                 filter_conditions["memory_type"] = memory_type
 
+            if memory_class:
+                if isinstance(memory_class, str):
+                    if memory_class.lower() != "all":
+                        filter_conditions["memory_class"] = memory_class
+                else:
+                    filter_conditions["memory_class"] = list(memory_class)
+
             results = memory_service.search_memory(
                 app_name="beto",
                 user_id=user_id,
@@ -129,6 +139,7 @@ def create_agent_memory_tools(agent_name: str) -> List[FunctionTool]:
                         {
                             "text": entry.get("text", ""),
                             "type": entry.get("memory_type", "unknown"),
+                            "memory_class": entry.get("memory_class", "episodic"),
                             "relevance_score": entry.get("relevance_score", 0),
                             "date": date_str,
                         }
@@ -156,6 +167,7 @@ def create_agent_memory_tools(agent_name: str) -> List[FunctionTool]:
     def store_agent_memory(
         information: str,
         memory_type: str = "important_fact",
+        memory_class: str = "explicit",
         tool_context: Optional[ToolContext] = None,
     ) -> Dict[str, Any]:
         """
@@ -180,8 +192,18 @@ def create_agent_memory_tools(agent_name: str) -> List[FunctionTool]:
                     "error_message": "Memory service not available.",
                 }
 
+            if memory_class not in VALID_MEMORY_CLASSES:
+                return {
+                    "status": "error",
+                    "error_message": (
+                        f"Invalid memory_class '{memory_class}'. "
+                        f"Must be one of: {sorted(VALID_MEMORY_CLASSES)}"
+                    ),
+                }
+
             metadata = {
                 "memory_type": memory_type,
+                "memory_class": memory_class,
                 "source_agent": agent_name,
             }
 

--- a/radbot/tools/memory/memory_tools.py
+++ b/radbot/tools/memory/memory_tools.py
@@ -6,12 +6,15 @@ These tools allow agents to interact with the memory system.
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from google.adk.tools.tool_context import ToolContext
 from qdrant_client import models
 
 logger = logging.getLogger(__name__)
+
+# EX4 taxonomy — the only valid values for the `memory_class` payload tag.
+VALID_MEMORY_CLASSES = {"episodic", "implicit", "explicit"}
 
 
 def _get_memory_service_and_user_id(tool_context):
@@ -75,6 +78,7 @@ def search_past_conversations(
     time_window_days: Optional[int] = None,
     tool_context: Optional[ToolContext] = None,
     memory_type: Optional[str] = None,
+    memory_class: Optional[Union[str, List[str]]] = None,
     limit: Optional[int] = None,
     return_stats_only: bool = False,
 ) -> Dict[str, Any]:
@@ -120,6 +124,15 @@ def search_past_conversations(
         # Add memory_type filter if specified and not "all"
         if memory_type and memory_type.lower() != "all":
             filter_conditions["memory_type"] = memory_type
+
+        # Add memory_class filter (EX4 taxonomy: episodic/implicit/explicit).
+        # Accepts a single class or a list. "all" disables filtering.
+        if memory_class:
+            if isinstance(memory_class, str):
+                if memory_class.lower() != "all":
+                    filter_conditions["memory_class"] = memory_class
+            else:
+                filter_conditions["memory_class"] = list(memory_class)
 
         # Handle return_stats_only to provide memory statistics
         if return_stats_only:
@@ -199,6 +212,8 @@ def search_past_conversations(
                 # Basic memory info
                 memory_text = entry.get("text", "")
                 memory_type = entry.get("memory_type", "unknown")
+                # Backward compat: untagged points default to episodic.
+                memory_class_val = entry.get("memory_class", "episodic")
                 relevance = entry.get("relevance_score", 0)
 
                 # Format timestamp if present
@@ -216,6 +231,7 @@ def search_past_conversations(
                 formatted_entry = {
                     "text": memory_text,
                     "type": memory_type,
+                    "memory_class": memory_class_val,
                     "relevance_score": relevance,
                     "date": date_str,
                 }
@@ -254,6 +270,7 @@ def search_past_conversations(
 def store_important_information(
     information: str,
     memory_type: str = "important_fact",
+    memory_class: str = "explicit",
     metadata: Optional[Dict[str, Any]] = None,
     tool_context: Optional[ToolContext] = None,
 ) -> Dict[str, Any]:
@@ -265,7 +282,12 @@ def store_important_information(
 
     Args:
         information: The text information to store
-        memory_type: Type of memory (e.g., 'important_fact', 'user_preference')
+        memory_type: Content category (e.g., 'important_fact', 'user_preference')
+        memory_class: EX4 taxonomy tag — 'episodic' (things that happened),
+            'implicit' (inferred preferences, agent-written), or 'explicit'
+            (facts stated directly by the user). Defaults to 'explicit' since
+            this tool is typically invoked when the user states something
+            durable.
         metadata: Additional metadata to store with the information
         tool_context: Tool context for accessing memory service
 
@@ -277,9 +299,19 @@ def store_important_information(
         if not memory_service:
             return {"status": "error", "error_message": "Memory service not available."}
 
+        if memory_class not in VALID_MEMORY_CLASSES:
+            return {
+                "status": "error",
+                "error_message": (
+                    f"Invalid memory_class '{memory_class}'. "
+                    f"Must be one of: {sorted(VALID_MEMORY_CLASSES)}"
+                ),
+            }
+
         # Create metadata if not provided
         metadata = metadata or {}
         metadata["memory_type"] = memory_type
+        metadata["memory_class"] = memory_class
 
         # Create the memory point
         point = memory_service._create_memory_point(
@@ -293,7 +325,10 @@ def store_important_information(
 
         return {
             "status": "success",
-            "message": f"Successfully stored information as {memory_type}.",
+            "message": (
+                f"Successfully stored information as {memory_type} "
+                f"(class={memory_class})."
+            ),
         }
 
     except Exception as e:

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -57,6 +57,18 @@ Semantic memory via `radbot/memory/enhanced_memory/`.
 - **Embedding model**: `gemini-embedding-001` with `output_dimensionality=768`
 - **Scoping**: Per-agent memory via `source_agent` tag (see `create_agent_memory_tools()`)
 - **User ID**: Fixed `"web_user"` across all sessions (single-user system)
+- **Indexed payload fields**: `user_id`, `timestamp`, `memory_type`, `source_agent`, `memory_class` (all KEYWORD except `timestamp` which is DATETIME)
+
+### Memory type taxonomy (EX4)
+
+Each Qdrant point carries two orthogonal tags:
+
+- `memory_type` — content category (`conversation_turn`, `user_query`, `important_fact`, `user_preference`, `general`, …). Used by existing filters.
+- `memory_class` — trust/decay taxonomy: `episodic` (things that happened; default), `implicit` (inferred, agent-written), `explicit` (user-stated, durable).
+
+Default at write time: `_create_memory_point` stamps `memory_class="episodic"` when metadata omits it. `store_important_information` / `store_agent_memory` default to `"explicit"` since they're user-authorized writes. Points written before EX4 have no `memory_class` in payload; `search_memory` treats them as `episodic` on read, so no migration is required.
+
+`search_memory` accepts `filter_conditions["memory_class"]` as either a single string (MatchValue) or a list (MatchAny). Agent-facing search tools (`search_past_conversations`, `search_agent_memory`) accept a `memory_class` parameter (str or list, `"all"` disables the filter).
 
 ## Credential Store
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -56,10 +56,10 @@ Created per-agent via `create_agent_memory_tools(agent_name)`. Scoped by `source
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `search_agent_memory` | `query`, `max_results`, `time_window_days`, `memory_type` | Search this agent's scoped memories |
-| `store_agent_memory` | `information`, `memory_type` | Store memory in agent's namespace |
+| `search_agent_memory` | `query`, `max_results`, `time_window_days`, `memory_type`, `memory_class` | Search this agent's scoped memories |
+| `store_agent_memory` | `information`, `memory_type`, `memory_class` | Store memory in agent's namespace |
 
-Global variants (`search_past_conversations`, `store_important_information`) exist but are not currently assigned to any agent.
+`memory_class` (EX4 taxonomy): `episodic` / `implicit` / `explicit` — orthogonal to `memory_type`. See `specs/storage.md` § Memory type taxonomy. Defaults: `explicit` on store (user-authorized), unfiltered on search. Global variants (`search_past_conversations`, `store_important_information`) accept the same parameters.
 
 ### telos project hierarchy — `tools/telos/telos_tools.py`
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -220,6 +220,89 @@ class TestQdrantMemoryService:
             assert results[0]["text"] == "Test memory"
             assert results[0]["memory_type"] == "test"
             assert results[0]["relevance_score"] == 0.95
+            # Old point with no memory_class in payload defaults to episodic.
+            assert results[0]["memory_class"] == "episodic"
+
+    @patch("radbot.memory.qdrant_memory.QdrantClient")
+    @patch("radbot.memory.qdrant_memory.get_embedding_model")
+    def test_create_memory_point_tags_memory_class(self, mock_get_model, mock_client):
+        """_create_memory_point should write memory_class into the payload."""
+        mock_model = MagicMock()
+        mock_model.vector_size = 768
+        mock_get_model.return_value = mock_model
+
+        mock_client_instance = MagicMock()
+        mock_client.return_value = mock_client_instance
+        collections_response = MagicMock()
+        collections_response.collections = []
+        mock_client_instance.get_collections.return_value = collections_response
+
+        with patch("radbot.memory.qdrant_memory.embed_text") as mock_embed:
+            mock_embed.return_value = [0.0] * 768
+            service = QdrantMemoryService(collection_name="t")
+
+            # Explicit class propagates
+            point = service._create_memory_point(
+                user_id="u",
+                text="wife is allergic to shellfish",
+                metadata={"memory_type": "important_fact", "memory_class": "explicit"},
+            )
+            assert point.payload["memory_class"] == "explicit"
+
+            # Missing class defaults to episodic
+            point2 = service._create_memory_point(
+                user_id="u", text="hello", metadata=None
+            )
+            assert point2.payload["memory_class"] == "episodic"
+
+    @patch("radbot.memory.qdrant_memory.QdrantClient")
+    @patch("radbot.memory.qdrant_memory.get_embedding_model")
+    def test_search_memory_builds_memory_class_filter(
+        self, mock_get_model, mock_client
+    ):
+        """filter_conditions['memory_class'] becomes a FieldCondition on the query."""
+        mock_model = MagicMock()
+        mock_model.vector_size = 768
+        mock_get_model.return_value = mock_model
+
+        mock_client_instance = MagicMock()
+        mock_client.return_value = mock_client_instance
+        collections_response = MagicMock()
+        collections_response.collections = []
+        mock_client_instance.get_collections.return_value = collections_response
+
+        mock_query_response = MagicMock()
+        mock_query_response.points = []
+        mock_client_instance.query_points.return_value = mock_query_response
+
+        with patch("radbot.memory.qdrant_memory.embed_text") as mock_embed:
+            mock_embed.return_value = [0.0] * 768
+            service = QdrantMemoryService(collection_name="t")
+
+            # Single class -> MatchValue
+            service.search_memory(
+                app_name="beto",
+                user_id="u",
+                query="q",
+                filter_conditions={"memory_class": "explicit"},
+            )
+            qf = mock_client_instance.query_points.call_args.kwargs["query_filter"]
+            keys = [c.key for c in qf.must]
+            assert "memory_class" in keys
+            mc_cond = next(c for c in qf.must if c.key == "memory_class")
+            assert mc_cond.match.value == "explicit"
+
+            # List of classes -> MatchAny
+            mock_client_instance.query_points.reset_mock()
+            service.search_memory(
+                app_name="beto",
+                user_id="u",
+                query="q",
+                filter_conditions={"memory_class": ["explicit", "implicit"]},
+            )
+            qf2 = mock_client_instance.query_points.call_args.kwargs["query_filter"]
+            mc_cond2 = next(c for c in qf2.must if c.key == "memory_class")
+            assert list(mc_cond2.match.any) == ["explicit", "implicit"]
 
 
 class TestMemoryTools:
@@ -285,12 +368,147 @@ class TestMemoryTools:
 
         # Verify result
         assert result["status"] == "success"
+        # Default memory_class for store_important_information is 'explicit'.
         mock_memory_service._create_memory_point.assert_called_once_with(
             user_id="user123",
             text="Important test fact",
-            metadata={"memory_type": "important_fact"},
+            metadata={"memory_type": "important_fact", "memory_class": "explicit"},
         )
         mock_memory_service.client.upsert.assert_called_once()
+
+    def test_store_important_information_with_memory_class(self):
+        """store_important_information should pass memory_class through metadata."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_context._invocation_context = mock_invocation_ctx
+        mock_memory_service._create_memory_point.return_value = MagicMock()
+
+        result = store_important_information(
+            information="User runs deploys on Fridays",
+            memory_type="user_preference",
+            memory_class="implicit",
+            tool_context=mock_context,
+        )
+
+        assert result["status"] == "success"
+        mock_memory_service._create_memory_point.assert_called_once_with(
+            user_id="user123",
+            text="User runs deploys on Fridays",
+            metadata={"memory_type": "user_preference", "memory_class": "implicit"},
+        )
+
+    def test_store_important_information_rejects_invalid_memory_class(self):
+        """Invalid memory_class values should return a structured error."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_context._invocation_context = mock_invocation_ctx
+
+        result = store_important_information(
+            information="whatever",
+            memory_class="archival",  # not in the EX4 taxonomy
+            tool_context=mock_context,
+        )
+
+        assert result["status"] == "error"
+        assert "memory_class" in result["error_message"]
+        mock_memory_service._create_memory_point.assert_not_called()
+
+    def test_search_past_conversations_passes_memory_class_filter(self):
+        """memory_class arg should show up in the filter_conditions passed to the service."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_invocation_ctx.app_name = "beto"
+        mock_context._invocation_context = mock_invocation_ctx
+
+        mock_memory_service.search_memory.return_value = []
+
+        search_past_conversations(
+            query="kids' allergies",
+            memory_class="explicit",
+            tool_context=mock_context,
+        )
+
+        call_kwargs = mock_memory_service.search_memory.call_args.kwargs
+        assert call_kwargs["filter_conditions"]["memory_class"] == "explicit"
+
+    def test_search_past_conversations_memory_class_list(self):
+        """memory_class can be a list for multi-class filtering (explicit+implicit)."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_invocation_ctx.app_name = "beto"
+        mock_context._invocation_context = mock_invocation_ctx
+        mock_memory_service.search_memory.return_value = []
+
+        search_past_conversations(
+            query="preferences",
+            memory_class=["explicit", "implicit"],
+            tool_context=mock_context,
+        )
+
+        call_kwargs = mock_memory_service.search_memory.call_args.kwargs
+        assert call_kwargs["filter_conditions"]["memory_class"] == [
+            "explicit",
+            "implicit",
+        ]
+
+    def test_search_past_conversations_memory_class_all_disables_filter(self):
+        """memory_class='all' should not add a filter."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_invocation_ctx.app_name = "beto"
+        mock_context._invocation_context = mock_invocation_ctx
+        mock_memory_service.search_memory.return_value = []
+
+        search_past_conversations(
+            query="anything",
+            memory_class="all",
+            tool_context=mock_context,
+        )
+
+        call_kwargs = mock_memory_service.search_memory.call_args.kwargs
+        assert "memory_class" not in call_kwargs["filter_conditions"]
+
+    def test_search_past_conversations_untagged_points_default_to_episodic(self):
+        """Results missing memory_class should surface as 'episodic' for backward compat."""
+        mock_context = MagicMock()
+        mock_memory_service = MagicMock()
+        mock_invocation_ctx = MagicMock()
+        mock_invocation_ctx.memory_service = mock_memory_service
+        mock_invocation_ctx.user_id = "user123"
+        mock_invocation_ctx.app_name = "beto"
+        mock_context._invocation_context = mock_invocation_ctx
+
+        # Simulate an old point with no memory_class field.
+        mock_memory_service.search_memory.return_value = [
+            {
+                "text": "old memory from before the taxonomy existed",
+                "memory_type": "conversation_turn",
+                "relevance_score": 0.8,
+                "timestamp": "2024-06-01T00:00:00",
+            }
+        ]
+
+        result = search_past_conversations(
+            query="anything", tool_context=mock_context
+        )
+
+        assert result["status"] == "success"
+        assert result["memories"][0]["memory_class"] == "episodic"
 
 
 # Restore the original PayloadSchemaType at the end of tests


### PR DESCRIPTION
## Summary
- Implements EX4 (memory type taxonomy) — adds an orthogonal `memory_class` payload field to Qdrant points with values `episodic` / `implicit` / `explicit`.
- `_create_memory_point` tags writes (default `episodic`); `search_memory` accepts single-value or list filters on `memory_class`; read path defaults untagged points to `episodic` for backward compat (no migration).
- `store_important_information` / `store_agent_memory` gain `memory_class` (default `explicit` — user-authorized writes); `search_past_conversations` / `search_agent_memory` gain `memory_class` (str or list; `"all"` disables).
- New payload index on `memory_class`; `specs/storage.md` + `specs/tools.md` updated.

### Design note
`memory_class` is a *new* field, orthogonal to the existing `memory_type` (which remains a content-category: `conversation_turn`, `user_query`, `important_fact`, …). Collapsing them would break existing filters and data semantics.

## Test plan
- [x] `tests/unit/test_memory.py` — 17 passing (7 new: tagging on write, default on read, filter passthrough, list filter, `"all"` disables, validation rejection, service-level filter building)
- [x] `tests/unit/test_enhanced_memory.py` — 7 passing (unchanged)
- [ ] Live smoke: store an `explicit` fact via beto, retrieve via `search_past_conversations(memory_class="explicit")`

## Specs updated
- `specs/storage.md` § Qdrant — added memory type taxonomy section + payload index list
- `specs/tools.md` § memory — added `memory_class` to parameter lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)