### PR TITLE
ci: move merge out of quality-pipeline; tighten ship skill local gates

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: ship
 description: >
-  Branch off main into an isolated worktree, run cheap local quality gates,
-  open a PR with the run-e2e and auto-merge-eligible labels applied, watch the
-  quality-pipeline workflow run, fix CI failures up to 3 times, and auto-merge
-  when the score crosses 90. Use when the user says "ship this", "open a PR
-  for this work", "merge when CI is green", or wants the full ship-it lifecycle
-  for a non-trivial change. Does NOT decide merge authority — the workflow's
-  own gates do; this skill just orchestrates the human-side loop.
+  Branch off main into an isolated worktree, run cheap local quality gates
+  (lint, static type-check, unit tests, frontend build/e2e), open a PR with
+  the run-e2e and auto-merge-eligible labels applied, watch the
+  quality-pipeline workflow run, fix CI failures up to 3 times, and merge
+  from the user's shell (so deploy workflows fire) when the score crosses 90.
+  Use when the user says "ship this", "open a PR for this work", "merge when
+  CI is green", or wants the full ship-it lifecycle for a non-trivial change.
+  Does NOT decide merge authority — the workflow's own gates do; this skill
+  just orchestrates the human-side loop.
 ---
 
 # /ship — work in worktree → PR → quality-pipeline → auto-merge at 90
@@ -58,26 +60,44 @@ From here, every command runs in the worktree.
 
 ## Phase 3 — Local gates (cheap subset)
 
-Run these — they catch the cheap failures before paying for CI:
+**Hard gate**: every command below must exit 0 before Phase 5 (secret scan) / Phase 6 (push). CI runs the same checks — running them locally first is the cheap way to avoid a red pipeline + 4-minute wait.
+
+### Python static + unit
 
 ```bash
-make lint                   # ruff + mypy
+make lint                   # flake8 + mypy over radbot/ and tests/
 make test-unit              # pytest tests/unit
-cd radbot/web/frontend && npm ci && npm run build && cd ../../..
-cd radbot/web/frontend && BASE_REF=origin/main npm run test:e2e:affected && cd ../../..
 ```
 
-Skip locally:
-- `make test-integration` (slow, depends on services)
-- `make test-e2e-browser` full run (covered by CI)
-- visual regression (requires real Anthropic spend; CI handles it)
-- chat-quality grading (`ANTHROPIC_API_KEY` required; CI handles it)
+### Frontend static + build (only if `radbot/web/frontend/**` changed)
 
-If anything fails:
-1. Show the user the failure.
-2. Fix only the failing thing — don't refactor.
-3. Re-run only the gate that failed.
-4. Repeat until green or user aborts.
+```bash
+cd radbot/web/frontend
+npm ci
+npm run lint                # eslint .
+npx tsc --noEmit            # TypeScript static type check
+npm run build               # catches import / prop-type issues missed by lint
+BASE_REF=origin/main npm run test:e2e:affected
+cd ../../..
+```
+
+Check `git diff --name-only origin/main...HEAD` (or the working tree for pre-commit runs) to decide whether the frontend block applies. If the diff is Python-only, skip the frontend block entirely.
+
+### Skip locally (CI covers these)
+
+- `make test-integration` — slow, depends on services
+- `make test-e2e-browser` full run — covered by functional-e2e
+- Visual regression — requires real Anthropic spend
+- Chat-quality grading — requires `ANTHROPIC_API_KEY`
+
+### On failure
+
+1. Show the user the failing output verbatim.
+2. Fix only the failing thing — don't refactor, don't auto-format unrelated code.
+3. Re-run **only** the gate that failed (not the whole suite).
+4. Repeat until green or the user aborts.
+
+Do not proceed to Phase 5 until every gate above is green. "I'll let CI catch it" is a failure mode — CI costs ~4 min and a GitHub Actions minute; `make lint` costs ~10 s.
 
 ## Phase 4 — Spec sync check
 
