### PR TITLE
feat(proactive): EX3 Dream + Heartbeat primitives

### DIFF
--- a/radbot/tools/heartbeat/__init__.py
+++ b/radbot/tools/heartbeat/__init__.py
@@ -1,0 +1,6 @@
+"""Heartbeat — proactive digest assembly and delivery."""
+
+from radbot.tools.heartbeat.delivery import deliver_digest
+from radbot.tools.heartbeat.digest import assemble_digest
+
+__all__ = ["assemble_digest", "deliver_digest"]

--- a/radbot/tools/heartbeat/delivery.py
+++ b/radbot/tools/heartbeat/delivery.py
@@ -8,7 +8,6 @@ behind the same `deliver_digest()` signature later.
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/radbot/tools/heartbeat/delivery.py
+++ b/radbot/tools/heartbeat/delivery.py
@@ -1,0 +1,67 @@
+"""Heartbeat delivery — pluggable transport for the digest.
+
+Default channel is ntfy (per EX3 open-question resolution). Transport
+is intentionally a thin adapter so email / other channels can be added
+behind the same `deliver_digest()` signature later.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def deliver_digest(
+    markdown: str,
+    *,
+    title: str = "Heartbeat",
+    tags: str = "sunrise,robot",
+) -> bool:
+    """Deliver a digest via the configured proactive channel.
+
+    Returns True if delivered, False otherwise (including the "nothing
+    worth bothering you with" empty-digest case).
+    """
+    if not markdown:
+        logger.info("Heartbeat: digest empty, nothing to deliver")
+        return False
+
+    try:
+        from radbot.tools.ntfy.ntfy_client import get_ntfy_client
+
+        client = get_ntfy_client()
+    except Exception as e:
+        logger.warning("Heartbeat: ntfy client unavailable: %s", e)
+        client = None
+
+    if client is None:
+        logger.info("Heartbeat: no delivery channel configured, skipping")
+        return False
+
+    # ntfy truncates at 2000 chars inside publish(), but signal a soft cap too.
+    body = markdown[:2000]
+    try:
+        result = await client.publish(title=title, message=body, tags=tags)
+    except Exception as e:
+        logger.warning("Heartbeat: ntfy publish raised: %s", e)
+        return False
+
+    if result is None:
+        return False
+
+    # Record in the unified notifications table so it surfaces in the UI.
+    try:
+        from radbot.tools.notifications.db import create_notification
+
+        create_notification(
+            type="heartbeat",
+            title=title,
+            message=markdown[:4000],
+            metadata={"channel": "ntfy"},
+        )
+    except Exception as e:
+        logger.debug("Heartbeat: notifications write failed (non-fatal): %s", e)
+
+    return True

--- a/radbot/tools/heartbeat/digest.py
+++ b/radbot/tools/heartbeat/digest.py
@@ -129,7 +129,7 @@ def _render_tasks(tasks: List[Dict[str, Any]]) -> str:
     lines = ["## Tasks"]
     for t in tasks[:15]:
         tag = " ⚠ overdue" if t.get("overdue") else (f" (due {t['due']})" if t.get("due") else "")
-        lines.append(f"- **{t.get('ref_code','')}**{tag} — {t.get('content','')}")
+        lines.append(f"- **{t.get('ref_code', '')}**{tag} — {t.get('content', '')}")
     return "\n".join(lines) + "\n"
 
 
@@ -151,7 +151,7 @@ def _render_reminders(rems: List[Dict[str, Any]]) -> str:
     lines = ["## Reminders"]
     for r in rems[:10]:
         at = r["remind_at"].strftime("%H:%M") if isinstance(r.get("remind_at"), datetime) else "?"
-        lines.append(f"- {at} — {r.get('message','')}")
+        lines.append(f"- {at} — {r.get('message', '')}")
     return "\n".join(lines) + "\n"
 
 
@@ -161,7 +161,7 @@ def _render_alerts(alerts: List[Dict[str, Any]]) -> str:
     lines = ["## Alerts"]
     for a in alerts[:10]:
         lines.append(
-            f"- [{a.get('severity','?')}] {a.get('alertname','?')} @ {a.get('instance','?')}"
+            f"- [{a.get('severity', '?')}] {a.get('alertname', '?')} @ {a.get('instance', '?')}"
         )
     return "\n".join(lines) + "\n"
 

--- a/radbot/tools/heartbeat/digest.py
+++ b/radbot/tools/heartbeat/digest.py
@@ -1,0 +1,208 @@
+"""Heartbeat digest assembly — markdown brief from the day's proactive sources.
+
+Content assembly is intentionally decoupled from transport (see
+`delivery.py`). Each section is optional and degrades silently if its
+data source is unavailable (e.g. calendar unauth, DB down).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    try:
+        s = str(value)
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def _fetch_tasks(horizon: datetime) -> List[Dict[str, Any]]:
+    try:
+        from radbot.tools.telos.db import list_section
+        from radbot.tools.telos.models import Section
+
+        entries = list_section(Section.PROJECT_TASKS, status="active")
+    except Exception as e:
+        logger.debug("Heartbeat: telos unavailable: %s", e)
+        return []
+
+    out: List[Dict[str, Any]] = []
+    today = date.today()
+    for e in entries:
+        meta = getattr(e, "metadata", None) or {}
+        if not isinstance(meta, dict):
+            meta = {}
+        due_raw = meta.get("due_date")
+        due: Optional[date] = None
+        if due_raw:
+            parsed = _parse_ts(due_raw)
+            if parsed:
+                due = parsed.date()
+            else:
+                try:
+                    due = date.fromisoformat(str(due_raw)[:10])
+                except Exception:
+                    due = None
+        task_status = str(meta.get("task_status", "")).lower()
+        if task_status in {"done", "completed"}:
+            continue
+        if due is None or due <= today:
+            out.append(
+                {
+                    "ref_code": getattr(e, "ref_code", ""),
+                    "content": getattr(e, "content", ""),
+                    "due": due.isoformat() if due else None,
+                    "overdue": bool(due and due < today),
+                }
+            )
+    return out
+
+
+def _fetch_calendar(horizon: datetime) -> List[Dict[str, Any]]:
+    try:
+        from radbot.tools.calendar.calendar_tools import get_calendar_manager
+
+        mgr = get_calendar_manager()
+        now = datetime.utcnow()
+        events = mgr.list_upcoming_events(time_min=now, time_max=horizon.replace(tzinfo=None), max_results=20)
+        if isinstance(events, dict) and events.get("error"):
+            return []
+        return list(events or [])
+    except Exception as e:
+        logger.debug("Heartbeat: calendar unavailable: %s", e)
+        return []
+
+
+def _fetch_reminders(horizon: datetime) -> List[Dict[str, Any]]:
+    try:
+        from radbot.tools.reminders.db import list_reminders
+
+        pending = list_reminders(status="pending") or []
+    except Exception as e:
+        logger.debug("Heartbeat: reminders unavailable: %s", e)
+        return []
+    out: List[Dict[str, Any]] = []
+    for r in pending:
+        remind_at = _parse_ts(r.get("remind_at"))
+        if remind_at and remind_at <= horizon:
+            out.append({"message": r.get("message", ""), "remind_at": remind_at})
+    return out
+
+
+def _fetch_alerts() -> List[Dict[str, Any]]:
+    try:
+        from radbot.tools.alertmanager.db import list_alerts
+
+        received = list_alerts(status="received", limit=20) or []
+    except Exception as e:
+        logger.debug("Heartbeat: alerts unavailable: %s", e)
+        return []
+    return received
+
+
+def _fetch_overnight_scheduler() -> List[Dict[str, Any]]:
+    try:
+        from radbot.tools.scheduler.db import get_undelivered_results
+
+        return get_undelivered_results() or []
+    except Exception as e:
+        logger.debug("Heartbeat: scheduler results unavailable: %s", e)
+        return []
+
+
+def _render_tasks(tasks: List[Dict[str, Any]]) -> str:
+    if not tasks:
+        return "## Tasks\n_No items_\n"
+    lines = ["## Tasks"]
+    for t in tasks[:15]:
+        tag = " ⚠ overdue" if t.get("overdue") else (f" (due {t['due']})" if t.get("due") else "")
+        lines.append(f"- **{t.get('ref_code','')}**{tag} — {t.get('content','')}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_calendar(events: List[Dict[str, Any]]) -> str:
+    if not events:
+        return "## Calendar\n_No items_\n"
+    lines = ["## Calendar"]
+    for ev in events[:10]:
+        summary = ev.get("summary", "(no title)")
+        start = ev.get("start") or {}
+        when = start.get("dateTime") or start.get("date") or "?"
+        lines.append(f"- {when} — {summary}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_reminders(rems: List[Dict[str, Any]]) -> str:
+    if not rems:
+        return "## Reminders\n_No items_\n"
+    lines = ["## Reminders"]
+    for r in rems[:10]:
+        at = r["remind_at"].strftime("%H:%M") if isinstance(r.get("remind_at"), datetime) else "?"
+        lines.append(f"- {at} — {r.get('message','')}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_alerts(alerts: List[Dict[str, Any]]) -> str:
+    if not alerts:
+        return "## Alerts\n_No items_\n"
+    lines = ["## Alerts"]
+    for a in alerts[:10]:
+        lines.append(
+            f"- [{a.get('severity','?')}] {a.get('alertname','?')} @ {a.get('instance','?')}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_overnight(rows: List[Dict[str, Any]]) -> str:
+    if not rows:
+        return "## Overnight Activity\n_No items_\n"
+    lines = ["## Overnight Activity"]
+    for row in rows[:10]:
+        name = row.get("task_name", "?")
+        resp = (row.get("response") or "")[:120].replace("\n", " ")
+        lines.append(f"- **{name}** — {resp}")
+    return "\n".join(lines) + "\n"
+
+
+async def assemble_digest(*, horizon_hours: int = 24) -> str:
+    """Assemble the morning brief as markdown.
+
+    Returns an empty string if every section is empty (nothing worth
+    bothering the user with — the "should I bother the user" decision).
+    """
+    now = datetime.now(timezone.utc)
+    horizon = now + timedelta(hours=horizon_hours)
+
+    tasks = _fetch_tasks(horizon)
+    events = _fetch_calendar(horizon)
+    reminders = _fetch_reminders(horizon)
+    alerts = _fetch_alerts()
+    overnight = _fetch_overnight_scheduler()
+
+    if not (tasks or events or reminders or alerts or overnight):
+        return ""
+
+    header = f"# Heartbeat — {now.strftime('%a %Y-%m-%d')}\n\n"
+    body = "\n".join(
+        [
+            _render_tasks(tasks),
+            _render_calendar(events),
+            _render_reminders(reminders),
+            _render_alerts(alerts),
+            _render_overnight(overnight),
+        ]
+    )
+    return header + body

--- a/radbot/tools/memory/memory_consolidation.py
+++ b/radbot/tools/memory/memory_consolidation.py
@@ -1,0 +1,269 @@
+"""Dream — scheduled memory consolidation over Qdrant.
+
+Runs periodically (via scheduler defaults) to:
+  * scan recent memory points,
+  * cluster near-duplicates by cosine similarity over already-stored vectors
+    (no re-embedding),
+  * write one `memory_type="consolidated"` point per cluster referencing the
+    originals via `merged_from`,
+  * mark original duplicates with `archived=true` (soft archive — never
+    delete, keep for audit),
+  * surface promotion *candidates* (high-signal points) without touching
+    durable storage.
+
+eTAMP safety: points flagged `trust="low"` or with `source` in
+{"alert","webhook"} are NEVER eligible for promotion candidacy, and
+promotion itself is gated behind an explicit `promote=True` flag which
+is intentionally a no-op in this first cut — promotion requires user
+confirmation via a separate (not-yet-built) flow.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+SIMILARITY_THRESHOLD = 0.97
+LOW_TRUST_SOURCES = {"alert", "webhook"}
+
+
+def _cosine(a: List[float], b: List[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _payload_is_low_trust(payload: Dict[str, Any]) -> bool:
+    if not payload:
+        return False
+    if str(payload.get("trust", "")).lower() == "low":
+        return True
+    if str(payload.get("source", "")).lower() in LOW_TRUST_SOURCES:
+        return True
+    return False
+
+
+def _group_key(payload: Dict[str, Any]) -> str:
+    return str(payload.get("source_agent") or payload.get("memory_type") or "_")
+
+
+def _cluster(points: List[Any]) -> List[List[Any]]:
+    """Greedy single-link cluster over cosine similarity ≥ threshold.
+
+    Each `point` is expected to have `.id`, `.vector`, `.payload`.
+    """
+    clusters: List[List[Any]] = []
+    for p in points:
+        vec = getattr(p, "vector", None)
+        if not vec:
+            continue
+        placed = False
+        for cluster in clusters:
+            head_vec = getattr(cluster[0], "vector", None)
+            if head_vec and _cosine(vec, head_vec) >= SIMILARITY_THRESHOLD:
+                cluster.append(p)
+                placed = True
+                break
+        if not placed:
+            clusters.append([p])
+    return clusters
+
+
+def _consolidated_payload(cluster: List[Any]) -> Dict[str, Any]:
+    head = cluster[0]
+    head_payload = dict(getattr(head, "payload", {}) or {})
+    merged_from = [str(getattr(p, "id", "")) for p in cluster]
+    texts = [str((getattr(p, "payload", {}) or {}).get("text", "")) for p in cluster]
+    # Keep the longest textual content as the canonical consolidated text.
+    canonical = max(texts, key=len) if texts else ""
+    return {
+        "text": canonical,
+        "memory_type": "consolidated",
+        "source_agent": head_payload.get("source_agent"),
+        "user_id": head_payload.get("user_id"),
+        "merged_from": merged_from,
+        "merged_count": len(cluster),
+        "promoted": False,
+        "consolidated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _get_memory_service() -> Optional[Any]:
+    """Lazy singleton accessor — returns None if Qdrant is unavailable."""
+    try:
+        from radbot.memory.qdrant_memory import QdrantMemoryService
+
+        return QdrantMemoryService()
+    except Exception as e:  # pragma: no cover - infra failure
+        logger.warning("Dream: memory service unavailable: %s", e)
+        return None
+
+
+async def run_dream(
+    *,
+    lookback_hours: int = 24,
+    promote: bool = False,
+    dry_run: bool = False,
+    memory_service: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Run a single Dream pass.
+
+    Args:
+        lookback_hours: scan window for episodic points.
+        promote: intentionally a no-op — promotion requires user confirmation
+            (eTAMP). If True, promotion *candidates* are still only returned,
+            not written to durable storage.
+        dry_run: compute clusters without writing to Qdrant.
+        memory_service: injectable for tests.
+
+    Returns:
+        Counts dict with keys: scanned, clusters, consolidated, archived,
+        promotion_candidates, skipped_low_trust.
+    """
+    svc = memory_service or _get_memory_service()
+    if svc is None:
+        return {
+            "scanned": 0,
+            "clusters": 0,
+            "consolidated": 0,
+            "archived": 0,
+            "promotion_candidates": 0,
+            "skipped_low_trust": 0,
+            "status": "skipped",
+        }
+
+    from qdrant_client import models as qmodels  # local import keeps module importable without qdrant
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=lookback_hours)
+
+    scroll_filter = qmodels.Filter(
+        must=[
+            qmodels.FieldCondition(
+                key="timestamp",
+                range=qmodels.DatetimeRange(gte=cutoff),
+            ),
+        ],
+        must_not=[
+            qmodels.FieldCondition(
+                key="memory_type",
+                match=qmodels.MatchValue(value="consolidated"),
+            ),
+            qmodels.FieldCondition(
+                key="archived",
+                match=qmodels.MatchValue(value=True),
+            ),
+        ],
+    )
+
+    points: List[Any] = []
+    offset = None
+    while True:
+        batch, offset = svc.client.scroll(
+            collection_name=svc.collection_name,
+            scroll_filter=scroll_filter,
+            limit=256,
+            with_payload=True,
+            with_vectors=True,
+            offset=offset,
+        )
+        if not batch:
+            break
+        points.extend(batch)
+        if offset is None:
+            break
+
+    scanned = len(points)
+    skipped_low_trust = 0
+
+    # Group by source_agent so we never cross-consolidate across scopes.
+    groups: Dict[str, List[Any]] = {}
+    for p in points:
+        payload = getattr(p, "payload", {}) or {}
+        groups.setdefault(_group_key(payload), []).append(p)
+
+    consolidated_count = 0
+    archived_count = 0
+    cluster_count = 0
+    promotion_candidates: List[str] = []
+
+    for _group, members in groups.items():
+        clusters = _cluster(members)
+        for cluster in clusters:
+            cluster_count += 1
+            if len(cluster) < 2:
+                # Single-point "cluster" — candidate for promotion only,
+                # but not consolidated.
+                only = cluster[0]
+                payload = getattr(only, "payload", {}) or {}
+                if _payload_is_low_trust(payload):
+                    skipped_low_trust += 1
+                    continue
+                if payload.get("memory_type") in {"important", "explicit"}:
+                    promotion_candidates.append(str(getattr(only, "id", "")))
+                continue
+
+            # 2+ points → consolidate.
+            new_payload = _consolidated_payload(cluster)
+            archive_ids = [str(getattr(p, "id", "")) for p in cluster]
+
+            if dry_run:
+                consolidated_count += 1
+                archived_count += len(archive_ids)
+                continue
+
+            try:
+                new_point = qmodels.PointStruct(
+                    id=str(uuid.uuid4()),
+                    vector=list(getattr(cluster[0], "vector", []) or []),
+                    payload=new_payload,
+                )
+                svc.client.upsert(
+                    collection_name=svc.collection_name,
+                    points=[new_point],
+                )
+                consolidated_count += 1
+            except Exception as e:
+                logger.warning("Dream: upsert failed: %s", e)
+                continue
+
+            try:
+                svc.client.set_payload(
+                    collection_name=svc.collection_name,
+                    payload={"archived": True, "archived_by": "dream"},
+                    points=archive_ids,
+                )
+                archived_count += len(archive_ids)
+            except Exception as e:
+                logger.warning("Dream: archive payload update failed: %s", e)
+
+    result = {
+        "scanned": scanned,
+        "clusters": cluster_count,
+        "consolidated": consolidated_count,
+        "archived": archived_count,
+        "promotion_candidates": len(promotion_candidates),
+        "skipped_low_trust": skipped_low_trust,
+        "status": "ok",
+    }
+    if promote:
+        # Intentional no-op: returning candidates only. Actual promotion to
+        # durable storage requires user confirmation via a separate flow.
+        result["promotion_candidate_ids"] = promotion_candidates
+        logger.info(
+            "Dream: promote=True requested but no-op in this build "
+            "(returning %d candidate ids only)",
+            len(promotion_candidates),
+        )
+    logger.info("Dream pass complete: %s", result)
+    return result

--- a/radbot/tools/memory/memory_consolidation.py
+++ b/radbot/tools/memory/memory_consolidation.py
@@ -24,7 +24,7 @@ import logging
 import math
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/radbot/tools/scheduler/defaults.py
+++ b/radbot/tools/scheduler/defaults.py
@@ -1,0 +1,124 @@
+"""Default scheduler jobs for proactive primitives (Dream + Heartbeat).
+
+Registered as native APScheduler cron jobs inside `SchedulerEngine.start()`
+so the primitives run as deterministic Python routines rather than
+LLM-prompt-driven scheduled tasks. Config-gated via `config:dream` and
+`config:heartbeat` sections (both enabled by default).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from apscheduler.triggers.cron import CronTrigger
+
+logger = logging.getLogger(__name__)
+
+DREAM_JOB_ID = "__dream__"
+HEARTBEAT_JOB_ID = "__heartbeat__"
+
+DEFAULT_DREAM_CRON = "0 3 * * *"       # 03:00 daily
+DEFAULT_HEARTBEAT_CRON = "0 8 * * *"    # 08:00 daily
+
+
+def _get_section(section: str) -> Dict[str, Any]:
+    try:
+        from radbot.config.config_loader import config_loader
+
+        val = config_loader.get_config().get(section) or {}
+        return val if isinstance(val, dict) else {}
+    except Exception:
+        return {}
+
+
+def _cron_trigger(expr: str) -> CronTrigger:
+    parts = expr.strip().split()
+    if len(parts) != 5:
+        raise ValueError(f"invalid cron expression: {expr!r}")
+    return CronTrigger(
+        minute=parts[0],
+        hour=parts[1],
+        day=parts[2],
+        month=parts[3],
+        day_of_week=parts[4],
+    )
+
+
+async def _run_dream_job() -> None:
+    """APScheduler entry-point for the Dream pass."""
+    try:
+        from radbot.tools.memory.memory_consolidation import run_dream
+
+        cfg = _get_section("dream")
+        lookback = int(cfg.get("lookback_hours", 24))
+        promote = bool(cfg.get("promote", False))
+        result = await run_dream(lookback_hours=lookback, promote=promote)
+        logger.info("Dream job finished: %s", result)
+    except Exception as e:
+        logger.error("Dream job failed: %s", e, exc_info=True)
+
+
+async def _run_heartbeat_job() -> None:
+    """APScheduler entry-point for the Heartbeat digest."""
+    try:
+        from radbot.tools.heartbeat.delivery import deliver_digest
+        from radbot.tools.heartbeat.digest import assemble_digest
+
+        cfg = _get_section("heartbeat")
+        horizon = int(cfg.get("horizon_hours", 24))
+        markdown = await assemble_digest(horizon_hours=horizon)
+        delivered = await deliver_digest(markdown)
+        logger.info(
+            "Heartbeat job finished: delivered=%s, length=%d",
+            delivered,
+            len(markdown),
+        )
+    except Exception as e:
+        logger.error("Heartbeat job failed: %s", e, exc_info=True)
+
+
+def register_default_jobs(engine: Any) -> None:
+    """Register Dream + Heartbeat jobs on the given SchedulerEngine.
+
+    Safe to call multiple times — replaces existing jobs by id. Never
+    raises; logs and continues on error so scheduler startup is not
+    blocked by a misconfigured primitive.
+    """
+    scheduler = getattr(engine, "_scheduler", None)
+    if scheduler is None:
+        logger.warning("register_default_jobs: engine has no _scheduler, skipping")
+        return
+
+    specs = [
+        ("dream", DREAM_JOB_ID, DEFAULT_DREAM_CRON, _run_dream_job, "Dream (memory consolidation)"),
+        ("heartbeat", HEARTBEAT_JOB_ID, DEFAULT_HEARTBEAT_CRON, _run_heartbeat_job, "Heartbeat (morning digest)"),
+    ]
+
+    for section, job_id, default_cron, callable_, label in specs:
+        cfg = _get_section(section)
+        enabled = cfg.get("enabled", True)
+        if not enabled:
+            logger.info("%s disabled via config:%s — not registering job", label, section)
+            continue
+        cron_expr = str(cfg.get("cron_expression") or default_cron)
+        try:
+            trigger = _cron_trigger(cron_expr)
+        except Exception as e:
+            logger.error("%s: bad cron %r (%s) — not registering", label, cron_expr, e)
+            continue
+
+        try:
+            existing = scheduler.get_job(job_id)
+            if existing:
+                existing.remove()
+            scheduler.add_job(
+                callable_,
+                trigger=trigger,
+                id=job_id,
+                name=label,
+                replace_existing=True,
+            )
+            logger.info("%s registered (cron=%s)", label, cron_expr)
+        except Exception as e:
+            logger.error("%s: failed to register job: %s", label, e)

--- a/radbot/tools/scheduler/engine.py
+++ b/radbot/tools/scheduler/engine.py
@@ -8,7 +8,7 @@ Results are pushed to active WebSocket connections.
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger

--- a/radbot/tools/scheduler/engine.py
+++ b/radbot/tools/scheduler/engine.py
@@ -89,6 +89,15 @@ class SchedulerEngine:
         except Exception as e:
             logger.error(f"Error loading reminders from DB: {e}")
 
+        # Register default proactive primitives (Dream + Heartbeat).
+        # Never allowed to block scheduler startup.
+        try:
+            from radbot.tools.scheduler.defaults import register_default_jobs
+
+            register_default_jobs(self)
+        except Exception as e:
+            logger.error(f"Error registering default proactive jobs: {e}")
+
         self._scheduler.start()
         self._started = True
         logger.info("SchedulerEngine started")

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -151,6 +151,15 @@ Uses WebSocket client (`ha_websocket_client.py`) for Lovelace CRUD.
 | `list_scheduled_tasks` | — |
 | `delete_scheduled_task` | `task_id` |
 
+Default proactive primitives (not LLM-callable; native APScheduler jobs registered by `tools/scheduler/defaults.py` inside `SchedulerEngine.start()`):
+
+| Job | Default cron | Implementation | Config section |
+|-----|--------------|----------------|----------------|
+| Dream (memory consolidation) | `0 3 * * *` | `tools/memory/memory_consolidation.py::run_dream` | `config:dream` (`enabled`, `cron_expression`, `lookback_hours`, `promote`) |
+| Heartbeat (morning digest) | `0 8 * * *` | `tools/heartbeat/digest.py::assemble_digest` + `tools/heartbeat/delivery.py::deliver_digest` (ntfy) | `config:heartbeat` (`enabled`, `cron_expression`, `horizon_hours`) |
+
+Dream eTAMP safety: low-trust points (`trust=low` or `source ∈ {alert,webhook}`) are excluded from promotion candidacy; `promote=True` surfaces candidate IDs only — never writes to durable storage without user confirmation.
+
 ### reminders — `tools/reminders/reminder_tools.py`
 
 | Tool | Parameters |

--- a/tests/unit/test_heartbeat_digest.py
+++ b/tests/unit/test_heartbeat_digest.py
@@ -1,0 +1,132 @@
+"""Unit tests for Heartbeat digest assembly and delivery."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from radbot.tools.heartbeat.delivery import deliver_digest
+from radbot.tools.heartbeat.digest import assemble_digest
+
+
+@pytest.mark.asyncio
+async def test_digest_empty_when_all_sources_empty():
+    with patch("radbot.tools.heartbeat.digest._fetch_tasks", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_calendar", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_reminders", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_alerts", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_overnight_scheduler", return_value=[]):
+        md = await assemble_digest()
+    assert md == ""
+
+
+@pytest.mark.asyncio
+async def test_digest_renders_all_sections():
+    now = datetime.now(timezone.utc)
+    tasks = [{"ref_code": "PT1", "content": "finish draft", "due": now.date().isoformat(), "overdue": False}]
+    events = [{"summary": "Standup", "start": {"dateTime": now.isoformat()}}]
+    reminders = [{"message": "call mom", "remind_at": now + timedelta(hours=2)}]
+    alerts = [{"severity": "warning", "alertname": "DiskFull", "instance": "srv1"}]
+    overnight = [{"task_name": "nightly-backup", "response": "ok, 42 files"}]
+    with patch("radbot.tools.heartbeat.digest._fetch_tasks", return_value=tasks), \
+         patch("radbot.tools.heartbeat.digest._fetch_calendar", return_value=events), \
+         patch("radbot.tools.heartbeat.digest._fetch_reminders", return_value=reminders), \
+         patch("radbot.tools.heartbeat.digest._fetch_alerts", return_value=alerts), \
+         patch("radbot.tools.heartbeat.digest._fetch_overnight_scheduler", return_value=overnight):
+        md = await assemble_digest()
+    assert "# Heartbeat" in md
+    assert "## Tasks" in md and "PT1" in md and "finish draft" in md
+    assert "## Calendar" in md and "Standup" in md
+    assert "## Reminders" in md and "call mom" in md
+    assert "## Alerts" in md and "DiskFull" in md
+    assert "## Overnight Activity" in md and "nightly-backup" in md
+
+
+@pytest.mark.asyncio
+async def test_digest_calendar_failure_degrades_silently():
+    tasks = [{"ref_code": "PT1", "content": "t", "due": None, "overdue": False}]
+
+    def raise_cal(*_a, **_k):
+        raise RuntimeError("unauth")
+
+    with patch("radbot.tools.heartbeat.digest._fetch_tasks", return_value=tasks), \
+         patch("radbot.tools.heartbeat.digest._fetch_calendar", side_effect=raise_cal), \
+         patch("radbot.tools.heartbeat.digest._fetch_reminders", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_alerts", return_value=[]), \
+         patch("radbot.tools.heartbeat.digest._fetch_overnight_scheduler", return_value=[]):
+        with pytest.raises(RuntimeError):
+            # the raw fetcher raises; assemble_digest itself isn't protecting
+            # third-party patches, so this just validates our own fetchers
+            # don't swallow caller-raised errors. The real _fetch_calendar
+            # already has its own try/except.
+            await assemble_digest()
+
+
+@pytest.mark.asyncio
+async def test_deliver_digest_empty_returns_false():
+    delivered = await deliver_digest("")
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_digest_no_ntfy_returns_false():
+    with patch("radbot.tools.ntfy.ntfy_client.get_ntfy_client", return_value=None):
+        delivered = await deliver_digest("# Heartbeat\n\ncontent")
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_digest_calls_ntfy_publish():
+    fake = MagicMock()
+    fake.publish = AsyncMock(return_value={"id": "abc"})
+    with patch("radbot.tools.ntfy.ntfy_client.get_ntfy_client", return_value=fake), \
+         patch("radbot.tools.notifications.db.create_notification", return_value={}):
+        delivered = await deliver_digest("# Heartbeat\n\nsome markdown", title="Morning Brief")
+    assert delivered is True
+    fake.publish.assert_awaited_once()
+    kwargs = fake.publish.await_args.kwargs
+    assert kwargs["title"] == "Morning Brief"
+    assert "sunrise" in kwargs["tags"]
+    assert kwargs["message"].startswith("# Heartbeat")
+
+
+@pytest.mark.asyncio
+async def test_fetch_tasks_filters_future_and_done(monkeypatch):
+    """Direct test of _fetch_tasks filtering via mocked telos list_section."""
+    from radbot.tools.heartbeat import digest as digest_mod
+
+    future_date = (datetime.now().date() + timedelta(days=30)).isoformat()
+    today = datetime.now().date().isoformat()
+    overdue = (datetime.now().date() - timedelta(days=2)).isoformat()
+
+    entries = [
+        SimpleNamespace(ref_code="PT1", content="today", metadata={"due_date": today}),
+        SimpleNamespace(ref_code="PT2", content="future", metadata={"due_date": future_date}),
+        SimpleNamespace(ref_code="PT3", content="done-today", metadata={"due_date": today, "task_status": "done"}),
+        SimpleNamespace(ref_code="PT4", content="overdue", metadata={"due_date": overdue}),
+        SimpleNamespace(ref_code="PT5", content="no-due", metadata={}),
+    ]
+
+    fake_list = MagicMock(return_value=entries)
+    fake_section = SimpleNamespace(PROJECT_TASKS="project_tasks")
+    # Patch imports *inside* _fetch_tasks.
+    import sys
+    telos_db = sys.modules.setdefault("radbot.tools.telos.db", MagicMock())
+    telos_models = sys.modules.setdefault("radbot.tools.telos.models", MagicMock())
+    monkeypatch.setattr(telos_db, "list_section", fake_list)
+    monkeypatch.setattr(telos_models, "Section", fake_section)
+
+    out = digest_mod._fetch_tasks(datetime.now(timezone.utc) + timedelta(days=1))
+    refs = {t["ref_code"] for t in out}
+    # Future task excluded, done task excluded; today, overdue, and no-due included.
+    assert "PT2" not in refs
+    assert "PT3" not in refs
+    assert "PT1" in refs
+    assert "PT4" in refs
+    assert "PT5" in refs
+    # overdue flag set correctly
+    overdue_task = next(t for t in out if t["ref_code"] == "PT4")
+    assert overdue_task["overdue"] is True

--- a/tests/unit/test_memory_consolidation.py
+++ b/tests/unit/test_memory_consolidation.py
@@ -1,0 +1,165 @@
+"""Unit tests for Dream memory consolidation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from radbot.tools.memory.memory_consolidation import (
+    SIMILARITY_THRESHOLD,
+    _cluster,
+    _cosine,
+    _payload_is_low_trust,
+    run_dream,
+)
+
+
+def _pt(pid: str, vector, payload=None):
+    return SimpleNamespace(id=pid, vector=vector, payload=payload or {})
+
+
+def test_cosine_identical():
+    assert _cosine([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal():
+    assert _cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_payload_low_trust_detection():
+    assert _payload_is_low_trust({"trust": "low"}) is True
+    assert _payload_is_low_trust({"source": "alert"}) is True
+    assert _payload_is_low_trust({"source": "webhook"}) is True
+    assert _payload_is_low_trust({"trust": "high"}) is False
+    assert _payload_is_low_trust({}) is False
+
+
+def test_cluster_groups_near_duplicates():
+    v1 = [1.0, 0.0, 0.0]
+    v1_close = [0.999, 0.01, 0.0]
+    v_far = [0.0, 1.0, 0.0]
+    pts = [_pt("a", v1), _pt("b", v1_close), _pt("c", v_far)]
+    clusters = _cluster(pts)
+    # Expect one cluster of 2 and one cluster of 1
+    sizes = sorted(len(c) for c in clusters)
+    assert sizes == [1, 2]
+
+
+class _FakeClient:
+    def __init__(self, points):
+        self._points = points
+        self.upserts = []
+        self.payload_updates = []
+        # signal at scroll: returns (points, None) on first call, empty on second
+        self._served = False
+
+    def scroll(self, **_kwargs):
+        if self._served:
+            return [], None
+        self._served = True
+        return list(self._points), None
+
+    def upsert(self, collection_name, points):
+        self.upserts.append((collection_name, list(points)))
+
+    def set_payload(self, collection_name, payload, points):
+        self.payload_updates.append((collection_name, payload, list(points)))
+
+
+def _service(points):
+    svc = MagicMock()
+    svc.collection_name = "test_col"
+    svc.client = _FakeClient(points)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_dream_consolidates_duplicates():
+    v = [1.0, 0.0, 0.0]
+    v_close = [0.9995, 0.01, 0.0]
+    v_other = [0.0, 1.0, 0.0]
+    pts = [
+        _pt("a", v, {"source_agent": "beto", "text": "fact A longer"}),
+        _pt("b", v_close, {"source_agent": "beto", "text": "fact A"}),
+        _pt("c", v_other, {"source_agent": "beto", "text": "different"}),
+    ]
+    svc = _service(pts)
+    result = await run_dream(memory_service=svc)
+
+    assert result["scanned"] == 3
+    assert result["consolidated"] == 1
+    assert result["archived"] == 2
+    # Singleton cluster for the different point — no consolidation of it.
+    assert result["clusters"] == 2
+    # One upsert for the consolidated point, one set_payload archiving 2 ids.
+    assert len(svc.client.upserts) == 1
+    assert len(svc.client.payload_updates) == 1
+    _, archive_payload, archive_ids = svc.client.payload_updates[0]
+    assert archive_payload["archived"] is True
+    assert set(archive_ids) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_dream_skips_low_trust_from_promotion_candidates():
+    v = [1.0, 0.0, 0.0]
+    pts = [
+        _pt("a", v, {"source_agent": "beto", "memory_type": "important", "trust": "low"}),
+        _pt("b", [0.0, 1.0, 0.0], {"source_agent": "beto", "memory_type": "important"}),
+    ]
+    svc = _service(pts)
+    result = await run_dream(memory_service=svc, promote=True)
+    # The low-trust singleton must not be a promotion candidate.
+    ids = result.get("promotion_candidate_ids", [])
+    assert "a" not in ids
+    assert "b" in ids
+    assert result["skipped_low_trust"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dream_promote_flag_is_noop_on_durable_storage():
+    v = [1.0, 0.0, 0.0]
+    pts = [_pt("a", v, {"source_agent": "beto", "memory_type": "important"})]
+    svc = _service(pts)
+    result = await run_dream(memory_service=svc, promote=True)
+    # promote=True must NOT cause consolidated writes for a singleton.
+    assert svc.client.upserts == []
+    assert svc.client.payload_updates == []
+    # Candidate id should be surfaced but nothing written.
+    assert result["promotion_candidate_ids"] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_dream_dry_run_skips_writes():
+    v = [1.0, 0.0, 0.0]
+    v_close = [0.999, 0.01, 0.0]
+    pts = [
+        _pt("a", v, {"source_agent": "beto", "text": "x"}),
+        _pt("b", v_close, {"source_agent": "beto", "text": "y"}),
+    ]
+    svc = _service(pts)
+    result = await run_dream(memory_service=svc, dry_run=True)
+    assert result["consolidated"] == 1
+    assert result["archived"] == 2
+    assert svc.client.upserts == []
+    assert svc.client.payload_updates == []
+
+
+@pytest.mark.asyncio
+async def test_dream_no_service_returns_skipped():
+    # monkeypatch factory to return None
+    from radbot.tools.memory import memory_consolidation as mc
+
+    original = mc._get_memory_service
+    mc._get_memory_service = lambda: None
+    try:
+        result = await run_dream()
+        assert result["status"] == "skipped"
+    finally:
+        mc._get_memory_service = original
+
+
+def test_threshold_is_reasonable():
+    # Sanity: threshold should reject clearly distinct vectors.
+    assert _cosine([1.0, 0.0], [0.5, 0.5]) < SIMILARITY_THRESHOLD

--- a/tests/unit/test_scheduler_defaults.py
+++ b/tests/unit/test_scheduler_defaults.py
@@ -82,6 +82,7 @@ def test_register_default_jobs_replaces_existing():
     engine, scheduler = _engine_with_scheduler()
     existing = MagicMock()
     # Return an existing job only for dream.
+
     def get_job(job_id):
         return existing if job_id == DREAM_JOB_ID else None
     scheduler.get_job.side_effect = get_job

--- a/tests/unit/test_scheduler_defaults.py
+++ b/tests/unit/test_scheduler_defaults.py
@@ -1,0 +1,106 @@
+"""Unit tests for scheduler default proactive primitives registration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from radbot.tools.scheduler.defaults import (
+    DEFAULT_DREAM_CRON,
+    DEFAULT_HEARTBEAT_CRON,
+    DREAM_JOB_ID,
+    HEARTBEAT_JOB_ID,
+    register_default_jobs,
+)
+
+
+def _engine_with_scheduler():
+    scheduler = MagicMock()
+    scheduler.get_job = MagicMock(return_value=None)
+    engine = SimpleNamespace(_scheduler=scheduler)
+    return engine, scheduler
+
+
+def test_register_default_jobs_both_enabled_by_default():
+    engine, scheduler = _engine_with_scheduler()
+    with patch("radbot.tools.scheduler.defaults._get_section", return_value={}):
+        register_default_jobs(engine)
+
+    assert scheduler.add_job.call_count == 2
+    ids = [call.kwargs.get("id") or call.args[2] if len(call.args) > 2 else call.kwargs.get("id")
+           for call in scheduler.add_job.call_args_list]
+    # Extract by kwargs (always passed by name in our impl)
+    ids = [call.kwargs["id"] for call in scheduler.add_job.call_args_list]
+    assert DREAM_JOB_ID in ids
+    assert HEARTBEAT_JOB_ID in ids
+
+
+def test_register_default_jobs_both_disabled():
+    engine, scheduler = _engine_with_scheduler()
+    with patch(
+        "radbot.tools.scheduler.defaults._get_section",
+        return_value={"enabled": False},
+    ):
+        register_default_jobs(engine)
+
+    scheduler.add_job.assert_not_called()
+
+
+def test_register_default_jobs_uses_custom_cron():
+    engine, scheduler = _engine_with_scheduler()
+    custom = "*/15 * * * *"
+
+    def section(name):
+        return {"enabled": True, "cron_expression": custom}
+
+    with patch("radbot.tools.scheduler.defaults._get_section", side_effect=section):
+        register_default_jobs(engine)
+
+    # Both jobs added with the custom cron expression — we don't inspect the
+    # trigger object directly, but we verify count and ids.
+    assert scheduler.add_job.call_count == 2
+
+
+def test_register_default_jobs_bad_cron_is_logged_and_skipped():
+    engine, scheduler = _engine_with_scheduler()
+
+    def section(name):
+        if name == "dream":
+            return {"enabled": True, "cron_expression": "not a cron"}
+        return {"enabled": True}  # heartbeat uses default
+
+    with patch("radbot.tools.scheduler.defaults._get_section", side_effect=section):
+        register_default_jobs(engine)
+
+    # Only heartbeat should have been added.
+    assert scheduler.add_job.call_count == 1
+    assert scheduler.add_job.call_args.kwargs["id"] == HEARTBEAT_JOB_ID
+
+
+def test_register_default_jobs_replaces_existing():
+    engine, scheduler = _engine_with_scheduler()
+    existing = MagicMock()
+    # Return an existing job only for dream.
+    def get_job(job_id):
+        return existing if job_id == DREAM_JOB_ID else None
+    scheduler.get_job.side_effect = get_job
+
+    with patch("radbot.tools.scheduler.defaults._get_section", return_value={}):
+        register_default_jobs(engine)
+
+    existing.remove.assert_called_once()
+    assert scheduler.add_job.call_count == 2
+
+
+def test_register_default_jobs_handles_missing_scheduler():
+    # No exception even if engine has no _scheduler.
+    engine = SimpleNamespace(_scheduler=None)
+    with patch("radbot.tools.scheduler.defaults._get_section", return_value={}):
+        register_default_jobs(engine)  # no-op, must not raise
+
+
+def test_defaults_constants_are_valid_5_field_cron():
+    for expr in (DEFAULT_DREAM_CRON, DEFAULT_HEARTBEAT_CRON):
+        assert len(expr.split()) == 5

--- a/tests/unit/test_scheduler_defaults.py
+++ b/tests/unit/test_scheduler_defaults.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from radbot.tools.scheduler.defaults import (
     DEFAULT_DREAM_CRON,


### PR DESCRIPTION
## Summary
Implements exploration **EX3 — Proactive primitives**:

- **Dream** (`radbot/tools/memory/memory_consolidation.py`) — scheduled Qdrant memory consolidation. Scrolls recent points, clusters near-duplicates by cosine similarity ≥0.97 (reusing stored vectors — no re-embedding), writes one `memory_type=consolidated` point per cluster referencing originals via `merged_from`, and soft-archives the originals with `archived=true`. **eTAMP safety**: low-trust points (`trust=low` or `source ∈ {alert,webhook}`) are excluded from promotion candidacy; `promote=True` is intentionally a no-op — it surfaces candidate IDs only and never writes to durable storage without user confirmation.
- **Heartbeat** (`radbot/tools/heartbeat/`) — morning markdown digest assembled from project_tasks (due today/overdue), calendar (next 24h), pending reminders, unresolved alerts, and overnight scheduler results. Returns `""` when every section is empty (the "should I bother the user" decision). `delivery.py` separates transport (ntfy) from content assembly, and records a `notifications` entry for UI surfacing.
- **Scheduler wiring** (`radbot/tools/scheduler/defaults.py`) — `register_default_jobs()` registers Dream + Heartbeat as **native APScheduler cron jobs** (not LLM-prompt-driven), called from `SchedulerEngine.start()`. Config-gated via `config:dream` / `config:heartbeat` sections (enabled by default; cron configurable). Defaults: Dream `0 3 * * *`, Heartbeat `0 8 * * *`.

## Specs updated
- `specs/tools.md` — new "Default proactive primitives" section under scheduler.

## Test plan
- [x] `uv run python -m pytest tests/unit/test_memory_consolidation.py tests/unit/test_heartbeat_digest.py tests/unit/test_scheduler_defaults.py -v` — 24 new tests pass (dedup, low-trust skip, no-op promotion, dry-run, empty/full digest, ntfy delivery, cron init with enabled/disabled/bad-cron/replace/missing-scheduler paths).
- [x] `uv run python -m pytest tests/unit/test_scheduler_engine.py -v` — 41 existing scheduler tests still pass.
- [ ] Manual: with DB + ntfy configured, `uv run python -c "import asyncio; from radbot.tools.heartbeat.digest import assemble_digest; print(asyncio.run(assemble_digest()))"` prints a markdown digest or empty string.
- [ ] Manual: with scheduler running, verify Dream + Heartbeat jobs appear via APScheduler introspection (IDs `__dream__`, `__heartbeat__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)