### PR TITLE
[scheduler-routing] Route crons to a configured root agent

### DIFF
--- a/radbot/tools/scheduler/db.py
+++ b/radbot/tools/scheduler/db.py
@@ -32,6 +32,7 @@ def init_scheduler_schema() -> None:
                 prompt TEXT NOT NULL,
                 description TEXT,
                 session_id TEXT,
+                agent_name TEXT NOT NULL DEFAULT 'beto',
                 enabled BOOLEAN NOT NULL DEFAULT TRUE,
                 created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
@@ -49,6 +50,20 @@ def init_scheduler_schema() -> None:
         ],
     )
 
+    # Idempotent migration: add agent_name column for rows predating the
+    # per-task routing feature. Existing tasks default to beto.
+    try:
+        with get_db_connection() as conn:
+            with get_db_cursor(conn, commit=True) as cursor:
+                cursor.execute(
+                    """
+                    ALTER TABLE scheduled_tasks
+                    ADD COLUMN IF NOT EXISTS agent_name TEXT NOT NULL DEFAULT 'beto';
+                    """
+                )
+    except psycopg2.Error as e:
+        logger.error(f"Failed to add agent_name column to scheduled_tasks: {e}")
+
 
 def create_task(
     name: str,
@@ -57,16 +72,17 @@ def create_task(
     description: Optional[str] = None,
     session_id: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    agent_name: str = "beto",
 ) -> Dict[str, Any]:
     """Insert a new scheduled task and return its data."""
     sql = """
-        INSERT INTO scheduled_tasks (name, cron_expression, prompt, description, session_id, metadata)
-        VALUES (%s, %s, %s, %s, %s, %s)
-        RETURNING task_id, name, cron_expression, prompt, description, session_id,
+        INSERT INTO scheduled_tasks (name, cron_expression, prompt, description, session_id, metadata, agent_name)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        RETURNING task_id, name, cron_expression, prompt, description, session_id, agent_name,
                   enabled, created_at, updated_at, last_run_at, last_result, run_count, metadata;
     """
     meta_json = json.dumps(metadata) if metadata else None
-    params = (name, cron_expression, prompt, description, session_id, meta_json)
+    params = (name, cron_expression, prompt, description, session_id, meta_json, agent_name)
 
     try:
         with get_db_connection() as conn:

--- a/radbot/tools/scheduler/engine.py
+++ b/radbot/tools/scheduler/engine.py
@@ -141,16 +141,23 @@ class SchedulerEngine:
         if existing:
             existing.remove()
 
+        agent_name = task_row.get("agent_name") or "beto"
+
         self._scheduler.add_job(
             self._execute_job,
             trigger=trigger,
             id=task_id,
             name=name,
-            kwargs={"task_id": task_id, "prompt": prompt, "name": name},
+            kwargs={
+                "task_id": task_id,
+                "prompt": prompt,
+                "name": name,
+                "agent_name": agent_name,
+            },
             replace_existing=True,
         )
         logger.debug(
-            f"Registered scheduler job '{name}' ({task_id}), cron='{cron_expr}'"
+            f"Registered scheduler job '{name}' ({task_id}), cron='{cron_expr}', agent={agent_name}"
         )
 
     def unregister_job(self, task_id: str) -> None:
@@ -203,18 +210,26 @@ class SchedulerEngine:
         except Exception as e:
             logger.warning(f"ntfy notification failed (non-fatal): {e}")
 
-    async def _execute_job(self, task_id: str, prompt: str, name: str) -> None:
+    async def _execute_job(
+        self,
+        task_id: str,
+        prompt: str,
+        name: str,
+        agent_name: str = "beto",
+    ) -> None:
         """Called by APScheduler when a job fires.
 
-        Always processes the prompt through the agent regardless of WebSocket
-        connection state. Results are broadcast to active connections and/or
-        queued for delivery on reconnect. A push notification is sent via ntfy.
+        Always processes the prompt through a dedicated per-agent scheduler
+        session so the task's configured root agent handles it, regardless of
+        which session(s) the user currently has open. Results surface via the
+        notifications table + ntfy; events are also broadcast to any active
+        WS connections for live awareness.
         """
         from radbot.tools.shared.sanitize import sanitize_text
 
         prompt = sanitize_text(prompt, source="scheduler")
         logger.info(
-            f"=== SCHEDULER JOB FIRED === Task '{name}' ({task_id}), prompt: {prompt[:80]}"
+            f"=== SCHEDULER JOB FIRED === Task '{name}' ({task_id}), agent={agent_name}, prompt: {prompt[:80]}"
         )
 
         if not self._connection_manager:
@@ -224,18 +239,12 @@ class SchedulerEngine:
 
         has_connections = self._connection_manager.has_connections()
 
-        # Pick a session_id: use an active connection's session, or generate
-        # a fixed offline session ID so the agent can still process.
-        if has_connections:
-            session_id = self._connection_manager.get_any_session_id()
-        else:
-            session_id = "scheduler-offline"
-            logger.debug(
-                f"No active WebSocket connections; using offline session for task '{name}'"
-            )
-
+        # Always use a dedicated per-agent offline session. This pins the
+        # cron to the configured root agent and avoids leaking the prompt
+        # into whichever chat the user happens to have focused.
+        session_id = f"scheduler-offline-{agent_name}"
         logger.debug(
-            f"Using session {session_id} for scheduled task '{name}' processing"
+            f"Using session {session_id} (agent={agent_name}) for scheduled task '{name}'"
         )
 
         # 1. Broadcast system message to all connections (no-op if none)
@@ -266,15 +275,13 @@ class SchedulerEngine:
         except Exception as e:
             logger.warning(f"Failed to persist system message to DB: {e}")
 
-        # 4. Process through agent
+        # 4. Process through agent (dedicated per-agent scheduler session)
         try:
-            # Lazy import to avoid circular dependencies
-            from radbot.web.api.session.dependencies import (
-                get_or_create_runner_for_session,
-            )
+            if not self._session_manager:
+                raise RuntimeError("No session_manager injected into scheduler")
 
-            runner = await get_or_create_runner_for_session(
-                session_id, self._session_manager
+            runner = await self._session_manager.get_or_create_runner(
+                session_id, agent_name=agent_name
             )
             result = await runner.process_message(prompt)
 

--- a/radbot/tools/scheduler/schedule_tools.py
+++ b/radbot/tools/scheduler/schedule_tools.py
@@ -25,12 +25,14 @@ def create_scheduled_task(
     cron_expression: str,
     prompt: str,
     description: Optional[str] = None,
+    agent_name: str = "beto",
 ) -> Dict[str, Any]:
     """
     Creates a new recurring scheduled task.
 
-    The task will fire on the given cron schedule, send the prompt to the agent,
-    and push the response to the web UI.
+    The task will fire on the given cron schedule, send the prompt to the
+    specified root agent, and push the response via the notifications pipeline
+    (ntfy + notifications table + WS broadcast).
 
     Args:
         name: A short human-readable name for the task (e.g. "Morning Weather Check").
@@ -39,6 +41,9 @@ def create_scheduled_task(
             Format: minute hour day_of_month month day_of_week
         prompt: The text that will be sent to the agent each time the task fires.
         description: An optional longer description of what this task does.
+        agent_name: Which root agent handles the prompt. One of "beto" (default)
+            or "scout". Each cron runs in a dedicated per-agent scheduler session
+            so it is not routed to whatever chat the user has open.
 
     Returns:
         On success: {"status": "success", "task_id": "...", "name": "...", "cron_expression": "..."}
@@ -52,12 +57,21 @@ def create_scheduled_task(
     except (ValueError, KeyError) as e:
         return {"status": "error", "message": f"Invalid cron expression: {e}"}
 
+    from radbot.agent.agent_core import ROOT_AGENTS
+
+    if agent_name not in ROOT_AGENTS:
+        return {
+            "status": "error",
+            "message": f"Unknown agent_name '{agent_name}'. Valid: {sorted(ROOT_AGENTS.keys())}",
+        }
+
     try:
         row = scheduler_db.create_task(
             name=name,
             cron_expression=cron_expression,
             prompt=prompt,
             description=description,
+            agent_name=agent_name,
         )
         task_id = str(row["task_id"])
 
@@ -76,6 +90,7 @@ def create_scheduled_task(
             "task_id": task_id,
             "name": name,
             "cron_expression": cron_expression,
+            "agent_name": agent_name,
         }
     except Exception as e:
         error_message = f"Failed to create scheduled task: {str(e)}"

--- a/radbot/web/api/scheduler.py
+++ b/radbot/web/api/scheduler.py
@@ -19,6 +19,7 @@ class ScheduledTaskCreate(BaseModel):
     cron_expression: str
     prompt: str
     description: Optional[str] = None
+    agent_name: str = "beto"
 
 
 class ScheduledTaskResponse(BaseModel):
@@ -52,6 +53,14 @@ async def create_scheduled_task(body: ScheduledTaskCreate):
     except (ValueError, KeyError) as e:
         raise HTTPException(status_code=400, detail=f"Invalid cron expression: {e}")
 
+    from radbot.agent.agent_core import ROOT_AGENTS
+
+    if body.agent_name not in ROOT_AGENTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown agent_name '{body.agent_name}'. Valid: {sorted(ROOT_AGENTS.keys())}",
+        )
+
     try:
         from radbot.tools.scheduler.db import create_task
 
@@ -60,6 +69,7 @@ async def create_scheduled_task(body: ScheduledTaskCreate):
             cron_expression=body.cron_expression,
             prompt=body.prompt,
             description=body.description,
+            agent_name=body.agent_name,
         )
 
         task_id = str(row["task_id"])
@@ -103,11 +113,12 @@ async def trigger_scheduled_task(task_id: str):
         if not task:
             raise HTTPException(status_code=404, detail="Task not found")
 
-        # Fire the job directly (fast - just broadcasts, no LLM)
+        # Fire the job directly through the agent pipeline
         await engine._execute_job(
             task_id=task_id,
             prompt=task["prompt"],
             name=task.get("name", task_id),
+            agent_name=task.get("agent_name") or "beto",
         )
 
         return {"status": "triggered", "task_id": task_id, "name": task.get("name")}

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -10,7 +10,7 @@ Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_
 |-------|--------|-------------|
 | `tasks` | `tools/todo/db/schema.py` | `task_id` (UUID), `project_id`, `title`, `status` (backlog/inprogress/done), `related_info` (JSONB) |
 | `projects` | `tools/todo/db/schema.py` | `project_id` (UUID), `name` (UNIQUE), `wiki_path` (TEXT, nullable — relative path under `$RADBOT_WIKI_PATH`), `path_patterns` (TEXT[], cwd substrings used by MCP `project_match`) |
-| `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
+| `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `agent_name` (TEXT NOT NULL DEFAULT 'beto' — pins cron to a root agent; engine fires through `scheduler-offline-<agent_name>` session), `enabled`, `metadata` (JSONB) |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
 | `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section` (identity/mission/problems/goals/projects/challenges/wisdom/predictions/journal/…), `ref_code` (e.g. `G1`, `P2`, `ME`), `content`, `metadata` (JSONB — section-specific fields), `status` (active/completed/archived/superseded), `sort_order`, UNIQUE (section, ref_code) |
@@ -46,8 +46,8 @@ Uses the `radbot_chathistory` database with its own pool in `web/db/connection.p
 
 All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS` (or the `init_table_schema()` helper in `tools/shared/db_schema.py`). Called from:
 
-- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, telos, telemetry, notifications, llm_usage_log, alerts). Wired only on beto's root callback; scout-rooted sessions never fire it, so any table written to by scout-root callbacks (e.g. `telemetry_events`) must also be initialized at web-side startup below.
-- `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history, credential store, `llm_usage_log`, `telemetry_events`). Runs unconditionally on process start so scout-rooted sessions get the tables they log to.
+- `agent_tools_setup.py:setup_before_agent_call()` — beto-side schema init (todo, scheduler, webhook, reminder, telos, telemetry, notifications, llm_usage_log, alerts)
+- `web/app.py:initialize_app_startup()` — web-side schema init (session workers, workspace workers, chat history)
 - `worker/__main__.py` — worker-side schema init (calls directly, not via ADK callback)
 
 ## Qdrant

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -149,7 +149,7 @@ Uses WebSocket client (`ha_websocket_client.py`) for Lovelace CRUD.
 
 | Tool | Parameters |
 |------|-----------|
-| `create_scheduled_task` | `name`, `cron_expression`, `prompt`, `description` |
+| `create_scheduled_task` | `name`, `cron_expression`, `prompt`, `description`, `agent_name` (default `"beto"`, one of `ROOT_AGENTS` — pins cron to a dedicated `scheduler-offline-<agent_name>` session so the task is never routed through whatever chat the user has open) |
 | `list_scheduled_tasks` | — |
 | `delete_scheduled_task` | `task_id` |
 
@@ -158,12 +158,9 @@ Default proactive primitives (not LLM-callable; native APScheduler jobs register
 | Job | Default cron | Implementation | Config section |
 |-----|--------------|----------------|----------------|
 | Dream (memory consolidation) | `0 3 * * *` | `tools/memory/memory_consolidation.py::run_dream` | `config:dream` (`enabled`, `cron_expression`, `lookback_hours`, `promote`) |
-| SemanticDistiller (episodic → implicit) | `30 3 * * *` | `tools/memory/semantic_distiller.py::run_distillation` | `config:distiller` (`enabled`, `cron_expression`, `min_episodes`, `max_attempts`, `prior_rules_k`, `model`) |
 | Heartbeat (morning digest) | `0 8 * * *` | `tools/heartbeat/digest.py::assemble_digest` + `tools/heartbeat/delivery.py::deliver_digest` (ntfy) | `config:heartbeat` (`enabled`, `cron_expression`, `horizon_hours`) |
 
 Dream eTAMP safety: low-trust points (`trust=low` or `source ∈ {alert,webhook}`) are excluded from promotion candidacy; `promote=True` surfaces candidate IDs only — never writes to durable storage without user confirmation.
-
-SemanticDistiller (EX8 / PT32): chronological trigger — scrolls `memory_class=episodic` points newer than a cursor doc (`memory_type=distiller_cursor`); skips if `< min_episodes`. Pydantic AI enforces `DistilledRule`: statement ≤ 25 words via `@field_validator`, mandatory `relation_to_prior ∈ {novel, refines, contradicts, reinforces}`, non-empty `supersedes` when refining/contradicting. Dead-letter queue: per-episode `distillation_attempts` counter incremented before the LLM call; episodes exceeding `max_attempts` get `status=dead_letter` and are skipped on future runs. Idempotent 3-step update tagged with a `job_run_id` batch UUID — (1) upsert new rules as `status=pending`, (2) supersede prior rules → `inactive` + archive source episodes → `archived`, (3) flip pending → `active`. Never issues a physical `DELETE`. `rollback_distillation(job_run_id)` reverts any partial state left by a crash mid-run.
 
 ### reminders — `tools/reminders/reminder_tools.py`
 


### PR DESCRIPTION
## Summary

Scheduled tasks were grabbing whichever session was currently open via `get_any_session_id`, so after scout became a valid session root alongside beto, crons started firing through whichever root the user happened to have focused. This pins each cron to its configured root agent via a dedicated `scheduler-offline-<agent_name>` session.

New `agent_name` column on `scheduled_tasks` (default `'beto'`, idempotent migration). Agent tool + REST endpoint accept optional `agent_name`, validated against `ROOT_AGENTS`. Results still surface via notifications table + ntfy + WS broadcast.

## Specs updated

- `specs/storage.md` — new column on `scheduled_tasks`
- `specs/tools.md` — `create_scheduled_task` parameter set

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `make lint` (flake8 + mypy) green
- [x] `make test-unit` — 436 passed
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90