@@ -194,18 +214,38 @@ If `score < $AUTO_MERGE_THRESHOLD`:
 
 Cap at $MAX_FIX_ATTEMPTS. Past that, hand control to the user with a summary.
 
-## Phase 11 — Auto-merge
+## Phase 11 — Merge (user-authenticated, so deploys trigger)
 
 If `score ≥ $AUTO_MERGE_THRESHOLD`:
 
 1. Confirm once with the user: `Score is NN/100 — merge now?` Skip if `--auto-yes` was passed.
-2. The workflow's aggregate job already calls `gh pr merge --auto --squash --delete-branch` when `auto-merge-eligible` is set, score ≥ 90, secret-scan succeeded, and path-guard didn't block. Verify the PR has `auto-merge` enabled:
+2. Verify the pipeline actually cleared the gates the skill cannot see:
 
 ```bash
-gh pr view $PR_NUMBER --repo $GITHUB_REPO --json autoMergeRequest --jq .autoMergeRequest
+gh pr view $PR_NUMBER --repo $GITHUB_REPO \
+  --json labels,statusCheckRollup \
+  --jq '{labels: [.labels[].name], aggregate_conclusion: ([.statusCheckRollup[] | select(.name=="aggregate") | .conclusion] | last)}'
 ```
 
-3. If auto-merge isn't queued (e.g. path-guard blocked, or `auto-merge-eligible` isn't applied), tell the user why and ask if they want to merge by hand.
+   - `auto-merge-eligible` must be in `labels` (otherwise the user chose `--manual-merge`; stop and hand off).
+   - `aggregate_conclusion` must be `SUCCESS`.
+
+3. Merge from the user's shell — **never from inside the workflow**. A merge authored by the workflow's `GITHUB_TOKEN` does not fire downstream `push` workflows (including `Build and Push Docker Image`), so merging from CI silently skips deploys ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). `gh` uses the user's PAT, so the resulting push to `main` triggers the docker-build workflow as expected.
+
+```bash
+gh pr merge $PR_NUMBER --repo $GITHUB_REPO --squash --delete-branch
+```
+
+4. After merge, confirm the deploy fired:
+
+```bash
+sleep 10
+gh run list --repo $GITHUB_REPO --workflow "Build and Push Docker Image" --branch main --limit 1
+```
+
+   Tell the user the run ID so they can watch it. If no run appears within ~30 s, the user should push an empty commit from their shell to force a fresh `push` event.
+
+5. If `auto-merge-eligible` is missing or `aggregate_conclusion` is not `SUCCESS`, tell the user why and stop — do not attempt the merge.
 
 The skill has NO authority to bypass branch protection or path-guard — it only orchestrates.
 

--- a/.github/workflows/quality-pipeline.yml
+++ b/.github/workflows/quality-pipeline.yml
@@ -596,22 +596,13 @@ jobs:
             -f state=$([ "$SCORE" -ge 70 ] && echo success || echo failure) \
             -f context="quality-pipeline/score" \
             -f description="$SCORE / 100"
-      - name: Auto-merge if eligible
-        if: |
-          needs.path-guard.outputs.auto_merge_blocked != 'true' &&
-          needs.secret-scan.result == 'success' &&
-          contains(github.event.pull_request.labels.*.name, 'auto-merge-eligible')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCORE: ${{ steps.tally.outputs.score }}
-        run: |
-          if [ "$SCORE" -ge 90 ]; then
-            gh pr merge ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
-              --auto --squash --delete-branch
-          else
-            echo "Score $SCORE < 90; auto-merge not enabled."
-          fi
+      # NOTE: Auto-merge is NOT performed inside this workflow.
+      # Merges authored by GITHUB_TOKEN do not fire downstream `push`
+      # workflows (including `Build and Push Docker Image`), so merging from
+      # CI silently skips deploys. The `/ship` skill (or a human) runs
+      # `gh pr merge` from a user-authenticated shell once the score is ≥ 90
+      # and `auto-merge-eligible` is applied. See
+      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Fail workflow if score < 70
         env:
           SCORE: ${{ steps.tally.outputs.score }}

