### PR TITLE
[pt46-schema-lint] PR-gate tool schema drift lint (EX17 / PT46)

### DIFF
--- a/.github/workflows/quality-pipeline.yml
+++ b/.github/workflows/quality-pipeline.yml
@@ -205,6 +205,8 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - run: uv sync --all-extras
       - run: make lint
+      - name: Tool schema drift lint (EX17 / PT46)
+        run: uv run python -m tests.schema.lint
       - id: score
         if: always()
         run: echo "score=${{ job.status == 'success' && '10' || '0' }}" >> "$GITHUB_OUTPUT"

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -123,7 +123,7 @@ Absent either condition, every job is skipped. No skipped/red noise.
 | `secret-scan` | — | yes | gitleaks + trufflehog on the diff. Failure caps total score at 0. |
 | `path-guard` | — | yes (sets flag) | Sets `auto_merge_blocked=true` if hard-block paths touched. |
 | `upstream-health` | — | no | Pre-flight Gemini + Anthropic 1-token ping; cancels workflow on upstream 5xx. |
-| `lint` | 10 | no | `make lint` |
+| `lint` | 10 | no | `make lint` + tool schema drift lint (`uv run python -m tests.schema.lint`) — EX17 / PT46. Fails on any drift from `tests/schema/snapshots/tool_schemas.snapshot.json`; regenerate locally with `--update`. |
 | `build` | 10 | no | `npm run build` |
 | `unit-tests` | 20 | no | `make test-unit && make test-integration` |
 | `coverage-delta` | 10 | no | New `src/pages/*.tsx` without coverage-map entry → 0/10. |

--- a/tests/schema/__main__.py
+++ b/tests/schema/__main__.py
@@ -1,0 +1,3 @@
+from tests.schema.lint import main
+
+raise SystemExit(main())

