### PR TITLE
[claude-cli-path] Resolve absolute path to claude CLI so Scout's session tools work off-PATH

### DIFF
--- a/radbot/tools/claude_code/claude_code_client.py
+++ b/radbot/tools/claude_code/claude_code_client.py
@@ -151,9 +151,46 @@ def _ensure_onboarding_complete(workspace_dir: Optional[str] = None) -> None:
         logger.debug("Failed to write %s: %s", settings_json, e)
 
 
+# Common install paths checked when the CLI isn't on PATH. Covers the Dockerfile
+# symlink (`/usr/local/bin/claude`), distro packaging, and NPM global defaults
+# for both root and user installs.
+_CLAUDE_FALLBACK_PATHS = (
+    "/usr/local/bin/claude",
+    "/usr/bin/claude",
+    "/opt/homebrew/bin/claude",
+)
+
+
+def _resolve_claude_cli() -> Optional[str]:
+    """Locate the ``claude`` CLI executable.
+
+    Resolution order:
+      1. ``CLAUDE_CLI_PATH`` env var (explicit override)
+      2. ``shutil.which("claude")`` on the inherited PATH
+      3. A short list of common install paths (container symlink, brew, npm)
+      4. ``~/.npm-global/bin/claude`` (per-user npm prefix)
+    """
+    override = os.environ.get("CLAUDE_CLI_PATH")
+    if override and os.path.isfile(override) and os.access(override, os.X_OK):
+        return override
+
+    found = shutil.which("claude")
+    if found:
+        return found
+
+    from pathlib import Path
+
+    candidates = list(_CLAUDE_FALLBACK_PATHS)
+    candidates.append(str(Path.home() / ".npm-global" / "bin" / "claude"))
+    for path in candidates:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return None
+
+
 def _claude_cli_available() -> bool:
-    """Check whether the ``claude`` CLI is on PATH."""
-    return shutil.which("claude") is not None
+    """Check whether the ``claude`` CLI can be located."""
+    return _resolve_claude_cli() is not None
 
 
 @dataclass
@@ -224,7 +261,8 @@ class ClaudeCodeClient:
         Returns:
             Dict with output, session_id, return_code, stderr
         """
-        cmd = ["claude", "--print", "--verbose", "--output-format", "stream-json"]
+        claude_bin = _resolve_claude_cli() or "claude"
+        cmd = [claude_bin, "--print", "--verbose", "--output-format", "stream-json"]
         if session_id:
             cmd.extend(["--resume", session_id])
         cmd.extend(["-p", prompt])
@@ -251,8 +289,9 @@ class ClaudeCodeClient:
         Returns:
             Dict with output, session_id, return_code, stderr
         """
+        claude_bin = _resolve_claude_cli() or "claude"
         cmd = [
-            "claude",
+            claude_bin,
             "--print",
             "--verbose",
             "--output-format",
@@ -297,7 +336,7 @@ class ClaudeCodeClient:
                 "output": "",
                 "session_id": None,
                 "return_code": -1,
-                "stderr": "claude CLI not found on PATH",
+                "stderr": "claude CLI not found — set CLAUDE_CLI_PATH or install the CLI",
             }
 
         output_parts: list[str] = []
@@ -415,8 +454,9 @@ class ClaudeCodeClient:
         """
         _ensure_onboarding_complete(working_dir)
 
+        claude_bin = _resolve_claude_cli() or "claude"
         cmd = [
-            "claude",
+            claude_bin,
             "--print",
             "--verbose",
             "--output-format",
@@ -575,7 +615,7 @@ def get_claude_code_status() -> Dict[str, Any]:
     if not cli_available:
         return {
             "status": "error",
-            "message": "claude CLI not found on PATH",
+            "message": "claude CLI not found — set CLAUDE_CLI_PATH or install the CLI",
             "cli_available": False,
             "token_configured": token_configured,
         }
@@ -598,8 +638,9 @@ def get_claude_code_status() -> Dict[str, Any]:
         else:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = token
 
+        claude_bin = _resolve_claude_cli() or "claude"
         result = subprocess.run(
-            ["claude", "auth", "status"],
+            [claude_bin, "auth", "status"],
             capture_output=True,
             text=True,
             timeout=10,


### PR DESCRIPTION
## Summary

Scout's new `start_claude_session` tool (shipped in #78) hit `[Errno 2] No such file or directory: 'claude'` in production — the radbot process's PATH when spawning subprocesses doesn't include the Dockerfile's `/usr/local/bin/claude` symlink in every deployment context. This adds an explicit resolution helper so the absolute path is passed to the subprocess regardless of PATH.

## Resolution order

1. `CLAUDE_CLI_PATH` env var (explicit override)
2. `shutil.which("claude")` on inherited PATH
3. `/usr/local/bin/claude`, `/usr/bin/claude`, `/opt/homebrew/bin/claude`
4. `~/.npm-global/bin/claude`

All four subprocess spawn sites (`run_plan`, `run_execute`, `start_background_session`, `auth status`) now pass the resolved absolute path instead of bare `"claude"`. Error messages updated to suggest the `CLAUDE_CLI_PATH` override.

## Specs updated

None needed — this is an internal resolution helper for an existing tool module. No new FunctionTool, no new config section, no new tool exported, no agent tool-count change.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local `make lint` (flake8 + mypy + black + isort) — green
- [x] `python -m tests.schema.lint` — snapshot match
- [x] `pytest tests/unit` — 481 passed
- [x] Smoke-tested `_resolve_claude_cli()` — returns `/home/perry/.local/bin/claude` on dev host
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90