### PR TITLE
[terse-admin] admin UI toggle + Beto prompt for Terse JSON Protocol (PT59 / PT60)

### DIFF
--- a/radbot/config/default_configs/instructions/main_agent.md
+++ b/radbot/config/default_configs/instructions/main_agent.md
@@ -9,6 +9,24 @@ You have memory tools to recall general context about the user.
 ## Response Rules
 When a sub-agent returns data (calendar events, emails, tasks, reminders, etc.), you MUST include the substantive content in your response. Do NOT just say "handled" or "all set" — relay the actual information the user asked for. Add your personality but keep the data intact.
 
+## Sub-Agent Output Format (Terse JSON Protocol)
+
+When the Terse JSON Protocol is on, casa / planner / comms / axel / kidsvid return a rehydrated reply in this shape:
+
+```
+**Summary:** <one or two terse, data-dense sentences from the sub-agent>
+
+**Pass-through:**
+<item 1>
+<item 2>
+...
+```
+
+- **Summary** is telegram-style by design — the sub-agent kept it short to save tokens. Re-voice it in your 90s SoCal register, trim filler, but **do not invent facts** that aren't in the summary or pass-through.
+- **Pass-through** lines are exact strings you must emit **verbatim** — tool-generated IDs, log lines, URLs, quoted errors, and `radbot:<kind>` UI fenced blocks (e.g. ```` ```radbot:card ... ``` ````). Paraphrasing a pass-through item counts as hallucination. If a pass-through line is already a fenced UI block, render the fences as given.
+- If a sub-agent reply has no `**Summary:** / **Pass-through:**` markers, treat it as normal prose (the feature flag is off, or the sub-agent didn't cooperate this turn).
+- If you see `(sub-agent response was malformed or truncated)`, the JSON fallback fired — relay that to the user in your own voice ("looks like <agent> got cut off, dude — try again?") rather than pretending the turn succeeded.
+
 ## Stay on task (hard rule)
 Only address the **current user turn**. You and the sub-agents receive the full conversation history as context — that is not a list of things to re-do.
 

--- a/radbot/config/schema/config_schema.json
+++ b/radbot/config/schema/config_schema.json
@@ -115,6 +115,11 @@
           "description": "Whether to use Vertex AI for model API access",
           "default": false
         },
+        "terse_protocol_enabled": {
+          "type": "boolean",
+          "description": "Enable the Terse JSON Protocol for sub-agent \u2192 Beto output compression. Attaches before/after model callbacks to casa, planner, comms, axel, and kidsvid. Env override: RADBOT_TERSE_PROTOCOL_ENABLED.",
+          "default": false
+        },
         "vertex_project": {
           "type": ["string", "null"],
           "description": "Google Cloud project ID for Vertex AI"

--- a/radbot/web/frontend/src/components/admin/panels/CorePanels.tsx
+++ b/radbot/web/frontend/src/components/admin/panels/CorePanels.tsx
@@ -194,6 +194,7 @@ export function AgentModelsPanel() {
   const [enableCodeExec, setEnableCodeExec] = useState(false);
   const [sessionMode, setSessionMode] = useState(false);
   const [maxWorkers, setMaxWorkers] = useState("10");
+  const [terseProtocolEnabled, setTerseProtocolEnabled] = useState(false);
   // Map of config_key ("casa_agent") → override string ("" = inherit default)
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [overridesOpen, setOverridesOpen] = useState(false);
@@ -218,6 +219,7 @@ export function AgentModelsPanel() {
     if (agent.enable_adk_code_execution !== undefined) setEnableCodeExec(!!agent.enable_adk_code_execution);
     if (agent.session_mode !== undefined) setSessionMode(agent.session_mode === "remote");
     if (agent.max_session_workers !== undefined) setMaxWorkers(String(agent.max_session_workers));
+    if (agent.terse_protocol_enabled !== undefined) setTerseProtocolEnabled(!!agent.terse_protocol_enabled);
 
     const agentModels = agent.agent_models || {};
     const init: Record<string, string> = {};
@@ -252,6 +254,7 @@ export function AgentModelsPanel() {
         enable_adk_code_execution: enableCodeExec,
         session_mode: sessionMode ? "remote" : "local",
         max_session_workers: parseInt(maxWorkers, 10) || 10,
+        terse_protocol_enabled: terseProtocolEnabled,
         agent_models: agentModels,
       });
 
@@ -307,6 +310,20 @@ export function AgentModelsPanel() {
             placeholder="10"
           />
         )}
+      </Card>
+
+      <Card title="Sub-Agent Output">
+        <Note>
+          Terse JSON Protocol: casa, planner, comms, axel, and kidsvid emit compressed JSON
+          (<code>summary</code> + <code>pass_through</code>) that Beto re-hydrates into prose.
+          Reduces sub-agent output tokens. Env override:{" "}
+          <code>RADBOT_TERSE_PROTOCOL_ENABLED</code>.
+        </Note>
+        <FormToggle
+          label="Enable Terse JSON Protocol"
+          checked={terseProtocolEnabled}
+          onChange={setTerseProtocolEnabled}
+        />
       </Card>
 
       {/* Collapsible Per-Agent Model Overrides */}


### PR DESCRIPTION
## Summary

Follow-ups to #71. Adds the admin UI toggle for `config:agent.terse_protocol_enabled` (in the existing `AgentModelsPanel`) and teaches Beto to consume the rehydrated `**Summary:** / **Pass-through:**` format in `main_agent.md`. Flag still defaults off — no runtime behavior change on merge until it's flipped.

## Specs updated

None needed. `terse_protocol_enabled` was added to `specs/config.md` in #71; `specs/web.md` doesn't enumerate individual admin panels; `specs/agents.md` already covers callback attachment.

## Implements

- **PT59** — schema entry + `AgentModelsPanel` toggle (no `_INTEGRATION_RESET_REGISTRY` entry needed; callbacks read live via `config_loader.get_agent_config()` and `PUT /api/config/agent` already hot-reloads)
- **PT60** — `main_agent.md` "Sub-Agent Output Format" section covering Summary re-voicing, verbatim Pass-through, and the degrade marker fallback

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `make lint` clean (flake8 + mypy + black + isort)
- [x] `npx tsc --noEmit` clean, `npm run build` clean
- [x] Terse protocol unit suite 25/25 still passing
- [x] Schema parses + `agent_core` imports cleanly
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)