### PR TITLE
[session-agent-pill] drop BETO·v0.9 badge, make chat pill reflect session root

### DIFF
--- a/radbot/web/frontend/src/components/chat/ChatHeader.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatHeader.tsx
@@ -104,14 +104,9 @@ export default function ChatHeader() {
               backgroundPosition: "60% 30%",
             }}
           />
-          <div className="hidden sm:flex items-baseline gap-2">
-            <h1 className="pixel-font text-[22px] text-txt-primary m-0 leading-none">
-              RADBOT
-            </h1>
-            <span className="inline-flex text-[9px] font-mono font-semibold tracking-[0.15em] text-[#ff9966] px-1.5 py-0.5 rounded-sm border border-[#ff9966]/40 bg-[#ff9966]/10">
-              BETO·v0.9
-            </span>
-          </div>
+          <h1 className="hidden sm:block pixel-font text-[22px] text-txt-primary m-0 leading-none">
+            RADBOT
+          </h1>
 
           {modelName && (
             <>

--- a/radbot/web/frontend/src/components/chat/ChatMessage.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatMessage.tsx
@@ -19,6 +19,7 @@ import InboxSummary, {
   type InboxSummaryData,
 } from "@/components/chat/InboxSummary";
 import { agentFor, type AgentIdentity } from "@/components/chat/agent-registry";
+import { useAppStore } from "@/stores/app-store";
 
 interface Props {
   message: Message;
@@ -36,10 +37,10 @@ const SYSTEM: AgentIdentity = {
   textClass: "text-terminal-red", bgClass: "bg-terminal-red/10 border-terminal-red/30",
 };
 
-function identityFor(message: Message): AgentIdentity {
+function identityFor(message: Message, sessionAgent: string | null): AgentIdentity {
   if (message.role === "user") return USER;
   if (message.role === "system") return SYSTEM;
-  return agentFor(message.agent);
+  return agentFor(message.agent ?? sessionAgent);
 }
 
 // ── AgentPill — left-column identity badge ──────────────
@@ -181,7 +182,11 @@ function formatTime(ts: number): string {
 }
 
 export default function ChatMessage({ message }: Props) {
-  const id = identityFor(message);
+  const sessionAgent = useAppStore((s) => {
+    const sess = s.sessions.find((x) => x.id === s.sessionId);
+    return sess?.agent_name ?? null;
+  });
+  const id = identityFor(message, sessionAgent);
   const lineCount = message.content.split("\n").length;
   const isAssistant = message.role === "assistant";
   const isSystem = message.role === "system";


### PR DESCRIPTION
## Summary

- Removes the hardcoded `BETO·v0.9` badge from the top bar next to the RADBOT wordmark.
- Assistant / system message pills now fall back to the current session's root agent (`chat_sessions.agent_name`) when a message has no explicit `agent` tag, instead of silently defaulting to BETO.
- Scout sessions render scout's green pill. Messages that carry an explicit `agent` field (handoffs) still render that sub-agent's identity, preserving handoff visualization.

## Specs updated

None needed — pure UI polish, no tool / agent / schema / routing shape changes (per `CLAUDE.md` spec ↔ code map).

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90