### PR TITLE
fix(telemetry): init telemetry_events schema at web startup

### DIFF
--- a/radbot/tools/telemetry/service.py
+++ b/radbot/tools/telemetry/service.py
@@ -101,7 +101,11 @@ class TelemetryService:
         self._worker: Optional[threading.Thread] = None
         self._start_lock = threading.Lock()
         self._stopping = threading.Event()
-        self._last_warn_at = 0.0
+        # None sentinel (not 0.0): on Linux `time.monotonic()` is seconds
+        # since boot, which on a freshly-booted CI runner can be < 60, so
+        # `now - 0.0 < WARN_THROTTLE_S` would silently throttle the very
+        # first warning. `None` means "never warned yet — always log".
+        self._last_warn_at: Optional[float] = None
         self._warn_lock = threading.Lock()
 
     # ------------------------------------------------------------------ public
@@ -194,7 +198,10 @@ class TelemetryService:
     def _warn_throttled(self, msg: str) -> None:
         now = time.monotonic()
         with self._warn_lock:
-            if now - self._last_warn_at < WARN_THROTTLE_S:
+            if (
+                self._last_warn_at is not None
+                and now - self._last_warn_at < WARN_THROTTLE_S
+            ):
                 return
             self._last_warn_at = now
         logger.warning(msg)

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -268,6 +268,24 @@ async def initialize_app_startup():
                 exc_info=True,
             )
 
+        # PT30 baseline telemetry (`telemetry_events`). Previously only
+        # initialized by `setup_before_agent_call` on beto's before-agent
+        # callback — so scout-rooted sessions (which don't wire that
+        # callback) dropped every batch with "relation telemetry_events
+        # does not exist". CREATE TABLE IF NOT EXISTS is idempotent, so
+        # eager startup init is safe.
+        logger.debug("Initializing PT30 telemetry_events schema...")
+        try:
+            from radbot.tools.telemetry import init_telemetry_schema
+
+            init_telemetry_schema()
+            logger.debug("telemetry_events schema initialized")
+        except Exception as tel_err:
+            logger.error(
+                f"Error initializing telemetry_events schema: {str(tel_err)}",
+                exc_info=True,
+            )
+
         # Initialize session workers schema
         logger.debug("Initializing session workers database schema...")
         try:

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -46,8 +46,8 @@ Uses the `radbot_chathistory` database with its own pool in `web/db/connection.p
 
 All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS` (or the `init_table_schema()` helper in `tools/shared/db_schema.py`). Called from:
 
-- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, telos, telemetry, notifications, llm_usage_log, alerts)
-- `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history)
+- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, telos, telemetry, notifications, llm_usage_log, alerts). Wired only on beto's root callback; scout-rooted sessions never fire it, so any table written to by scout-root callbacks (e.g. `telemetry_events`) must also be initialized at web-side startup below.
+- `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history, credential store, `llm_usage_log`, `telemetry_events`). Runs unconditionally on process start so scout-rooted sessions get the tables they log to.
 - `worker/__main__.py` — worker-side schema init (calls directly, not via ADK callback)
 
 ## Qdrant


### PR DESCRIPTION
## Summary

PT30 wired the `telemetry_events` schema init only into beto's `setup_before_agent_call`. Scout-rooted sessions don't fire that callback, so every scout model turn dropped its telemetry batch in production with:

```
telemetry: dropped batch of 1 — DB write failed: relation \"telemetry_events\" does not exist
```

This PR moves the init call into `web/app.py::initialize_app_startup` so it runs unconditionally on process start, alongside the existing `credential_store` + `chat_history` + `llm_usage_log` schema inits. The beto-side init stays in place (idempotent `CREATE TABLE IF NOT EXISTS`, no harm in running twice).

## Specs updated

- `specs/storage.md` — updated the schema-init section to explicitly call out the scout-root callback gap and list `telemetry_events` under `web/app.py::initialize_app_startup`.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local `make lint` green
- [x] Local `make test-unit` green (426 passed)
- [x] Confirmed prod stderr (Nomad alloc `8f24ddab`) showed the error on every scout model turn
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90