--- a/tests/schema/extract.py
+++ b/tests/schema/extract.py
@@ -1,0 +1,167 @@
+"""Shared schema-extraction library for RadBot tool validation.
+
+Produces a `pydantic.TypeAdapter` for a tool's input payload so that both the
+PR-gate static lint and the FakeLlm runtime validator can enforce that mock /
+fixture payloads satisfy the real Python-level constraints of the callable —
+constraints that are lossy when round-tripped through the Gemini schema proto
+(EX17 "pydantic-constraint drift").
+
+Public API:
+    extract_pydantic_adapter(tool) -> TypeAdapter
+    MCPToolSkipped                   (NotImplementedError subclass / skip marker)
+    iter_tool_adapters(tools)        (lint helper that skips MCP tools)
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+
+from pydantic import BaseModel, TypeAdapter, create_model
+
+
+class MCPToolSkipped(NotImplementedError):
+    """Raised for MCP-proxied tools — schemas live on the remote server.
+
+    Doubles as the skip marker: lint / validator call sites catch this and
+    record a skip rather than failing. See EX17 rubric item 2.
+    """
+
+
+@dataclass(frozen=True)
+class SkippedTool:
+    """Record emitted by `iter_tool_adapters` for tools we can't introspect."""
+
+    tool_name: str
+    reason: str
+
+
+_CONTEXT_PARAM_NAMES = frozenset({"tool_context", "callback_context", "input_stream"})
+
+
+def _is_mcp_tool(tool: Any) -> bool:
+    # Duck-typed to avoid importing the ADK MCP module at lint time (it pulls
+    # in async MCP machinery). Fall back to the real class if available.
+    cls = type(tool)
+    mod = getattr(cls, "__module__", "") or ""
+    if "mcp_tool" in mod or "mcp_toolset" in mod:
+        return True
+    return cls.__name__ in {"MCPTool", "McpTool"}
+
+
+def _callable_to_model(func: Callable[..., Any], *, model_name: str) -> type[BaseModel]:
+    """Build a pydantic model mirroring the callable's keyword signature.
+
+    Skips ADK-injected context params and variadic *args/**kwargs. Parameters
+    without annotations are typed as `Any` — this matches the permissiveness of
+    `FunctionTool._get_declaration` while still letting pydantic enforce any
+    annotations / `Annotated[..., Field(...)]` constraints that *are* present.
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError) as exc:
+        raise NotImplementedError(f"cannot inspect {func!r}: {exc}") from exc
+
+    # Resolve string annotations (PEP 563 / `from __future__ import annotations`)
+    # back to real types, preserving `Annotated[...]` metadata like Field(ge=...).
+    try:
+        resolved_hints = typing.get_type_hints(func, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+
+    fields: dict[str, tuple[Any, Any]] = {}
+    for name, param in sig.parameters.items():
+        if name in _CONTEXT_PARAM_NAMES:
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if name in resolved_hints:
+            annotation = resolved_hints[name]
+        elif param.annotation is not inspect.Parameter.empty:
+            annotation = param.annotation
+        else:
+            annotation = Any
+        default = ... if param.default is inspect.Parameter.empty else param.default
+        fields[name] = (annotation, default)
+
+    model = create_model(model_name, **fields)  # type: ignore[call-overload]
+    model.model_rebuild(force=True)
+    return model
+
+
+def _agent_input_model(tool: Any) -> type[BaseModel]:
+    agent = getattr(tool, "agent", None)
+    if agent is None:
+        raise NotImplementedError(f"AgentTool {tool!r} has no .agent attribute")
+
+    # LlmAgent exposes `input_schema`; composite agents may delegate to a sub.
+    schema = getattr(agent, "input_schema", None)
+    if schema is None and getattr(agent, "sub_agents", None):
+        schema = getattr(agent.sub_agents[0], "input_schema", None)
+
+    if schema is not None and inspect.isclass(schema) and issubclass(schema, BaseModel):
+        return schema
+
+    # ADK's default when no input_schema: {"request": str}.
+    return create_model(f"{agent.name}Input", request=(str, ...))
+
+
+def extract_pydantic_adapter(tool: Any) -> TypeAdapter:
+    """Return a `TypeAdapter` that validates the tool's input payload.
+
+    Raises:
+        MCPToolSkipped: for MCP-proxied tools. Callers must catch and record a
+            skip — MCP schemas are defined remotely and cannot be round-tripped
+            through pydantic without contacting the server.
+        NotImplementedError: for other un-introspectable tool shapes.
+    """
+    if _is_mcp_tool(tool):
+        name = getattr(tool, "name", type(tool).__name__)
+        raise MCPToolSkipped(f"{name} is MCP-proxied; schema is defined remotely")
+
+    if hasattr(tool, "agent"):
+        model = _agent_input_model(tool)
+        return TypeAdapter(model)
+
+    func = getattr(tool, "func", None)
+    if callable(func):
+        model_name = getattr(tool, "name", None) or func.__name__
+        model = _callable_to_model(func, model_name=f"{model_name}Input")
+        return TypeAdapter(model)
+
+    if callable(tool):
+        model_name = getattr(tool, "__name__", type(tool).__name__)
+        model = _callable_to_model(tool, model_name=f"{model_name}Input")
+        return TypeAdapter(model)
+
+    raise NotImplementedError(
+        f"don't know how to extract a schema from {type(tool).__name__} "
+        f"(module {type(tool).__module__})"
+    )
+
+
+def iter_tool_adapters(
+    tools: list[Any],
+) -> Iterator[tuple[str, TypeAdapter | SkippedTool]]:
+    """Yield `(name, adapter_or_skip)` pairs for a list of tools.
+
+    MCP tools (and other un-introspectable tools) yield a `SkippedTool` record
+    so the lint produces a stable manifest including what was skipped and why.
+    """
+    for tool in tools:
+        name = (
+            getattr(tool, "name", None)
+            or getattr(tool, "__name__", None)
+            or type(tool).__name__
+        )
+        try:
+            yield name, extract_pydantic_adapter(tool)
+        except MCPToolSkipped as exc:
+            yield name, SkippedTool(tool_name=name, reason=str(exc))
+        except NotImplementedError as exc:
+            yield name, SkippedTool(tool_name=name, reason=f"unsupported: {exc}")

--- a/tests/schema/lint.py
+++ b/tests/schema/lint.py
@@ -1,0 +1,192 @@
+"""PR-gate static lint — snapshot + diff of every tool's pydantic schema.
+
+Walks the full RadBot agent graph (beto + all sub-agents), extracts a
+pydantic-derived JSON schema for every tool via `extract_pydantic_adapter`,
+and serializes the result through the `ToolSchemaSet` model (same committed-
+pydantic pattern ADK uses for `EvalSet`). Compares against the committed
+snapshot. On mismatch: fails CI with instructions to regenerate.
+
+Usage:
+    uv run python -m tests.schema.lint            # check mode (CI default)
+    uv run python -m tests.schema.lint --update   # regenerate snapshot locally
+
+The lint fails on *any* change. Classification of breaking vs non-breaking
+drift is deliberately out of scope — the rule is "someone must look at this."
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tests.schema.extract import SkippedTool, iter_tool_adapters
+
+SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / "tool_schemas.snapshot.json"
+
+
+class ToolSchema(BaseModel):
+    """One tool's input-schema record. Mirrors ADK's EvalCase ergonomics."""
+
+    name: str
+    agent: str
+    json_schema: dict[str, Any]
+
+
+class SkippedRecord(BaseModel):
+    name: str
+    agent: str
+    reason: str
+
+
+class ToolSchemaSet(BaseModel):
+    """Committed snapshot of every tool schema in the agent graph.
+
+    Follows the google/adk-python `EvalSet` convention: pydantic BaseModel,
+    single JSON file, `model_dump_json(indent=2)` serialization for
+    human-reviewable diffs in PRs.
+    """
+
+    snapshot_id: str = "radbot-tool-schemas-v1"
+    description: str = (
+        "Import-time schema of every agent tool. Regenerate with "
+        "`uv run python -m tests.schema.lint --update` and review the diff."
+    )
+    tools: list[ToolSchema] = Field(default_factory=list)
+    skipped: list[SkippedRecord] = Field(default_factory=list)
+
+
+def _walk_agents(root: Any) -> list[tuple[str, Any]]:
+    """Yield `(agent_name, tool)` for root + every reachable sub-agent, deduped."""
+    seen_agents: set[int] = set()
+    seen_tools: set[tuple[str, str]] = set()
+    out: list[tuple[str, Any]] = []
+
+    def visit(agent: Any) -> None:
+        if id(agent) in seen_agents:
+            return
+        seen_agents.add(id(agent))
+        for tool in getattr(agent, "tools", None) or []:
+            tool_name = getattr(tool, "name", None) or type(tool).__name__
+            key = (agent.name, tool_name)
+            if key in seen_tools:
+                continue
+            seen_tools.add(key)
+            out.append((agent.name, tool))
+        for sub in getattr(agent, "sub_agents", None) or []:
+            visit(sub)
+
+    visit(root)
+    return out
+
+
+def _load_root_agent() -> Any:
+    from radbot.agent.agent_core import root_agent
+
+    return root_agent
+
+
+def build_snapshot() -> ToolSchemaSet:
+    """Regenerate the snapshot in-memory from the live agent graph."""
+    root = _load_root_agent()
+    pairs = _walk_agents(root)
+
+    tools: list[ToolSchema] = []
+    skipped: list[SkippedRecord] = []
+
+    for agent_name, tool in pairs:
+        name = getattr(tool, "name", None) or type(tool).__name__
+        # `iter_tool_adapters` handles MCP + unsupported shapes gracefully.
+        results = list(iter_tool_adapters([tool]))
+        _, result = results[0]
+        if isinstance(result, SkippedTool):
+            skipped.append(
+                SkippedRecord(name=name, agent=agent_name, reason=result.reason)
+            )
+            continue
+        try:
+            schema = result.json_schema()
+        except Exception as exc:  # pragma: no cover — defensive
+            skipped.append(
+                SkippedRecord(
+                    name=name, agent=agent_name, reason=f"schema render failed: {exc}"
+                )
+            )
+            continue
+        tools.append(ToolSchema(name=name, agent=agent_name, json_schema=schema))
+
+    tools.sort(key=lambda t: (t.agent, t.name))
+    skipped.sort(key=lambda s: (s.agent, s.name))
+    return ToolSchemaSet(tools=tools, skipped=skipped)
+
+
+def _serialize(snap: ToolSchemaSet) -> str:
+    # `indent=2` + trailing newline → clean git diffs.
+    return snap.model_dump_json(indent=2) + "\n"
+
+
+def _load_committed() -> str | None:
+    if not SNAPSHOT_PATH.exists():
+        return None
+    return SNAPSHOT_PATH.read_text()
+
+
+def check() -> int:
+    current = _serialize(build_snapshot())
+    committed = _load_committed()
+
+    if committed is None:
+        sys.stderr.write(
+            f"error: no committed snapshot at {SNAPSHOT_PATH}.\n"
+            "Run `uv run python -m tests.schema.lint --update` and commit the result.\n"
+        )
+        return 2
+
+    if current == committed:
+        print(f"ok: tool schemas match {SNAPSHOT_PATH.name}")
+        return 0
+
+    diff = difflib.unified_diff(
+        committed.splitlines(keepends=True),
+        current.splitlines(keepends=True),
+        fromfile=f"a/{SNAPSHOT_PATH.name}",
+        tofile=f"b/{SNAPSHOT_PATH.name}",
+    )
+    sys.stderr.write(
+        "error: tool schemas drifted from committed snapshot.\n"
+        "This is the pydantic-constraint drift guard (EX17 / PT46).\n"
+        "If the change is intentional, regenerate and commit:\n"
+        "    uv run python -m tests.schema.lint --update\n"
+        "Diff:\n"
+    )
+    sys.stderr.writelines(diff)
+    return 1
+
+
+def update() -> int:
+    snap = build_snapshot()
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_PATH.write_text(_serialize(snap))
+    print(
+        f"wrote {SNAPSHOT_PATH}: {len(snap.tools)} tools, {len(snap.skipped)} skipped"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Regenerate and write the committed snapshot (developer action; NOT for CI).",
+    )
+    args = parser.parse_args(argv)
+    return update() if args.update else check()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/schema/snapshots/tool_schemas.snapshot.json
+++ b/tests/schema/snapshots/tool_schemas.snapshot.json
@@ -1,0 +1,5079 @@
+{
+  "snapshot_id": "radbot-tool-schemas-v1",
+  "description": "Import-time schema of every agent tool. Regenerate with `uv run python -m tests.schema.lint --update` and review the diff.",
+  "tools": [
+    {
+      "name": "check_nomad_service_health",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "service_name": {
+            "title": "Service Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_name"
+        ],
+        "title": "check_nomad_service_healthInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "claude_code_continue",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "work_folder": {
+            "title": "Work Folder",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt",
+          "session_id",
+          "work_folder"
+        ],
+        "title": "claude_code_continueInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "claude_code_execute",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "work_folder": {
+            "title": "Work Folder",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Session Id"
+          }
+        },
+        "required": [
+          "prompt",
+          "work_folder"
+        ],
+        "title": "claude_code_executeInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "claude_code_plan",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "work_folder": {
+            "title": "Work Folder",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Session Id"
+          }
+        },
+        "required": [
+          "prompt",
+          "work_folder"
+        ],
+        "title": "claude_code_planInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "clone_repository",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "repo": {
+            "title": "Repo",
+            "type": "string"
+          },
+          "branch": {
+            "default": "main",
+            "title": "Branch",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ],
+        "title": "clone_repositoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "code_execution_tool",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "code_execution_toolInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "commit_and_push",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "work_folder": {
+            "title": "Work Folder",
+            "type": "string"
+          },
+          "commit_message": {
+            "title": "Commit Message",
+            "type": "string"
+          },
+          "branch": {
+            "default": "main",
+            "title": "Branch",
+            "type": "string"
+          }
+        },
+        "required": [
+          "work_folder",
+          "commit_message"
+        ],
+        "title": "commit_and_pushInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "execute_shell_command",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "command": {
+            "title": "Command",
+            "type": "string"
+          },
+          "arguments": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Arguments"
+          },
+          "timeout": {
+            "default": 60,
+            "title": "Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "title": "execute_shell_commandInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "generate_documentation",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "output_format": {
+            "default": "markdown",
+            "title": "Output Format",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "title": "generate_documentationInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_info_func",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "get_info_funcInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_nomad_allocation_logs",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "task": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Task"
+          },
+          "log_type": {
+            "default": "stderr",
+            "title": "Log Type",
+            "type": "string"
+          },
+          "lines": {
+            "default": 100,
+            "title": "Lines",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "job_id"
+        ],
+        "title": "get_nomad_allocation_logsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_nomad_job_status",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id"
+        ],
+        "title": "get_nomad_job_statusInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_directory_func",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "path": {
+            "default": "",
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "title": "list_directory_funcInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_nomad_jobs",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prefix"
+          }
+        },
+        "title": "list_nomad_jobsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_workspaces",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {},
+        "title": "list_workspacesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "plan_nomad_job_update",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "job_hcl": {
+            "title": "Job Hcl",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_hcl"
+        ],
+        "title": "plan_nomad_job_updateInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "read_file_func",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "read_file_funcInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "restart_nomad_allocation",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "task": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Task"
+          }
+        },
+        "required": [
+          "job_id"
+        ],
+        "title": "restart_nomad_allocationInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "run_tests",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "test_file": {
+            "title": "Test File",
+            "type": "string"
+          },
+          "test_pattern": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Test Pattern"
+          }
+        },
+        "required": [
+          "test_file"
+        ],
+        "title": "run_testsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_func",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "pattern": {
+            "title": "Pattern",
+            "type": "string"
+          },
+          "exclude_patterns": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Exclude Patterns"
+          }
+        },
+        "required": [
+          "path",
+          "pattern"
+        ],
+        "title": "search_funcInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "submit_nomad_job_update",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "job_spec_json": {
+            "title": "Job Spec Json",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_spec_json"
+        ],
+        "title": "submit_nomad_job_updateInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "validate_code",
+      "agent": "axel",
+      "json_schema": {
+        "properties": {
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "title": "validate_codeInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_entry",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Metadata"
+          },
+          "ref_code": {
+            "default": "",
+            "title": "Ref Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section",
+          "content"
+        ],
+        "title": "telos_add_entryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_exploration",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "topic": {
+            "title": "Topic",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "notes": {
+            "default": "",
+            "title": "Notes",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic",
+          "parent_project"
+        ],
+        "title": "telos_add_explorationInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_goal",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "deadline": {
+            "default": "",
+            "title": "Deadline",
+            "type": "string"
+          },
+          "kpi": {
+            "default": "",
+            "title": "Kpi",
+            "type": "string"
+          },
+          "parent_problem": {
+            "default": "",
+            "title": "Parent Problem",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "telos_add_goalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_idea",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "idea": {
+            "title": "Idea",
+            "type": "string"
+          }
+        },
+        "required": [
+          "idea"
+        ],
+        "title": "telos_add_ideaInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_journal",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "entry": {
+            "title": "Entry",
+            "type": "string"
+          },
+          "event_type": {
+            "default": "",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "related_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Related Refs"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "title": "telos_add_journalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_milestone",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "deadline": {
+            "default": "",
+            "title": "Deadline",
+            "type": "string"
+          },
+          "details": {
+            "default": "",
+            "title": "Details",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "parent_project"
+        ],
+        "title": "telos_add_milestoneInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_prediction",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "claim": {
+            "title": "Claim",
+            "type": "string"
+          },
+          "probability": {
+            "title": "Probability",
+            "type": "number"
+          },
+          "deadline": {
+            "default": "",
+            "title": "Deadline",
+            "type": "string"
+          }
+        },
+        "required": [
+          "claim",
+          "probability"
+        ],
+        "title": "telos_add_predictionInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_task",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "parent_milestone": {
+            "default": "",
+            "title": "Parent Milestone",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "category": {
+            "default": "",
+            "title": "Category",
+            "type": "string"
+          },
+          "task_status": {
+            "default": "backlog",
+            "title": "Task Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "parent_project"
+        ],
+        "title": "telos_add_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_wisdom",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "principle": {
+            "title": "Principle",
+            "type": "string"
+          },
+          "origin": {
+            "default": "",
+            "title": "Origin",
+            "type": "string"
+          }
+        },
+        "required": [
+          "principle"
+        ],
+        "title": "telos_add_wisdomInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_archive",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "reason": {
+            "default": "",
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section",
+          "ref_code"
+        ],
+        "title": "telos_archiveInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_archive_task",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "reason": {
+            "default": "",
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_code"
+        ],
+        "title": "telos_archive_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_complete_goal",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "resolution": {
+            "default": "",
+            "title": "Resolution",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_code"
+        ],
+        "title": "telos_complete_goalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_complete_milestone",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "resolution": {
+            "default": "",
+            "title": "Resolution",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_code"
+        ],
+        "title": "telos_complete_milestoneInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_complete_task",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_code"
+        ],
+        "title": "telos_complete_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_entry",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section",
+          "ref_code"
+        ],
+        "title": "telos_get_entryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_full",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {},
+        "title": "telos_get_fullInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_project",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_or_name": {
+            "title": "Ref Or Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_or_name"
+        ],
+        "title": "telos_get_projectInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_section",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "include_inactive": {
+            "default": false,
+            "title": "Include Inactive",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "section"
+        ],
+        "title": "telos_get_sectionInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_import_markdown",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "markdown_text": {
+            "title": "Markdown Text",
+            "type": "string"
+          },
+          "replace": {
+            "default": false,
+            "title": "Replace",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "markdown_text"
+        ],
+        "title": "telos_import_markdownInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_list_projects",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {},
+        "title": "telos_list_projectsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_list_tasks",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "parent_project": {
+            "default": "",
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "parent_milestone": {
+            "default": "",
+            "title": "Parent Milestone",
+            "type": "string"
+          },
+          "task_status": {
+            "default": "",
+            "title": "Task Status",
+            "type": "string"
+          },
+          "include_inactive": {
+            "default": false,
+            "title": "Include Inactive",
+            "type": "boolean"
+          }
+        },
+        "title": "telos_list_tasksInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_note_taste",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "item": {
+            "title": "Item",
+            "type": "string"
+          },
+          "sentiment": {
+            "title": "Sentiment",
+            "type": "string"
+          },
+          "note": {
+            "default": "",
+            "title": "Note",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "item",
+          "sentiment"
+        ],
+        "title": "telos_note_tasteInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_note_wrong",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "thing": {
+            "title": "Thing",
+            "type": "string"
+          },
+          "why": {
+            "default": "",
+            "title": "Why",
+            "type": "string"
+          }
+        },
+        "required": [
+          "thing"
+        ],
+        "title": "telos_note_wrongInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_resolve_prediction",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "outcome": {
+            "title": "Outcome",
+            "type": "boolean"
+          },
+          "actual_value": {
+            "default": "",
+            "title": "Actual Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_code",
+          "outcome"
+        ],
+        "title": "telos_resolve_predictionInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_search_journal",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "telos_search_journalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_update_entry",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          },
+          "content": {
+            "default": "",
+            "title": "Content",
+            "type": "string"
+          },
+          "metadata_merge": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Metadata Merge"
+          },
+          "status": {
+            "default": "",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section",
+          "ref_code"
+        ],
+        "title": "telos_update_entryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_upsert_identity",
+      "agent": "beto",
+      "json_schema": {
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "location": {
+            "default": "",
+            "title": "Location",
+            "type": "string"
+          },
+          "role": {
+            "default": "",
+            "title": "Role",
+            "type": "string"
+          },
+          "pronouns": {
+            "default": "",
+            "title": "Pronouns",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "telos_upsert_identityInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_lidarr_album",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "foreign_album_id": {
+            "title": "Foreign Album Id",
+            "type": "string"
+          },
+          "album_title": {
+            "title": "Album Title",
+            "type": "string"
+          },
+          "foreign_artist_id": {
+            "title": "Foreign Artist Id",
+            "type": "string"
+          },
+          "artist_name": {
+            "title": "Artist Name",
+            "type": "string"
+          },
+          "monitored": {
+            "default": true,
+            "title": "Monitored",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "foreign_album_id",
+          "album_title",
+          "foreign_artist_id",
+          "artist_name"
+        ],
+        "title": "add_lidarr_albumInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_lidarr_artist",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "foreign_artist_id": {
+            "title": "Foreign Artist Id",
+            "type": "string"
+          },
+          "artist_name": {
+            "title": "Artist Name",
+            "type": "string"
+          },
+          "monitored": {
+            "default": true,
+            "title": "Monitored",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "foreign_artist_id",
+          "artist_name"
+        ],
+        "title": "add_lidarr_artistInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_to_picnic_cart",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "product_id": {
+            "title": "Product Id",
+            "type": "string"
+          },
+          "count": {
+            "default": 1,
+            "title": "Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "product_id"
+        ],
+        "title": "add_to_picnic_cartInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "clear_picnic_cart",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "clear_picnic_cartInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_ha_dashboard",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "url_path": {
+            "title": "Url Path",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Icon"
+          },
+          "require_admin": {
+            "default": false,
+            "title": "Require Admin",
+            "type": "boolean"
+          },
+          "show_in_sidebar": {
+            "default": true,
+            "title": "Show In Sidebar",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "url_path",
+          "title"
+        ],
+        "title": "create_ha_dashboardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_ha_dashboard",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "dashboard_id": {
+            "title": "Dashboard Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "dashboard_id"
+        ],
+        "title": "delete_ha_dashboardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "function",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "search_term": {
+            "title": "Search Term",
+            "type": "string"
+          },
+          "domain_filter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Domain Filter"
+          }
+        },
+        "required": [
+          "search_term"
+        ],
+        "title": "search_ha_entitiesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_ha_dashboard_config",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "url_path": {
+            "default": "",
+            "title": "Url Path",
+            "type": "string"
+          }
+        },
+        "title": "get_ha_dashboard_configInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_overseerr_media_details",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "tmdb_id": {
+            "title": "Tmdb Id",
+            "type": "integer"
+          },
+          "media_type": {
+            "title": "Media Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tmdb_id",
+          "media_type"
+        ],
+        "title": "get_overseerr_media_detailsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_picnic_cart",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "get_picnic_cartInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_picnic_delivery_details",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "delivery_id": {
+            "title": "Delivery Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "delivery_id"
+        ],
+        "title": "get_picnic_delivery_detailsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_picnic_delivery_slots",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "get_picnic_delivery_slotsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_picnic_order_history",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "get_picnic_order_historyInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_ha_dashboards",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "list_ha_dashboardsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_lidarr_quality_profiles",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {},
+        "title": "list_lidarr_quality_profilesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_overseerr_requests",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "max_results": {
+            "default": 20,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "filter_status": {
+            "default": "all",
+            "title": "Filter Status",
+            "type": "string"
+          }
+        },
+        "title": "list_overseerr_requestsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "remove_from_picnic_cart",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "product_id": {
+            "title": "Product Id",
+            "type": "string"
+          },
+          "count": {
+            "default": 1,
+            "title": "Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "product_id"
+        ],
+        "title": "remove_from_picnic_cartInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "request_overseerr_media",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "tmdb_id": {
+            "title": "Tmdb Id",
+            "type": "integer"
+          },
+          "media_type": {
+            "title": "Media Type",
+            "type": "string"
+          },
+          "seasons": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Seasons"
+          }
+        },
+        "required": [
+          "tmdb_id",
+          "media_type"
+        ],
+        "title": "request_overseerr_mediaInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "save_ha_dashboard_config",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "config": {
+            "title": "Config",
+            "type": "string"
+          },
+          "url_path": {
+            "default": "",
+            "title": "Url Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "config"
+        ],
+        "title": "save_ha_dashboard_configInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_lidarr_album",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_lidarr_albumInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_lidarr_artist",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_lidarr_artistInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_overseerr_media",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "page": {
+            "default": 1,
+            "title": "Page",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_overseerr_mediaInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_picnic_product",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_picnic_productInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "set_picnic_delivery_slot",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "slot_id": {
+            "title": "Slot Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slot_id"
+        ],
+        "title": "set_picnic_delivery_slotInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "show_ha_device_card",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "entity_id": {
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "area": {
+            "title": "Area",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Detail"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Icon"
+          },
+          "brightness_pct": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Brightness Pct"
+          }
+        },
+        "required": [
+          "entity_id",
+          "name",
+          "area",
+          "state"
+        ],
+        "title": "show_ha_device_cardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "show_media_card",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tmdb_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tmdb Id"
+          },
+          "media_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Media Type"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Year"
+          },
+          "year_range": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Year Range"
+          },
+          "resolution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Resolution"
+          },
+          "format_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Format Label"
+          },
+          "content_rating": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Content Rating"
+          },
+          "season_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Season Count"
+          },
+          "episode_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Episode Count"
+          },
+          "episode_runtime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Episode Runtime"
+          },
+          "on_server_have": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Server Have"
+          },
+          "on_server_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Server Total"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Progress"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Note"
+          },
+          "subtitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subtitle"
+          },
+          "poster_accent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Poster Accent"
+          },
+          "poster_badge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Poster Badge"
+          },
+          "poster_footer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Poster Footer"
+          },
+          "poster_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Poster Title"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Poster Url"
+          }
+        },
+        "required": [
+          "title",
+          "kind",
+          "status"
+        ],
+        "title": "show_media_cardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "show_season_breakdown",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "show": {
+            "title": "Show",
+            "type": "string"
+          },
+          "seasons": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Seasons",
+            "type": "array"
+          }
+        },
+        "required": [
+          "show",
+          "seasons"
+        ],
+        "title": "show_season_breakdownInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "show_video_card",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "video_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Video Id"
+          },
+          "channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Channel"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Duration Seconds"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Published At"
+          },
+          "thumbnail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Thumbnail Url"
+          },
+          "view_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "View Count"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tags"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Note"
+          },
+          "subtitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subtitle"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "kideo_video_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Kideo Video Id"
+          }
+        },
+        "required": [
+          "title",
+          "source",
+          "url"
+        ],
+        "title": "show_video_cardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "submit_shopping_list_to_picnic",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "project_name": {
+            "default": "Groceries",
+            "title": "Project Name",
+            "type": "string"
+          }
+        },
+        "title": "submit_shopping_list_to_picnicInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_ha_dashboard",
+      "agent": "casa",
+      "json_schema": {
+        "properties": {
+          "dashboard_id": {
+            "title": "Dashboard Id",
+            "type": "integer"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Title"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Icon"
+          },
+          "require_admin": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Require Admin"
+          },
+          "show_in_sidebar": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Show In Sidebar"
+          }
+        },
+        "required": [
+          "dashboard_id"
+        ],
+        "title": "update_ha_dashboardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_jira_comment",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "issue_key": {
+            "title": "Issue Key",
+            "type": "string"
+          },
+          "comment": {
+            "title": "Comment",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue_key",
+          "comment"
+        ],
+        "title": "add_jira_commentInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_email_wrapper",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "message_id": {
+            "title": "Message Id",
+            "type": "string"
+          },
+          "account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Account"
+          }
+        },
+        "required": [
+          "message_id"
+        ],
+        "title": "get_email_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_issue_transitions",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "issue_key": {
+            "title": "Issue Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue_key"
+        ],
+        "title": "get_issue_transitionsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_jira_issue",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "issue_key": {
+            "title": "Issue Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue_key"
+        ],
+        "title": "get_jira_issueInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_emails_wrapper",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "max_results": {
+            "default": 10,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "label": {
+            "default": "INBOX",
+            "title": "Label",
+            "type": "string"
+          },
+          "account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Account"
+          }
+        },
+        "title": "list_emails_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_gmail_accounts_wrapper",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {},
+        "title": "list_gmail_accounts_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_my_jira_issues",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Priority"
+          },
+          "max_results": {
+            "default": 20,
+            "title": "Max Results",
+            "type": "integer"
+          }
+        },
+        "title": "list_my_jira_issuesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_emails_wrapper",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 10,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Account"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_emails_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_jira_issues",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "jql": {
+            "title": "Jql",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 20,
+            "title": "Max Results",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "jql"
+        ],
+        "title": "search_jira_issuesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "transition_jira_issue",
+      "agent": "comms",
+      "json_schema": {
+        "properties": {
+          "issue_key": {
+            "title": "Issue Key",
+            "type": "string"
+          },
+          "status_name": {
+            "title": "Status Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue_key",
+          "status_name"
+        ],
+        "title": "transition_jira_issueInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_video_to_kideo",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "collection_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Collection Id"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "add_video_to_kideoInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_videos_to_kideo_batch",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "urls": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Urls",
+            "type": "array"
+          },
+          "collection_id": {
+            "title": "Collection Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "urls",
+          "collection_id"
+        ],
+        "title": "add_videos_to_kideo_batchInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_kideo_collection",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "color": {
+            "default": "#4F46E5",
+            "title": "Color",
+            "type": "string"
+          },
+          "icon": {
+            "default": "star",
+            "title": "Icon",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "create_kideo_collectionInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "generate_video_tags",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "channel_title": {
+            "default": "",
+            "title": "Channel Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "video_id",
+          "title"
+        ],
+        "title": "generate_video_tagsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_kideo_channel_stats",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "collection_id": {
+            "title": "Collection Id",
+            "type": "string"
+          },
+          "days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Days"
+          }
+        },
+        "required": [
+          "collection_id"
+        ],
+        "title": "get_kideo_channel_statsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_kideo_popular_videos",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "collection_id": {
+            "title": "Collection Id",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Days"
+          }
+        },
+        "required": [
+          "collection_id"
+        ],
+        "title": "get_kideo_popular_videosInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_kideo_tag_stats",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "collection_id": {
+            "title": "Collection Id",
+            "type": "string"
+          },
+          "days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Days"
+          }
+        },
+        "required": [
+          "collection_id"
+        ],
+        "title": "get_kideo_tag_statsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_youtube_channel_info",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "channel_id": {
+            "title": "Channel Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channel_id"
+        ],
+        "title": "get_youtube_channel_infoInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_youtube_video_details",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "video_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Video Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "video_ids"
+        ],
+        "title": "get_youtube_video_detailsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_curiositystream_categories",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {},
+        "title": "list_curiositystream_categoriesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_kideo_collections",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {},
+        "title": "list_kideo_collectionsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "retag_untagged_kideo_videos",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {},
+        "title": "retag_untagged_kideo_videosInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_curiositystream",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 10,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "kid_friendly_only": {
+            "default": true,
+            "title": "Kid Friendly Only",
+            "type": "boolean"
+          },
+          "categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Categories"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_curiositystreamInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_youtube_videos",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 10,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "safe_search": {
+            "default": "strict",
+            "title": "Safe Search",
+            "type": "string"
+          },
+          "video_duration": {
+            "default": "medium",
+            "title": "Video Duration",
+            "type": "string"
+          },
+          "order": {
+            "default": "relevance",
+            "title": "Order",
+            "type": "string"
+          },
+          "channel_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Channel Id"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_youtube_videosInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "set_kideo_video_tags",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          }
+        },
+        "required": [
+          "video_id",
+          "tags"
+        ],
+        "title": "set_kideo_video_tagsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "show_video_card",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "video_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Video Id"
+          },
+          "channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Channel"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Duration Seconds"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Published At"
+          },
+          "thumbnail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Thumbnail Url"
+          },
+          "view_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "View Count"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tags"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Note"
+          },
+          "subtitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subtitle"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "kideo_video_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Kideo Video Id"
+          }
+        },
+        "required": [
+          "title",
+          "source",
+          "url"
+        ],
+        "title": "show_video_cardInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "kidsvid",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "check_calendar_availability_wrapper",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "calendar_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Calendar Ids"
+          },
+          "days_ahead": {
+            "default": 7,
+            "title": "Days Ahead",
+            "type": "integer"
+          },
+          "is_workspace": {
+            "default": false,
+            "title": "Is Workspace",
+            "type": "boolean"
+          }
+        },
+        "title": "check_calendar_availability_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_calendar_event_wrapper",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "start_time": {
+            "title": "Start Time",
+            "type": "string"
+          },
+          "end_time": {
+            "title": "End Time",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Location"
+          },
+          "attendees": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Attendees"
+          },
+          "calendar_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Calendar Id"
+          },
+          "timezone": {
+            "default": "UTC",
+            "title": "Timezone",
+            "type": "string"
+          },
+          "is_workspace": {
+            "default": false,
+            "title": "Is Workspace",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "summary",
+          "start_time",
+          "end_time"
+        ],
+        "title": "create_calendar_event_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_reminder",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "remind_at": {
+            "default": "",
+            "title": "Remind At",
+            "type": "string"
+          },
+          "delay_minutes": {
+            "default": 0,
+            "title": "Delay Minutes",
+            "type": "number"
+          },
+          "timezone_name": {
+            "default": "America/Los_Angeles",
+            "title": "Timezone Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "create_reminderInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_scheduled_task",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "cron_expression": {
+            "title": "Cron Expression",
+            "type": "string"
+          },
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description"
+          },
+          "agent_name": {
+            "default": "beto",
+            "title": "Agent Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "cron_expression",
+          "prompt"
+        ],
+        "title": "create_scheduled_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_webhook",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "path_suffix": {
+            "title": "Path Suffix",
+            "type": "string"
+          },
+          "prompt_template": {
+            "title": "Prompt Template",
+            "type": "string"
+          },
+          "secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Secret"
+          }
+        },
+        "required": [
+          "name",
+          "path_suffix",
+          "prompt_template"
+        ],
+        "title": "create_webhookInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_calendar_event_wrapper",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "calendar_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Calendar Id"
+          },
+          "is_workspace": {
+            "default": false,
+            "title": "Is Workspace",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "event_id"
+        ],
+        "title": "delete_calendar_event_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_reminder",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "reminder_id": {
+            "title": "Reminder Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reminder_id"
+        ],
+        "title": "delete_reminderInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_scheduled_task",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_id"
+        ],
+        "title": "delete_scheduled_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_webhook",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "webhook_id": {
+            "title": "Webhook Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "webhook_id"
+        ],
+        "title": "delete_webhookInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "function",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "city": {
+            "default": "UTC",
+            "title": "City",
+            "type": "string"
+          }
+        },
+        "title": "get_current_timeInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_calendar_events_wrapper",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "calendar_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Calendar Id"
+          },
+          "max_results": {
+            "default": 10,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Query"
+          },
+          "days_ahead": {
+            "default": 7,
+            "title": "Days Ahead",
+            "type": "integer"
+          },
+          "is_workspace": {
+            "default": false,
+            "title": "Is Workspace",
+            "type": "boolean"
+          }
+        },
+        "title": "list_calendar_events_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_reminders",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "status": {
+            "default": "pending",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "list_remindersInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_scheduled_tasks",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {},
+        "title": "list_scheduled_tasksInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_webhooks",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {},
+        "title": "list_webhooksInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_calendar_event_wrapper",
+      "agent": "planner",
+      "json_schema": {
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Summary"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Time"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Location"
+          },
+          "attendees": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Attendees"
+          },
+          "calendar_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Calendar Id"
+          },
+          "timezone": {
+            "default": "UTC",
+            "title": "Timezone",
+            "type": "string"
+          },
+          "is_workspace": {
+            "default": false,
+            "title": "Is Workspace",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "event_id"
+        ],
+        "title": "update_calendar_event_wrapperInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "critique_architecture",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "plan": {
+            "title": "Plan",
+            "type": "string"
+          },
+          "prior_round_findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prior Round Findings"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "critique_architectureInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "critique_feasibility",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "plan": {
+            "title": "Plan",
+            "type": "string"
+          },
+          "prior_round_findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prior Round Findings"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "critique_feasibilityInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "critique_safety",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "plan": {
+            "title": "Plan",
+            "type": "string"
+          },
+          "prior_round_findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prior Round Findings"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "critique_safetyInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "critique_ux_dx",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "plan": {
+            "title": "Plan",
+            "type": "string"
+          },
+          "prior_round_findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Prior Round Findings"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "critique_ux_dxInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "divergent_ideation",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "problem_statement": {
+            "title": "Problem Statement",
+            "type": "string"
+          }
+        },
+        "required": [
+          "problem_statement"
+        ],
+        "title": "divergent_ideationInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "grounded_search",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "grounded_searchInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "repo_map",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "repo_name": {
+            "title": "Repo Name",
+            "type": "string"
+          },
+          "subpath": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subpath"
+          },
+          "languages": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Languages"
+          },
+          "max_files": {
+            "default": 200,
+            "title": "Max Files",
+            "type": "integer"
+          },
+          "max_symbols_per_file": {
+            "default": 50,
+            "title": "Max Symbols Per File",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "repo_name"
+        ],
+        "title": "repo_mapInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "repo_read",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "repo_name": {
+            "title": "Repo Name",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "start_line": {
+            "default": 1,
+            "title": "Start Line",
+            "type": "integer"
+          },
+          "end_line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Line"
+          },
+          "max_lines": {
+            "default": 500,
+            "title": "Max Lines",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "repo_name",
+          "path"
+        ],
+        "title": "repo_readInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "repo_references",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "symbol": {
+            "title": "Symbol",
+            "type": "string"
+          },
+          "repo_name": {
+            "title": "Repo Name",
+            "type": "string"
+          },
+          "subpath": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subpath"
+          },
+          "file_glob": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "File Glob"
+          },
+          "max_results": {
+            "default": 200,
+            "title": "Max Results",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "symbol",
+          "repo_name"
+        ],
+        "title": "repo_referencesInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "repo_search",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "repo_name": {
+            "title": "Repo Name",
+            "type": "string"
+          },
+          "subpath": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Subpath"
+          },
+          "file_glob": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "File Glob"
+          },
+          "max_matches": {
+            "default": 50,
+            "title": "Max Matches",
+            "type": "integer"
+          },
+          "context_lines": {
+            "default": 3,
+            "title": "Context Lines",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query",
+          "repo_name"
+        ],
+        "title": "repo_searchInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "repo_sync",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "repo_url": {
+            "title": "Repo Url",
+            "type": "string"
+          },
+          "repo_name": {
+            "title": "Repo Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_url",
+          "repo_name"
+        ],
+        "title": "repo_syncInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_agent_memory",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 5,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "time_window_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Time Window Days"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Type"
+          },
+          "memory_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Class"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "search_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "should_convene_council",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "plan": {
+            "title": "Plan",
+            "type": "string"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "should_convene_councilInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "store_agent_memory",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "information": {
+            "title": "Information",
+            "type": "string"
+          },
+          "memory_type": {
+            "default": "important_fact",
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "memory_class": {
+            "default": "explicit",
+            "title": "Memory Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "information"
+        ],
+        "title": "store_agent_memoryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_exploration",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "topic": {
+            "title": "Topic",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "notes": {
+            "default": "",
+            "title": "Notes",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic",
+          "parent_project"
+        ],
+        "title": "telos_add_explorationInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_journal",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "entry": {
+            "title": "Entry",
+            "type": "string"
+          },
+          "event_type": {
+            "default": "",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "related_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Related Refs"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "title": "telos_add_journalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_milestone",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "deadline": {
+            "default": "",
+            "title": "Deadline",
+            "type": "string"
+          },
+          "details": {
+            "default": "",
+            "title": "Details",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "parent_project"
+        ],
+        "title": "telos_add_milestoneInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_add_task",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "parent_project": {
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "parent_milestone": {
+            "default": "",
+            "title": "Parent Milestone",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "category": {
+            "default": "",
+            "title": "Category",
+            "type": "string"
+          },
+          "task_status": {
+            "default": "backlog",
+            "title": "Task Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "parent_project"
+        ],
+        "title": "telos_add_taskInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_entry",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "ref_code": {
+            "title": "Ref Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section",
+          "ref_code"
+        ],
+        "title": "telos_get_entryInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_full",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {},
+        "title": "telos_get_fullInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_project",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "ref_or_name": {
+            "title": "Ref Or Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref_or_name"
+        ],
+        "title": "telos_get_projectInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_get_section",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          },
+          "include_inactive": {
+            "default": false,
+            "title": "Include Inactive",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "section"
+        ],
+        "title": "telos_get_sectionInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_list_projects",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {},
+        "title": "telos_list_projectsInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_list_tasks",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "parent_project": {
+            "default": "",
+            "title": "Parent Project",
+            "type": "string"
+          },
+          "parent_milestone": {
+            "default": "",
+            "title": "Parent Milestone",
+            "type": "string"
+          },
+          "task_status": {
+            "default": "",
+            "title": "Task Status",
+            "type": "string"
+          },
+          "include_inactive": {
+            "default": false,
+            "title": "Include Inactive",
+            "type": "boolean"
+          }
+        },
+        "title": "telos_list_tasksInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "telos_search_journal",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "telos_search_journalInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "web_fetch",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "web_fetchInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "wiki_list",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "glob": {
+            "default": "**/*.md",
+            "title": "Glob",
+            "type": "string"
+          }
+        },
+        "title": "wiki_listInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "wiki_read",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "wiki_readInput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "wiki_search",
+      "agent": "scout",
+      "json_schema": {
+        "properties": {
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "glob": {
+            "default": "**/*.md",
+            "title": "Glob",
+            "type": "string"
+          },
+          "limit": {
+            "default": 50,
+            "title": "Limit",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "wiki_searchInput",
+        "type": "object"
+      }
+    }
+  ],
+  "skipped": [
+    {
+      "name": "finish_task",
+      "agent": "axel",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "load_artifacts",
+      "agent": "axel",
+      "reason": "unsupported: don't know how to extract a schema from LoadArtifactsTool (module google.adk.tools.load_artifacts_tool)"
+    },
+    {
+      "name": "finish_task",
+      "agent": "casa",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "finish_task",
+      "agent": "comms",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "finish_task",
+      "agent": "kidsvid",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "finish_task",
+      "agent": "planner",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "finish_task",
+      "agent": "scout",
+      "reason": "unsupported: don't know how to extract a schema from FinishTaskTool (module google.adk.agents.llm.task._finish_task_tool)"
+    },
+    {
+      "name": "google_search",
+      "agent": "search_agent",
+      "reason": "unsupported: don't know how to extract a schema from GoogleSearchTool (module google.adk.tools.google_search_tool)"
+    }
+  ]
+}