--- a/docs/implementation/ship_skill.md
+++ b/docs/implementation/ship_skill.md
@@ -30,7 +30,7 @@ Optional arguments:
 
 1. **Pre-flight** — confirm clean working tree, derive slug.
 2. **Worktree** — `git worktree add /tmp/radbot-ship-<slug> -b ship/<slug> origin/main`.
-3. **Local gates (cheap subset)** — `make lint`, `make test-unit`, `npm run build`, `npm run test:e2e:affected`. Skips visual regression and chat-quality (CI handles them).
+3. **Local gates (cheap subset, hard gate)** — `make lint` (flake8 + mypy), `make test-unit`. When frontend changed: `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e:affected`. Every gate must be green before push — skipping a local gate to "let CI catch it" wastes ~4 min of pipeline time. Skips visual regression and chat-quality (CI handles them).
 4. **Spec sync check** — for every changed source file, verify the corresponding `specs/*.md` is in the diff (per `CLAUDE.md` Spec ↔ code map).
 5. **Secret scan** — regex on staged + unstaged files (`AKIA…`, `ghp_…`, `sk-ant-…`, etc.). Hard stop on match.
 6. **Commit + push** — conventional-commit message, push to `ship/<slug>`.
@@ -38,7 +38,7 @@ Optional arguments:
 8. **Watch workflow** — `gh run watch` (server-side stream, not polling).
 9. **Read score** — from commit status `quality-pipeline/score` (NOT the sticky comment, which is forgeable — see `docs/implementation/ci-security.md`).
 10. **CI fix loop** — up to 3 attempts to address pipeline feedback.
