### PR TITLE
[terse-protocol] sub-agent → Beto JSON token compression (EX21 / PT56-58)

### DIFF
--- a/.claude/skills/telos-review/SKILL.md
+++ b/.claude/skills/telos-review/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: telos-review
+description: >
+  Operate the Claude Code side of the Telos Bipartite Review Loop — the formal
+  Scout↔Claude Code protocol for grounding plans in codebase reality before
+  execution. Use when the user says "review EX<N>", "reality check this
+  exploration", "check scout's plan", "read EX<N> from telos", or wants to
+  pressure-test an exploration written by Scout. Also use when the user says
+  "execute PT<N>", "work PT<X> then PT<Y>", "run the telos tasks", or asks to
+  pick up Project Tasks that Scout has solidified. Covers both the read-only
+  Reality Check stage (Stage 2) and the Contract Execution stage (Stage 4) of
+  the lifecycle. Trigger aggressively whenever the user references an EX<N> or
+  PT<N> code from Telos in a way that implies review or execution — the
+  lifecycle discipline matters more than the exact phrasing.
+---
+
+# telos-review — Bipartite Review Loop (Claude Code side)
+
+## What this skill is
+
+Radbot uses a **Bipartite Review Loop** to keep plans honest. Scout drafts
+hypotheses in Telos; Claude Code (you) grounds them against the real
+repository before they harden into Project Tasks. This skill is the Claude
+Code half of that protocol.
+
+The loop has five stages. You are invoked for two of them:
+
+- **Stage 2 — Reality Check** — read an Exploration (`EX<N>`), compare it to the
+  actual codebase, report what will break. **Do not implement anything.**
+- **Stage 4 — Contract Execution** — once Scout has solidified the plan into
+  Project Tasks (`PT<N>`), pick them up one at a time and execute.
+
+Stages 1, 3, 5 happen on Scout's side (and in Perry's head) — you do not drive
+them, but you should understand them so your output feeds them cleanly.
+
+## Memory primitive discipline
+
+Radbot's memory primitives are strictly typed. When writing back to Telos or
+memory, respect the boundary — do not conflate them:
+
+| Primitive | Purpose | Who writes |
+|---|---|---|
+| `store_agent_memory` | Durable architectural patterns, repo rules, web findings | Scout (post-mortem) |
+| `telos_add_journal` | Personal trajectory, state changes, daily decisions | Scout (post-mortem) |
+| `telos_add_exploration` (`EX<N>`) | Long-form proposals, 5-role context packages, **unverified** | Scout (Stage 1) |
+| `telos_add_task` (`PT<N>`) | Granular, single-turn-sized execution bounds on a Project | Scout (Stage 4) |
+
+The 5-role context package inside an Exploration is: **Authority** (who/what
+decided this), **Exemplar** (concrete pattern to follow), **Constraints**
+(hard limits), **Rubric** (how we know it's done), **Metadata** (refs,
+dependencies). Review against these roles — each one is a place the plan can
+fail.
+
+## Stage 2 — Reality Check
+
+### Rule #1: you do not write code in this stage
+
+The whole point of the Bipartite Review Loop is that Scout's plan may be
+elegant in the abstract but broken against physical repo constraints. If you
+start editing, you collapse the review into implementation and Scout never
+gets the feedback. **Read, grep, reason, report. No Edit / Write / Bash
+mutations.**
+
+If you notice a trivial fix while reading, *still do not fix it* — note it in
+the report. Perry will relay to Scout and the plan will absorb it.
+
+### Procedure
+
+1. **Fetch the exploration from Telos.** Use `mcp__radbot__telos_get_entry`
+   with the section `explorations` and the `ref_code` the user named (e.g.
+   `EX12`). If the user didn't name one, ask — don't guess from recent
+   journal entries, because Explorations and Journals live in separate
+   sections.
+
+2. **Read the 5-role context package carefully.** Before touching the repo,
+   write down (in your head, or a short scratch block) what each role is
+   claiming:
+   - What Authority / decision is being invoked?
+   - What Exemplar file/pattern is the plan imitating?
+   - What Constraints does Scout think apply?
+   - What Rubric will say this is done?
+   - What Metadata (refs, deps, affected modules) is declared?
+
+3. **Consult the LLM Wiki for external research context.** Invoke the
+   `llm-wiki:query` skill with the exploration's topic and any library /
+   pattern / technique names Scout cited. The wiki is our **research**
+   knowledge base — agentic AI patterns, Claude Code practice, production
+   agent deployments, AI-intel feeds (HN / arxiv / YouTube). Use it to
+   check whether the approach Scout proposed has known pitfalls, better
+   alternatives, or prior art from outside this repo. **The wiki is not a
+   source of internal project decisions** — those live in `SPEC.md`,
+   `specs/*.md`, `CLAUDE.md`, and `docs/`, which you read separately in
+   step 4. If the wiki surfaces something that contradicts or refines the
+   plan, fold it into the review. If it's silent on a technique the plan
+   leans on heavily, that's a research gap worth flagging.
+
+4. **Ground each role against the codebase and internal docs.**
+   - Exemplar: does the referenced file/pattern actually exist and still
+     look the way Scout described? Read it. Patterns rot.
+   - Constraints: are there *other* constraints Scout missed? Grep for
+     callers of any function the plan wants to change. Read the spec files
+     (`SPEC.md`, `specs/*.md`, `CLAUDE.md`) and `docs/` entries that govern
+     the affected area — these are the canonical internal record and
+     override anything the wiki says about how *this* project works.
+   - Metadata: follow at least one dependency link. If Scout says "uses
+     `get_integration_config`," open that function and confirm the signature
+     still matches what the plan assumes.
+   - Rubric: is the success criterion actually observable from outside? If
+     not, Scout probably needs to add a test surface before this can ship.
+
+4. **Look for the classes of failure Scout can't see from outside the repo:**
+   - **Stale references** — file/function/flag named in the plan has been
+     renamed or removed.
+   - **Hidden callers** — the change surface has more callers than the plan
+     acknowledges.
+   - **Spec drift** — the plan contradicts a rule in `CLAUDE.md` /
+     `specs/*.md` that Scout didn't re-read.
+   - **Context engineering issues** — the plan would require a single Claude
+     Code turn to hold more context than is reasonable (cross-cutting, many
+     files, ambiguous boundaries). Flag this; Scout should split.
+   - **Agentic technical debt** — the plan ships a shortcut that will force
+     future turns to work around it (missing tests, silent fallbacks,
+     backwards-compat shims the code doesn't need).
+   - **Dependency clashes** — the plan assumes a library/version/behavior
+     that isn't what's actually installed (`pyproject.toml`, lockfiles).
+
+5. **Report in this shape.** Keep it scannable — Perry will paste this back
+   to Scout:
+
+   ```
+   ## Reality Check: EX<N>
+
+   **Verdict:** <airtight | needs revision | fundamentally broken>
+
+   **Grounded correctly:**
+   - <role or claim that checks out, with file:line evidence>
+
+   **Will break:**
+   - <concrete failure mode, with file:line evidence and why it breaks>
+
+   **Missing from the plan:**
+   - <constraint / caller / spec rule Scout should have cited>
+
+   **Suggested refinements for Scout:**
+   - <what to change in EX<N> to make it airtight — as guidance, not a rewrite>
+   ```
+
+6. **Stop.** Do not proceed to implementation even if the plan looks perfect.
+   The handoff from Stage 2 → Stage 4 goes through Scout, not directly from
+   you. Perry will come back with `PT<N>` codes when the contract is ready.
+
+### Why no edits in Stage 2
+
+Two reasons. First, the Exploration is still Scout's artifact — mutating the
+code underneath an unratified plan creates a state Scout didn't see. Second,
+the review's value is precisely that you haven't committed yet; the moment
+you start implementing, your incentive shifts from "find problems" to "make
+this work," and the review degrades.
+
+## Stage 4 — Contract Execution
+
+Once Scout has broken `EX<N>` into `PT<N>` tasks, each task is sized so one
+Claude Code turn can complete it. Your job is to execute them — one at a
+time, in the order Perry specifies.
+
+### Procedure
+
+1. **Fetch each task** via `mcp__radbot__telos_get_entry` (section:
+   `project_tasks`, ref_code: `PT<N>`). If Perry names multiple (e.g.
+   "execute PT34 then PT35"), fetch them all up front so you can see the
+   shape, but **execute sequentially** — do not interleave.
+
+2. **Before touching a task, verify its preconditions.** The contract was
+   written when Scout and you both agreed `EX<N>` was airtight, but time may
+   have passed or the previous `PT<N>` may have shifted state. If the
+   preconditions no longer hold, stop and tell Perry — don't improvise
+   around a broken contract.
+
+3. **Execute within the task's bounds.** `PT<N>` tasks are deliberately
+   narrow. If you find yourself wanting to do work that isn't in the task,
+   that's a signal the contract needs to go back to Scout for re-scoping,
+   not that you should expand scope. Note it and finish the task you were
+   given.
+
+4. **Mark the task complete** via `mcp__radbot__task_complete` when done,
+   with a brief completion note. This is what lets Stage 5 (Scout's
+   post-mortem) find the task and extract lessons.
+
+5. **Report to Perry**: what changed (files + a one-line summary), any
+   friction you hit, and whether the next `PT<N>` in the chain still looks
+   executable given the state you left the repo in. Keep it terse — Perry
+   will relay the friction notes to Scout for Stage 5.
+
+### Don't skip the post-mortem surface
+
+Stage 5 is how Scout learns. Your completion note and friction report are
+the raw material. If something was harder than the plan suggested, *say so*
+even if the task succeeded. Silent successes produce worse future plans
+than noisy successes.
+
+## Triggering shortcuts
+
+- User names a code starting with `EX` → Stage 2 (Reality Check).
+- User names a code starting with `PT` → Stage 4 (Contract Execution).
+- User says "review scout's plan" without a code → ask which `EX<N>`;
+  optionally list recent explorations via `mcp__radbot__search_memory` or
+  `telos_get_section` before asking.
+- User says "work through the telos tasks" without codes → list the open
+  `PT<N>` tasks via `mcp__radbot__list_tasks` and confirm the order with
+  Perry before starting.
+
+## Anti-patterns
+
+- **Collapsing Stage 2 into Stage 4.** Reading `EX<N>` and then implementing
+  it directly because it "looks fine." Defeats the loop.
+- **Writing new tasks yourself.** `PT<N>` creation belongs to Scout. If you
+  think a task is missing, report that as a refinement suggestion in the
+  Reality Check output.
+- **Editing the Exploration.** You do not mutate `EX<N>`. Scout owns the
+  drafting table.
+- **Silent scope creep during Stage 4.** Expanding a `PT<N>` because it
+  "obviously also needs X." Finish the bounded task, report X as friction.
+- **Skipping the Exemplar check.** The Exemplar is the most common source
+  of plan rot — a named pattern that has since moved or been replaced.
+  Always read the file Scout cited.

--- a/radbot/agent/agent_core.py
+++ b/radbot/agent/agent_core.py
@@ -33,6 +33,10 @@ from radbot.callbacks.scope_to_current_turn import (
     scope_sub_agent_context_callback,
 )
 from radbot.callbacks.telemetry_callback import telemetry_after_model_callback
+from radbot.callbacks.terse_protocol import (
+    terse_protocol_after_model_callback,
+    terse_protocol_before_model_callback,
+)
 from radbot.config.config_loader import config_loader
 
 # Import memory tools and services
@@ -162,12 +166,32 @@ _before_cbs = [
     scrub_empty_content_before_model,
     sanitize_tool_schemas_before_model,
 ]
+# Terse JSON Protocol (EX21 / PT56 / PT58): instruct sub-agents to emit
+# compact JSON and re-hydrate it for Beto. Gated at runtime by
+# ``is_terse_protocol_enabled()`` so these callbacks are safe to register
+# with the flag off. Scoped to natural-language sub-agents only — ADK
+# built-ins (search_agent, code_execution_agent) return structured outputs
+# that the protocol would corrupt.
+# Scout is also excluded: per EX21 the protocol applies only to casa,
+# planner, comms, axel, kidsvid. Scout emits structured plans (and can be
+# a session root on its own), which the terse-JSON-to-Beto contract would
+# mangle.
+_TERSE_PROTOCOL_EXCLUDED = {"search_agent", "code_execution_agent", "scout"}
 for sa in all_sub_agents:
+    terse_applies = sa.name not in _TERSE_PROTOCOL_EXCLUDED
     if not sa.after_model_callback:
-        sa.after_model_callback = _after_cbs
+        sa.after_model_callback = (
+            _after_cbs + [terse_protocol_after_model_callback]
+            if terse_applies
+            else _after_cbs
+        )
     # Replace any existing before_model_callback (typically just scrub...) with
     # our combined list so the scope-to-turn filter runs first.
-    sa.before_model_callback = _before_cbs
+    sa.before_model_callback = (
+        _before_cbs + [terse_protocol_before_model_callback]
+        if terse_applies
+        else _before_cbs
+    )
 
 # Create the root agent with ALL sub-agents in the constructor
 root_agent = Agent(

--- a/radbot/callbacks/terse_protocol.py
+++ b/radbot/callbacks/terse_protocol.py
@@ -1,0 +1,357 @@
+"""Terse JSON Protocol for sub-agent → Beto token compression.
+
+### Why
+
+Sub-agents emit a lot of free-form prose that Beto re-renders into its own
+voice. Every token of that intermediate prose is billed twice (once as
+sub-agent output, once as Beto's prompt). Under the Opus 4.7 tokenizer tax
+this is a large and compounding cost.
+
+### What
+
+When ``config:agent.terse_protocol_enabled`` is true (or the env override
+``RADBOT_TERSE_PROTOCOL_ENABLED`` is set truthy), sub-agents are instructed
+to format their final reply to Beto as dense JSON with two fields:
+
+* ``summary`` — a terse, compressed narrative (the thing whose tokens we
+  are trying to save).
+* ``pass_through`` — an array of exact strings Beto must not paraphrase
+  (tool-result dicts, UI fenced blocks like ``radbot:<kind>``, logs, IDs).
+
+Two callbacks cooperate:
+
+* ``terse_protocol_before_model_callback`` (PT56) — appends the protocol
+  instruction to the sub-agent's ``llm_request.config.system_instruction``.
+* ``terse_protocol_after_model_callback`` (PT58) — intercepts the
+  sub-agent's text response, parses the JSON, and re-emits a deterministic
+  markdown rendering for Beto. If parsing fails (malformed or truncated
+  JSON), it strips the broken JSON markers and returns the raw inner text
+  so the turn degrades gracefully instead of dumping ``{"summary":`` at
+  the user.
+
+### Why a separate file
+
+``scope_to_current_turn.py`` trims ``llm_request.contents``; its contract
+is history-level. The terse protocol operates on ``config.system_instruction``
+(request side) and ``llm_response.content`` (response side). Overloading
+the existing callback would blur two orthogonal concerns — reviewed and
+rejected in the EX21 plan council.
+
+### ADK compatibility
+
+Written for ``google-adk>=2.0.0a3`` in V1 LlmAgent mode (the project
+default; see ``CLAUDE.md`` for why V2 ``_Mesh`` is off). Callback
+signatures match the pattern used by ``scope_to_current_turn`` and
+``telemetry_callback``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+TERSE_JSON_OPEN = "<terse_json>"
+TERSE_JSON_CLOSE = "</terse_json>"
+
+TERSE_PROTOCOL_INSTRUCTION = """\
+## Output Protocol: Terse JSON
+
+Your final reply to the orchestrator (Beto) MUST be a single JSON object
+wrapped in <terse_json>...</terse_json> tags. Do not emit any text outside
+those tags on your final turn.
+
+Schema:
+{
+  "summary": "<one to three short sentences, data-dense, no prose filler>",
+  "pass_through": ["<exact string 1>", "<exact string 2>", ...]
+}
+
+Rules:
+- "summary" is the only place your own words appear. Write like a telegram,
+  not like a chat reply. The orchestrator will re-hydrate it into its own
+  voice, so persona / pleasantries / hedging are wasted tokens here.
+- "pass_through" holds strings that must reach the user verbatim: tool
+  result identifiers, exact log lines, UI fenced blocks such as
+  ```radbot:card ... ``` (include the fences), URLs, IDs, quoted errors.
+  When in doubt, pass through rather than summarize — paraphrasing a
+  tool-generated string counts as hallucination.
+- Do not emit the protocol tags on tool-call turns. They apply only to
+  the final natural-language response that returns control to Beto.
+- If you truly have nothing to report, emit
+  <terse_json>{"summary": "", "pass_through": []}</terse_json>
+  rather than an empty reply.
+"""
+
+
+# ── Feature flag ─────────────────────────────────────────────
+
+
+def is_terse_protocol_enabled() -> bool:
+    """Read the flag from ``config:agent.terse_protocol_enabled`` with an
+    env override.
+
+    Env var ``RADBOT_TERSE_PROTOCOL_ENABLED`` wins when set to one of
+    ``{"1", "true", "yes", "on"}`` (case-insensitive). Otherwise we fall
+    back to the DB-merged config via ``config_loader.get_agent_config()``,
+    which picks up admin-UI edits after ``load_db_config()``.
+
+    Defaults to ``False`` — the feature is strictly opt-in.
+    """
+    env = os.environ.get("RADBOT_TERSE_PROTOCOL_ENABLED")
+    if env is not None:
+        if env.strip().lower() in {"1", "true", "yes", "on"}:
+            return True
+        if env.strip().lower() in {"0", "false", "no", "off", ""}:
+            return False
+    try:
+        from radbot.config.config_loader import config_loader
+
+        agent_cfg = config_loader.get_agent_config()
+        return bool(agent_cfg.get("terse_protocol_enabled", False))
+    except Exception as e:
+        logger.debug("is_terse_protocol_enabled: config read failed (%s)", e)
+        return False
+
+
+# ── Rehydration (pure, unit-testable) ────────────────────────
+
+
+_TERSE_TAG_RE = re.compile(
+    rf"{re.escape(TERSE_JSON_OPEN)}\s*(.*?)\s*{re.escape(TERSE_JSON_CLOSE)}",
+    re.DOTALL,
+)
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_BARE_JSON_RE = re.compile(r"(\{[^{}]*\"summary\"[^{}]*\})", re.DOTALL)
+
+
+_TRUNCATED_DEGRADE_MARKER = "(sub-agent response was malformed or truncated)"
+
+
+def _extract_terse_candidate(raw_text: str) -> Optional[str]:
+    """Return the JSON candidate string, or None if no wrapper/shape found.
+
+    Tries, in order: ``<terse_json>...</terse_json>`` tags, ```` ```json
+    ... ``` ```` fences, then a bare ``{...}`` object that at least mentions
+    ``"summary"``. Returning the first match keeps the function cheap and
+    deterministic for tests.
+
+    A special empty-string return (``""``) signals "saw a protocol marker
+    but couldn't extract a candidate" — e.g. an unclosed ``<terse_json>``
+    from a truncated response. The caller routes that to the malformed
+    path so truncated output still gets its markers stripped.
+    """
+    m = _TERSE_TAG_RE.search(raw_text)
+    if m:
+        return m.group(1).strip()
+    # Open tag with no close tag → truncation. Signal with "" instead of None.
+    if TERSE_JSON_OPEN in raw_text and TERSE_JSON_CLOSE not in raw_text:
+        return ""
+    m = _JSON_FENCE_RE.search(raw_text)
+    if m:
+        return m.group(1).strip()
+    m = _BARE_JSON_RE.search(raw_text)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _strip_broken_markers(raw_text: str) -> str:
+    """Remove terse-protocol markers and bare JSON fences, leave the rest.
+
+    Used on the malformed path so that the user sees the sub-agent's best
+    effort without a half-open ``{"summary":`` smeared across the turn.
+    """
+    # Strip any complete <terse_json>...</terse_json> blocks first.
+    stripped = _TERSE_TAG_RE.sub("", raw_text)
+    # Then scrub stray opening/closing tags (truncation leaves these behind).
+    stripped = stripped.replace(TERSE_JSON_OPEN, "")
+    stripped = stripped.replace(TERSE_JSON_CLOSE, "")
+    # Drop JSON code-fence markup (keep fence *contents* — they may be the
+    # only remnant of the sub-agent's attempt).
+    stripped = re.sub(r"```(?:json)?", "", stripped)
+    stripped = stripped.replace("```", "")
+    cleaned = stripped.strip()
+    if cleaned:
+        return cleaned
+    # Nothing salvageable — don't leak raw tags, and don't return empty
+    # (which would trip the empty-content retry loop). A standard marker
+    # keeps the turn non-empty and gives Beto / the user a clear signal.
+    return _TRUNCATED_DEGRADE_MARKER
+
+
+def rehydrate_terse_payload(raw_text: str) -> str:
+    """Convert a sub-agent's terse-JSON response into Beto-friendly markdown.
+
+    On valid JSON: returns a canonical markdown block with ``Summary`` and
+    (optionally) ``Pass-through`` sections. Markdown was chosen over
+    re-emitting the raw JSON because (a) it composes with Beto's existing
+    prompt conventions and (b) it's deterministic across model retries,
+    which is what the unit test pins.
+
+    On malformed JSON: strips the broken protocol markers and returns the
+    raw inner text. The turn still shows the user *something* — worst case,
+    the sub-agent's truncated prose — rather than leaking
+    ``<terse_json>{"summary":`` at them.
+
+    Empty / non-protocol input is returned untouched; the callback checks
+    enablement separately so this function stays pure.
+    """
+    if not raw_text:
+        return raw_text
+
+    candidate = _extract_terse_candidate(raw_text)
+    if candidate is None:
+        # Sub-agent ignored the protocol (flag flipped mid-session, or an
+        # older cached system prompt). Pass through as-is.
+        return raw_text
+    if candidate == "":
+        # Unclosed <terse_json> — truncated mid-stream. Route to strip path
+        # so the tags don't leak.
+        return _strip_broken_markers(raw_text)
+
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        logger.debug(
+            "terse_protocol: malformed JSON (len=%d) — degrading to raw text",
+            len(candidate),
+        )
+        return _strip_broken_markers(raw_text)
+
+    if not isinstance(payload, dict):
+        return _strip_broken_markers(raw_text)
+
+    summary = payload.get("summary", "")
+    pass_through = payload.get("pass_through", []) or []
+    if not isinstance(summary, str):
+        summary = str(summary)
+    if not isinstance(pass_through, list):
+        pass_through = []
+
+    lines = []
+    if summary.strip():
+        lines.append(f"**Summary:** {summary.strip()}")
+    if pass_through:
+        lines.append("")
+        lines.append("**Pass-through:**")
+        for item in pass_through:
+            lines.append(str(item))
+    if not lines:
+        # Valid JSON but empty both fields — tell Beto there's no content
+        # without returning an empty string (which would trip the empty-
+        # content callback and force a retry).
+        return "(sub-agent returned empty terse payload)"
+    return "\n".join(lines)
+
+
+# ── ADK callbacks ────────────────────────────────────────────
+
+
+def _append_to_system_instruction(llm_request: Any, text: str) -> None:
+    """Append ``text`` to ``llm_request.config.system_instruction``.
+
+    Mirrors the helper in ``radbot.tools.telos.callback`` — ADK stores the
+    system instruction as ``str``, ``Content``, or ``None`` depending on
+    how the agent was constructed. We normalize to string and concatenate.
+    """
+    config = getattr(llm_request, "config", None)
+    if config is None:
+        return
+    existing = getattr(config, "system_instruction", None)
+    if existing is None:
+        config.system_instruction = text
+        return
+    if isinstance(existing, str):
+        config.system_instruction = f"{existing}\n\n{text}"
+        return
+    try:
+        parts = getattr(existing, "parts", None) or []
+        chunks = [getattr(p, "text", "") or "" for p in parts]
+        existing_text = "\n".join(c for c in chunks if c)
+    except Exception:
+        existing_text = ""
+    config.system_instruction = f"{existing_text}\n\n{text}" if existing_text else text
+
+
+def terse_protocol_before_model_callback(
+    callback_context: Any,
+    llm_request: Any,
+) -> Optional[Any]:
+    """Append the Terse JSON protocol instruction to the sub-agent's system
+    prompt when the feature flag is enabled.
+
+    Touches only ``llm_request.config.system_instruction`` — never
+    ``llm_request.contents``, per EX21 Constraint 1.
+    """
+    try:
+        if not is_terse_protocol_enabled():
+            return None
+        _append_to_system_instruction(llm_request, TERSE_PROTOCOL_INSTRUCTION)
+    except Exception as e:
+        logger.debug("terse_protocol before_model error (non-fatal): %s", e)
+    return None
+
+
+def _response_text_parts(llm_response: Any) -> list:
+    """Return the list of Part objects on an ``LlmResponse`` that carry
+    text (no function_call / function_response)."""
+    content = getattr(llm_response, "content", None)
+    if content is None:
+        return []
+    parts = getattr(content, "parts", None) or []
+    text_parts = []
+    for p in parts:
+        if getattr(p, "function_call", None):
+            return []  # mid-stream tool turn — skip rehydration entirely
+        if getattr(p, "function_response", None):
+            return []
+        if getattr(p, "text", None):
+            text_parts.append(p)
+    return text_parts
+
+
+def terse_protocol_after_model_callback(
+    callback_context: Any,
+    llm_response: Any,
+) -> Optional[Any]:
+    """Rehydrate a sub-agent's terse JSON reply into Beto-friendly markdown.
+
+    No-ops unless:
+      * the feature flag is enabled, AND
+      * the response carries pure text (no function_call / function_response
+        parts — we only transform final natural-language turns, not mid-
+        stream tool calls).
+
+    Degrades gracefully on malformed JSON via ``_strip_broken_markers``.
+    Returns ``None`` — the llm_response is mutated in place, which is the
+    same pattern ``handle_empty_response_after_model`` uses.
+    """
+    try:
+        if not is_terse_protocol_enabled():
+            return None
+        text_parts = _response_text_parts(llm_response)
+        if not text_parts:
+            return None
+
+        # Concatenate text across parts, transform once, write back to the
+        # first part and blank the rest. Most sub-agent text responses are
+        # a single part; multi-part text is rare but we handle it so the
+        # rehydrated markdown isn't split across parts in a way Beto would
+        # see as two separate messages.
+        raw = "".join(getattr(p, "text", "") or "" for p in text_parts)
+        rehydrated = rehydrate_terse_payload(raw)
+        if rehydrated == raw:
+            return None
+
+        text_parts[0].text = rehydrated
+        for p in text_parts[1:]:
+            p.text = ""
+    except Exception as e:
+        logger.debug("terse_protocol after_model error (non-fatal): %s", e)
+    return None

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -216,6 +216,7 @@ All assembly happens in `radbot/agent/agent_core.py` at module import time:
 5. **Before construction**, callbacks are attached to each sub-agent:
    - `before_model_callback = [scope_sub_agent_context_callback, scrub_empty_content_before_model, sanitize_tool_schemas_before_model]`
    - `after_model_callback = [handle_empty_response_after_model, telemetry_after_model_callback]`
+   - Natural-language sub-agents (casa, planner, comms, axel, kidsvid) additionally get `terse_protocol_before_model_callback` + `terse_protocol_after_model_callback` appended. These are runtime-gated by `config:agent.terse_protocol_enabled` (env override: `RADBOT_TERSE_PROTOCOL_ENABLED`), so registering them is safe when the flag is off. Excluded: `search_agent`, `code_execution_agent` (structured outputs that the protocol would corrupt) and `scout` (emits plans, and can be a session root).
 6. Root `Agent(...)` is constructed — ADK's `model_post_init()` builds the `_Mesh` routing graph once, setting `parent_agent` on every sub-agent
 
 **Critical**: agents added to `sub_agents` after construction are NOT part of the mesh — `transfer_to_agent` will not find them. See `docs/implementation/session_id_tracking.md` for history.
@@ -261,6 +262,8 @@ From `config/default_configs/instructions/main_agent.md`:
 | `inject_telos_context` | `tools/telos/callback.py` | beto only (before_model) | Inject Telos anchor every turn + full block on first turn of session into `system_instruction` |
 | `handle_empty_response_after_model` | `callbacks/empty_content_callback.py` | all (after_model) | Replace empty model responses with a "still thinking" marker |
 | `telemetry_after_model_callback` | `callbacks/telemetry_callback.py` | all (after_model) | Record token usage + cost in `llm_usage_log` with `session_id` |
+| `terse_protocol_before_model_callback` | `callbacks/terse_protocol.py` | casa/planner/comms/axel/kidsvid (before_model) | Append Terse JSON Protocol instruction to `llm_request.config.system_instruction` when `config:agent.terse_protocol_enabled` is true. Compresses sub-agent → Beto commentary; pass-through array preserves exact tool-result strings verbatim. |
+| `terse_protocol_after_model_callback` | `callbacks/terse_protocol.py` | casa/planner/comms/axel/kidsvid (after_model) | Re-hydrate the sub-agent's terse JSON into Beto-friendly markdown (`**Summary:**` / `**Pass-through:**`). Degrades gracefully on malformed / truncated JSON. |
 | `tool_call_repair_callback` | `callbacks/tool_call_repair_callback.py` | (available, not wired by default) | Repair malformed function calls |
 
 ## Key Files
@@ -277,5 +280,6 @@ From `config/default_configs/instructions/main_agent.md`:
 | `tools/adk_builtin/code_execution_tool.py` | `code_execution_agent` factory |
 | `callbacks/scope_to_current_turn.py` | Per-turn context scoping for sub-agents |
 | `callbacks/sanitize_tool_schemas.py` | Strip the non-standard `additional_properties` key from tool parameter schemas before Gemini rejects them |
+| `callbacks/terse_protocol.py` | Terse JSON Protocol: sub-agent output compression (before_model injects instruction, after_model re-hydrates). Gated by `config:agent.terse_protocol_enabled`. |
 | `tools/telos/callback.py` | Inject Telos user-context into beto's `system_instruction` (anchor every turn, full block session-start) |
 | `tools/shared/card_protocol.py` | `radbot:<kind>` fenced-block card emission |

--- a/specs/config.md
+++ b/specs/config.md
@@ -37,7 +37,7 @@ Stored as `config:<section>` entries in `radbot_credentials` (`credential_type='
 
 | Section | Keys | Purpose |
 |---------|------|---------|
-| `config:agent` | `main_model`, `sub_model`, per-agent models (`casa_agent`, `planner_agent`, `comms_agent`, `axel_agent`/`axel_agent_model`, `scout_agent`, `kidsvid_agent`), `session_mode`, `max_session_workers`, `worker_image_tag` | Agent model selection + session/worker config |
+| `config:agent` | `main_model`, `sub_model`, per-agent models (`casa_agent`, `planner_agent`, `comms_agent`, `axel_agent`/`axel_agent_model`, `scout_agent`, `kidsvid_agent`), `session_mode`, `max_session_workers`, `worker_image_tag`, `terse_protocol_enabled` (bool; env override `RADBOT_TERSE_PROTOCOL_ENABLED`; default false) | Agent model selection + session/worker config + terse-protocol feature flag |
 | `config:integrations` | `home_assistant.*`, `overseerr.*`, `lidarr.*`, `picnic.*`, `jira.*`, `ntfy.*`, `github.*`, `nomad.*`, `kideo.*`, `alertmanager.*`, `ollama.*` | Integration endpoints, flags, non-secret keys |
 | `config:vector_db` | `url`, `api_key`, `host`, `port`, `collection` | Qdrant connection + collection |
 | `config:scheduler` | `enabled` | Scheduler engine toggle |

--- a/tests/unit/test_terse_after_model_callback.py
+++ b/tests/unit/test_terse_after_model_callback.py
@@ -1,0 +1,219 @@
+"""Unit tests for the Terse JSON Protocol after_model callback and its
+pure ``rehydrate_terse_payload`` helper.
+
+Deterministic and Python-level — no LLM in the loop. The callback's valid
+path is exercised via the helper (same code path); the LlmResponse mutation
+path is covered with lightweight stand-ins so we don't pull in ADK's model
+types just to assert on ``part.text``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from radbot.callbacks.terse_protocol import (
+    TERSE_JSON_CLOSE,
+    TERSE_JSON_OPEN,
+    is_terse_protocol_enabled,
+    rehydrate_terse_payload,
+    terse_protocol_after_model_callback,
+)
+
+# ── rehydrate_terse_payload: valid JSON ───────────────────────────────────
+
+
+class TestRehydrateValidPayloads:
+    def test_rehydrate_wrapped_in_terse_tags_returns_markdown(self):
+        raw = (
+            f"{TERSE_JSON_OPEN}"
+            '{"summary": "Light kitchen is off.", "pass_through": []}'
+            f"{TERSE_JSON_CLOSE}"
+        )
+        out = rehydrate_terse_payload(raw)
+        assert "**Summary:** Light kitchen is off." in out
+        assert TERSE_JSON_OPEN not in out
+        assert "Pass-through" not in out  # empty pass_through → no section
+
+    def test_rehydrate_passes_through_exact_strings_verbatim(self):
+        raw = (
+            f"{TERSE_JSON_OPEN}"
+            '{"summary": "Found 3 entities.", '
+            '"pass_through": ["light.kitchen: on", "light.bedroom: off"]}'
+            f"{TERSE_JSON_CLOSE}"
+        )
+        out = rehydrate_terse_payload(raw)
+        assert "**Summary:** Found 3 entities." in out
+        assert "**Pass-through:**" in out
+        assert "light.kitchen: on" in out
+        assert "light.bedroom: off" in out
+
+    def test_rehydrate_accepts_json_fenced_block(self):
+        raw = (
+            "Sure thing.\n\n```json\n"
+            '{"summary": "Done.", "pass_through": ["id=42"]}\n'
+            "```\n"
+        )
+        out = rehydrate_terse_payload(raw)
+        assert "**Summary:** Done." in out
+        assert "id=42" in out
+
+    def test_rehydrate_accepts_bare_json_object_with_summary(self):
+        raw = '{"summary": "Bare form works.", "pass_through": []}'
+        out = rehydrate_terse_payload(raw)
+        assert "**Summary:** Bare form works." in out
+
+    def test_rehydrate_empty_both_fields_emits_nonempty_marker(self):
+        # Empty string output would trip the empty-content callback into a
+        # retry loop, so we require a non-empty placeholder.
+        raw = (
+            f'{TERSE_JSON_OPEN}{{"summary": "", "pass_through": []}}{TERSE_JSON_CLOSE}'
+        )
+        out = rehydrate_terse_payload(raw)
+        assert out.strip() != ""
+
+
+# ── rehydrate_terse_payload: malformed / degrade gracefully ──────────────
+
+
+class TestRehydrateMalformedDegradeGracefully:
+    def test_truncated_json_returns_stripped_raw_text(self):
+        # Model hit max_output_tokens mid-JSON — the classic failure mode.
+        raw = (
+            f"{TERSE_JSON_OPEN}"
+            '{"summary": "This was going to say something long but got cut off '
+        )
+        out = rehydrate_terse_payload(raw)
+        # No leaking tags or half-open braces dumped at the user.
+        assert TERSE_JSON_OPEN not in out
+        assert TERSE_JSON_CLOSE not in out
+        # The inner text (even broken) is still surfaced so the user gets
+        # *something* rather than a mystery empty turn.
+        assert "summary" in out or "cut off" in out
+
+    def test_malformed_json_fence_returns_text_without_fence(self):
+        raw = 'Sorry:\n\n```json\n{"summary": "oops", broken}\n```'
+        out = rehydrate_terse_payload(raw)
+        assert "```" not in out
+        assert "Sorry" in out  # prose envelope preserved
+
+    def test_non_protocol_text_passes_through_unchanged(self):
+        # Sub-agent ignored the protocol entirely (flag flipped mid-session,
+        # stale cached system prompt, etc.). Must not mangle the reply.
+        raw = "Hey, totally gnarly — the lights are all off, my dude."
+        out = rehydrate_terse_payload(raw)
+        assert out == raw
+
+    def test_json_with_non_dict_root_degrades_gracefully(self):
+        # Valid JSON, wrong shape (array instead of object with summary).
+        raw = f'{TERSE_JSON_OPEN}["not", "an", "object"]{TERSE_JSON_CLOSE}'
+        out = rehydrate_terse_payload(raw)
+        # The _BARE_JSON_RE only fires on objects containing "summary", and
+        # the tag extractor will hand json.loads a list — which parses but
+        # is rejected by the isinstance(dict) check, producing a stripped
+        # fallback.
+        assert TERSE_JSON_OPEN not in out
+        assert TERSE_JSON_CLOSE not in out
+
+    def test_empty_input_returns_empty(self):
+        assert rehydrate_terse_payload("") == ""
+
+
+# ── terse_protocol_after_model_callback: flag + LlmResponse shape ────────
+
+
+def _mk_response(text: str, *, function_call=False):
+    """Build a minimal stand-in for ``google.adk.models.LlmResponse``.
+
+    We only touch ``response.content.parts[*].text``, so a SimpleNamespace
+    tree with the right attribute shape is enough — no need to import ADK.
+    """
+    part = SimpleNamespace(
+        text=text,
+        function_call=SimpleNamespace() if function_call else None,
+        function_response=None,
+    )
+    return SimpleNamespace(content=SimpleNamespace(parts=[part]))
+
+
+class TestAfterModelCallbackRespectsFlag:
+    def test_callback_noop_when_flag_disabled(self):
+        raw = (
+            f'{TERSE_JSON_OPEN}{{"summary": "x", "pass_through": []}}{TERSE_JSON_CLOSE}'
+        )
+        resp = _mk_response(raw)
+        with patch(
+            "radbot.callbacks.terse_protocol.is_terse_protocol_enabled",
+            return_value=False,
+        ):
+            assert terse_protocol_after_model_callback(None, resp) is None
+        # Text untouched.
+        assert resp.content.parts[0].text == raw
+
+    def test_callback_rehydrates_when_flag_enabled(self):
+        raw = f'{TERSE_JSON_OPEN}{{"summary": "hi", "pass_through": []}}{TERSE_JSON_CLOSE}'
+        resp = _mk_response(raw)
+        with patch(
+            "radbot.callbacks.terse_protocol.is_terse_protocol_enabled",
+            return_value=True,
+        ):
+            terse_protocol_after_model_callback(None, resp)
+        assert "**Summary:** hi" in resp.content.parts[0].text
+        assert TERSE_JSON_OPEN not in resp.content.parts[0].text
+
+    def test_callback_skips_function_call_turns(self):
+        # Mid-stream tool call — rehydration must not fire, since the
+        # protocol applies only to the final natural-language turn.
+        resp = _mk_response("irrelevant", function_call=True)
+        with patch(
+            "radbot.callbacks.terse_protocol.is_terse_protocol_enabled",
+            return_value=True,
+        ):
+            terse_protocol_after_model_callback(None, resp)
+        assert resp.content.parts[0].text == "irrelevant"
+
+    def test_callback_handles_missing_content_gracefully(self):
+        resp = SimpleNamespace(content=None)
+        with patch(
+            "radbot.callbacks.terse_protocol.is_terse_protocol_enabled",
+            return_value=True,
+        ):
+            # Must not raise.
+            assert terse_protocol_after_model_callback(None, resp) is None
+
+
+# ── is_terse_protocol_enabled: env override precedence ────────────────────
+
+
+class TestFlagResolution:
+    @pytest.mark.parametrize("value", ["1", "true", "True", "yes", "on"])
+    def test_env_truthy_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv("RADBOT_TERSE_PROTOCOL_ENABLED", value)
+        assert is_terse_protocol_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+    def test_env_falsy_values_disable_even_if_config_true(self, monkeypatch, value):
+        monkeypatch.setenv("RADBOT_TERSE_PROTOCOL_ENABLED", value)
+        with patch(
+            "radbot.config.config_loader.config_loader.get_agent_config",
+            return_value={"terse_protocol_enabled": True},
+        ):
+            assert is_terse_protocol_enabled() is False
+
+    def test_falls_back_to_config_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("RADBOT_TERSE_PROTOCOL_ENABLED", raising=False)
+        with patch(
+            "radbot.config.config_loader.config_loader.get_agent_config",
+            return_value={"terse_protocol_enabled": True},
+        ):
+            assert is_terse_protocol_enabled() is True
+
+    def test_defaults_false_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("RADBOT_TERSE_PROTOCOL_ENABLED", raising=False)
+        with patch(
+            "radbot.config.config_loader.config_loader.get_agent_config",
+            return_value={},
+        ):
+            assert is_terse_protocol_enabled() is False


### PR DESCRIPTION
## Summary

Adds a feature-flagged Terse JSON Protocol for sub-agent → Beto communication to cut Opus 4.7 tokenizer tax. Sub-agents emit `{"summary": …, "pass_through": […]}`; an `after_model_callback` re-hydrates it into Beto-friendly markdown, degrading gracefully on malformed / truncated JSON. Applied to casa / planner / comms / axel / kidsvid only; `search_agent` / `code_execution_agent` / `scout` are excluded by design. Gated by `config:agent.terse_protocol_enabled` (env override `RADBOT_TERSE_PROTOCOL_ENABLED`), default off — no runtime behavior change on merge.

## Specs updated

- `specs/agents.md` — callback attachment list + Callback Inventory + Key Files table entries for `terse_protocol.py`.
- `specs/config.md` — new `terse_protocol_enabled` key on `config:agent`.

## Implements

- EX21 (refined via Stage 2 Reality Check)
- PT56 — `before_model_callback` appending protocol instruction to `llm_request.config.system_instruction`
- PT57 — callback attachment to casa/planner/comms/axel/kidsvid, excluding ADK built-ins + scout
- PT58 — `after_model_callback` with deterministic Python-level parser + fallback, 25 unit tests

Also bundles a new `.claude/skills/telos-review/` skill for the Bipartite Review Loop (Stage 2 + Stage 4 for Claude Code).

## Not in this PR

- PT54 admin-UI panel for the flag (callbacks read via the existing `config_loader` DB merge; manual `config:agent` edit or env var works today)
- PT55 `main_agent.md` prompt tweak for Beto (callback already emits Beto-friendly markdown, so end-to-end works)
- EX21 Rubric #1 empirical ≥40% token-drop validation (requires live casa session with `run_label` tagging)

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `make lint` green (flake8 + mypy + black + isort)
- [x] `make test-unit` — new suite 25/25 passing; 4 pre-existing failures in `test_mcp_setup_endpoint.py` verified to exist on clean `origin/main` (unrelated)
- [x] `python -c "from radbot.agent import agent_core"` clean import; callback attachment verified at runtime (casa/planner/comms/axel/kidsvid: wired; search_agent/code_execution_agent/scout: excluded)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)