--- a/tests/schema/test_extract.py
+++ b/tests/schema/test_extract.py
@@ -1,0 +1,154 @@
+"""Unit tests for the schema-extraction library.
+
+Follows the google-adk-python test idiom: construct real `FunctionTool` /
+`LlmAgent` instances from plain Python callables, use `MagicMock(spec=...)`
+only for ADK contexts we don't need to exercise, and assert on concrete
+behavior (the produced `TypeAdapter`) rather than mocking the tool itself.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.tools.agent_tool import AgentTool
+from google.adk.tools.function_tool import FunctionTool
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+from tests.schema.extract import (
+    MCPToolSkipped,
+    SkippedTool,
+    extract_pydantic_adapter,
+    iter_tool_adapters,
+)
+
+
+def plain_add(a: int, b: int) -> int:
+    """Add two ints."""
+    return a + b
+
+
+def constrained_search(
+    query: str, year: Annotated[int, Field(ge=1900, le=2100)] = 2026
+) -> str:
+    """Search with a Python-level constraint that a Gemini proto would lose."""
+    return f"{query}:{year}"
+
+
+def with_context(
+    query: str, tool_context
+) -> str:  # noqa: ARG001 — mirrors ADK's injected param
+    """Tool that declares the ADK-injected context param (must be filtered out)."""
+    return query
+
+
+class _FakeMCPTool:
+    """Stand-in for google.adk.tools.mcp_tool.mcp_tool.MCPTool.
+
+    The extractor detects MCP tools by module-name duck-typing; we mimic that by
+    forcing `__module__` into the `mcp_tool` namespace.
+    """
+
+    __module__ = "google.adk.tools.mcp_tool.mcp_tool"
+    name = "remote_mcp_thing"
+
+
+class SearchInput(BaseModel):
+    topic: str
+    limit: int = Field(ge=1, le=50, default=10)
+
+
+class test_function_tool:  # noqa: N801 — pytest class-less style not used; flat funcs below
+    pass
+
+
+def test_extracts_plain_function_tool_schema():
+    tool = FunctionTool(plain_add)
+
+    adapter = extract_pydantic_adapter(tool)
+
+    # Valid payload passes.
+    assert adapter.validate_python({"a": 1, "b": 2}) is not None
+    # Missing required field fails.
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"a": 1})
+
+
+def test_extractor_enforces_pydantic_constraints_that_gemini_proto_would_drop():
+    """The EX17 'pydantic-constraint drift' failure mode — this is the whole point."""
+    tool = FunctionTool(constrained_search)
+
+    adapter = extract_pydantic_adapter(tool)
+
+    # In-bounds year passes.
+    adapter.validate_python({"query": "hi", "year": 2026})
+    # Out-of-bounds year that a lossy Gemini proto round-trip would accept as a plain int.
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"query": "hi", "year": 1800})
+
+
+def test_extractor_filters_adk_context_params():
+    tool = FunctionTool(with_context)
+
+    adapter = extract_pydantic_adapter(tool)
+
+    # tool_context must not appear in the validated schema.
+    validated = adapter.validate_python({"query": "ok"})
+    assert "tool_context" not in validated.model_dump()
+
+
+def test_agent_tool_uses_input_schema_when_present():
+    agent = LlmAgent(
+        name="searcher", model="gemini-2.5-flash", input_schema=SearchInput
+    )
+    tool = AgentTool(agent=agent)
+
+    adapter = extract_pydantic_adapter(tool)
+
+    adapter.validate_python({"topic": "llms", "limit": 5})
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"topic": "llms", "limit": 999})
+
+
+def test_agent_tool_defaults_to_request_string_when_no_input_schema():
+    agent = LlmAgent(name="chatter", model="gemini-2.5-flash")
+    tool = AgentTool(agent=agent)
+
+    adapter = extract_pydantic_adapter(tool)
+
+    adapter.validate_python({"request": "hello"})
+    with pytest.raises(ValidationError):
+        adapter.validate_python({})  # 'request' is required
+
+
+def test_mcp_tool_raises_skip_marker():
+    tool = _FakeMCPTool()
+
+    with pytest.raises(MCPToolSkipped) as exc:
+        extract_pydantic_adapter(tool)
+
+    assert "mcp" in str(exc.value).lower() or "remote" in str(exc.value).lower()
+
+
+def test_mcp_skip_is_notimplementederror_subclass():
+    """Callers that catch NotImplementedError (the PT46 contract) must also catch the marker."""
+    assert issubclass(MCPToolSkipped, NotImplementedError)
+
+
+def test_iter_tool_adapters_records_skipped_mcp_tools():
+    tools = [FunctionTool(plain_add), _FakeMCPTool()]
+
+    results = dict(iter_tool_adapters(tools))
+
+    assert isinstance(results["plain_add"], TypeAdapter)
+    assert isinstance(results["remote_mcp_thing"], SkippedTool)
+    assert results["remote_mcp_thing"].reason  # non-empty
+
+
+def test_unknown_tool_shape_raises_not_implemented():
+    class NotATool:
+        pass
+
+    with pytest.raises(NotImplementedError):
+        extract_pydantic_adapter(NotATool())

--- a/tests/schema/test_lint.py
+++ b/tests/schema/test_lint.py
@@ -1,0 +1,52 @@
+"""Tests for the PR-gate lint — build_snapshot + drift detection."""
+
+from __future__ import annotations
+
+import json
+
+from tests.schema import lint as lint_module
+
+
+def test_committed_snapshot_matches_live_agent_graph():
+    """The committed snapshot must match what the live agent graph produces.
+
+    This is the actual PR-gate assertion, runnable as a unit test (so it
+    shows up in pytest output alongside everything else). If this fails
+    locally, run `uv run python -m tests.schema.lint --update` and review
+    the diff before committing.
+    """
+    current = lint_module._serialize(lint_module.build_snapshot())
+    committed = lint_module.SNAPSHOT_PATH.read_text()
+    assert current == committed, (
+        "Tool schemas drifted from the committed snapshot.\n"
+        "Regenerate with: uv run python -m tests.schema.lint --update"
+    )
+
+
+def test_snapshot_captures_full_toolset():
+    """Sanity check: snapshot covers every agent in the graph."""
+    snap = json.loads(lint_module.SNAPSHOT_PATH.read_text())
+    agents = {t["agent"] for t in snap["tools"]}
+    # Known agents from CLAUDE.md tool table. Scout has no sub-agents
+    # of its own; the root-agent graph exposes these 8 children.
+    assert {"beto", "axel", "casa", "comms", "kidsvid", "planner"}.issubset(agents)
+
+
+def test_check_fails_on_injected_drift(tmp_path, monkeypatch):
+    """`check()` must exit non-zero when the live schema differs from the snapshot."""
+    # Point the lint at a throwaway path seeded with a deliberately wrong snapshot.
+    fake_snapshot = tmp_path / "tool_schemas.snapshot.json"
+    fake_snapshot.write_text('{"snapshot_id":"bogus","tools":[],"skipped":[]}\n')
+    monkeypatch.setattr(lint_module, "SNAPSHOT_PATH", fake_snapshot)
+
+    rc = lint_module.check()
+
+    assert rc == 1  # drift detected
+
+
+def test_check_errors_when_snapshot_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(lint_module, "SNAPSHOT_PATH", tmp_path / "missing.json")
+
+    rc = lint_module.check()
+
+    assert rc == 2  # distinct exit code so CI can spot the bootstrap case


### PR DESCRIPTION
## Summary

Adds `tests/schema/` — a PR-gate static lint that extracts a pydantic `TypeAdapter` for every tool in the live agent graph (beto + all 8 sub-agents, 161 tools) and diffs against a committed snapshot. Catches the EX17 **pydantic-constraint drift** failure mode: a developer tightens a Python-level constraint (e.g. `Annotated[int, Field(ge=1900)]`) but the lossy Gemini `FunctionDeclaration` round-trip drops it, the LLM calls with a bad value, pydantic rejects at invocation, prod breaks.

Snapshot format follows `google/adk-python`'s `EvalSet` convention: pydantic `BaseModel` + single JSON file + `model_dump_json(indent=2)` for human-reviewable diffs. Unit tests follow ADK's own test idiom (real `FunctionTool`/`LlmAgent`, `MagicMock(spec=...)` only for contexts). MCP-proxied tools raise `MCPToolSkipped` (a `NotImplementedError` subclass that doubles as the skip marker).

## Specs updated

- `specs/testing.md` — lint row updated to include the drift lint step, per the spec ↔ code map rule.

No other specs touched (this is a pure test-infrastructure addition; no new tools, agents, DB tables, or API surface).

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local lint, unit tests, build, schema-specific tests all green (13/13)
- [x] Secret scan clean
- [x] Drift detection verified end-to-end (caught real drift from `repo_read` landing on `main`)
- [x] Stability verified across reruns (memory-address pitfall fixed pre-commit)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)