-11. **Auto-merge** — confirms once with you (unless `--auto-yes`), verifies the workflow's aggregate enabled `--auto`, reports.
+11. **Merge (user-authenticated)** — confirms once with you (unless `--auto-yes`), verifies `auto-merge-eligible` label + `aggregate` SUCCESS + score ≥ 90, then runs `gh pr merge --squash --delete-branch` from your shell. Not performed inside CI — a merge authored by `GITHUB_TOKEN` does not trigger the `Build and Push Docker Image` workflow (GitHub's recursion guard), so running the merge locally is what makes deploys fire.
 12. **Cleanup** — reminds you the worktree exists; offers to remove on confirmation.
 
 ## Recovery from common failures
@@ -51,6 +51,9 @@ The sticky PR comment lists per-gate scores. Identify which gate cost you the po
 
 ### "path-guard blocked auto-merge"
 You touched a sensitive path (admin.py, credentials/, deps, …). This is correct — these always require human merge. The skill posts the offending paths in its summary; review the PR by hand and merge with `gh pr merge <num> --squash`.
+
+### "Score ≥ 90 but docker-build didn't fire after the merge"
+Pre–2026-04-20 behavior: the workflow's aggregate job called `gh pr merge --auto` itself, and `GITHUB_TOKEN`-authored merges don't trigger downstream `push` workflows. The skill now merges from your shell to avoid this. If you're seeing this on a new PR, check that Phase 11 actually ran (the skill should have invoked `gh pr merge` locally) — if the PR merged without your shell running the command, something else merged it and you'll need to push an empty commit to `main` to trigger the deploy.
 
 ### "CI fix loop hit max attempts"
 The skill stops after 3 failed CI attempts and hands control back to you. Inspect the artifacts, fix manually, push. Re-run `/ship` if you want it to take over again from the watch step.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -129,13 +129,13 @@ Absent either condition, every job is skipped. No skipped/red noise.
 | `coverage-delta` | 10 | no | New `src/pages/*.tsx` without coverage-map entry → 0/10. |
 | `functional-e2e` | 30 | no | Docker stack via `bootstrap-radbot-stack`, `npm run test:e2e:affected`, real Gemini + Anthropic. Failure artifact on disk + uploaded. |
 | `visual-regression` | 20 | no | Dual checkout (main + PR), capture `@screenshot` specs into separate dirs, Anthropic vision compares pairs, emits 0–20. |
-| `aggregate` | sums | yes (must pass) | Tallies, posts sticky comment, sets commit status, calls `gh pr merge --auto`, fails if score < 70. |
+| `aggregate` | sums | yes (must pass) | Tallies scores, posts sticky comment, sets `quality-pipeline/score` commit status, fails workflow if score < 70. Does **not** merge. |
 
-Maximum score: 100. Fail floor: 70. Auto-merge floor: 90.
+Maximum score: 100. Fail floor: 70. Merge floor (advisory, enforced outside CI): 90.
 
 ### Hard-block paths (`path-guard`)
 
-Auto-merge is **unconditionally disabled** for PRs touching:
+The `auto-merge-eligible` label is **unconditionally ignored** (and the PR comment flags the touched paths) for PRs touching:
 - `radbot/credentials/**` — encryption store, key handling
 - `radbot/web/api/admin.py` — admin auth surface
 - `radbot/db/**`, `**/*.sql`, any new `init_*_schema()` — migrations
@@ -148,15 +148,17 @@ Auto-merge is **unconditionally disabled** for PRs touching:
 
 PR comment names the offending paths so the user knows exactly why human merge is required.
 
-### Auto-merge
+### Merge (performed outside CI)
 
-`gh pr merge --auto --squash --delete-branch` runs only when:
+The workflow does **not** merge PRs. A `gh pr merge` call authored by `GITHUB_TOKEN` does not fire downstream `push` workflows (including `Build and Push Docker Image`), so merging from inside CI silently skips deploys — see [GitHub's `GITHUB_TOKEN` docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+
+Instead, a user-authenticated `gh pr merge --squash --delete-branch` is run from the developer's shell (typically by the `/ship` skill's Phase 11) once all of:
 - `auto-merge-eligible` label is applied (separate from `run-e2e`)
-- `score ≥ 90`
+- `aggregate` job concluded `SUCCESS` with `score ≥ 90`
 - `secret-scan` succeeded
 - `path-guard.auto_merge_blocked != true`
 
-Auto-merge then waits for branch protection checks before actually merging — this workflow controls the *enable*, not the merge itself.
+Because the push is authored by a real user PAT, `Build and Push Docker Image` fires normally on `main`.
 
 ### Cost envelope
 


### PR DESCRIPTION
## Summary
- `Build and Push Docker Image` stopped firing on auto-merged PRs because the workflow was calling `gh pr merge --auto` with `GITHUB_TOKEN`, which GitHub's [recursion guard](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) silently suppresses downstream `push` workflows for.
- Drops the `Auto-merge if eligible` step from `quality-pipeline.yml`. Aggregate still tallies, posts the sticky comment, sets the commit status, and fails the workflow if score < 70 — it just no longer performs the merge.
- `/ship` Phase 11 now runs `gh pr merge --squash --delete-branch` from the user's shell (PAT-authored push → docker-build fires normally), verifies `auto-merge-eligible` + `aggregate=SUCCESS` + score ≥ 90 first, and checks for a docker-build run after merge.
- `/ship` Phase 3 tightened: flake8 + mypy + unit tests always; when `radbot/web/frontend/**` changed, also eslint + `tsc --noEmit` + `npm run build` + affected e2e. Framed as a hard gate — local is 10s, CI is ~4 min.
- `specs/testing.md` + `docs/implementation/ship_skill.md`: updated to reflect the new merge location + rationale.

## Specs updated
- `specs/testing.md` § Aggregate / Auto-merge → Merge (performed outside CI)
- `docs/implementation/ship_skill.md` Phases 3 and 11 + new troubleshooting entry

## Test plan
- [ ] Merge this PR manually from the shell and confirm `Build and Push Docker Image` fires on the merge commit
- [ ] Next `/ship` run exercises the new Phase 11 flow
- [ ] Next PR with a lint failure surfaces locally via Phase 3 before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)