### PR TITLE
[claude-cli-symlink] Fix dangling claude CLI symlink (upstream moved entry to bin/claude.exe)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,10 @@ RUN mkdir -p /data/repos
 # Copy Node.js binary + Claude Code CLI (no npm/nodesource needed at runtime)
 COPY --from=claude-code-build /usr/local/bin/node /usr/local/bin/node
 COPY --from=claude-code-build /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s ../lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude
+# Upstream @anthropic-ai/claude-code ships its entry at `bin/claude.exe`
+# (a Node script — the .exe name is cross-platform, not Windows-specific).
+# Keep this in sync with the package's "bin" field in its package.json.
+RUN ln -s ../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe /usr/local/bin/claude
 
 # Copy Claude Code onboarding state
 COPY --from=claude-code-build /root/.claude /root/.claude


### PR DESCRIPTION
## Summary

The Dockerfile symlink `/usr/local/bin/claude → ../lib/node_modules/@anthropic-ai/claude-code/cli.js` has been dangling in the runtime image since upstream `@anthropic-ai/claude-code` moved its entry to `bin/claude.exe`. Docker doesn't validate symlink targets at build time, so every build looked fine, but inside the container `/usr/local/bin/claude` pointed at nothing — which surfaced today when Scout's new `start_claude_session` tool (PR #78) tried to spawn `claude` and got `[Errno 2] No such file or directory`.

Diagnosed via `nomad alloc exec` into the running radbot container:
- `ls -la /usr/local/bin/claude` → symlink exists, 52-byte target (`.../cli.js`)
- `ls /usr/local/lib/node_modules/@anthropic-ai/claude-code/` → no `cli.js`; new layout has `bin/claude.exe`, `cli-wrapper.cjs`, `install.cjs`
- `cat package.json | grep -A3 bin` → `"claude": "bin/claude.exe"`

Fix: update the symlink target + add a comment so the next upstream rename is a quick check of `package.json`'s `bin` field.

The `.exe` suffix is cross-platform-agnostic — it's a Node script, not a Windows PE binary (Anthropic's packaging team chose that name).

## Why this wasn't caught earlier

The existing `claude_code_plan` / `claude_code_execute` / `claude_code_continue` tools also would have failed with the same error, but they're only reachable via Axel's explicit plan-then-execute flow which apparently hadn't been exercised against this image. Scout's new `start_claude_session` is the first tool that tried `claude` in the fresh container and discovered the rot.

## Specs updated

None needed — this is a Dockerfile / runtime image fix. No new tool, no new config section, no agent/tool-count change. `specs/deployment.md` could mention the symlink but the existing docs don't track filesystem-level Dockerfile internals.

## Quality pipeline

Score: _pending_ — awaiting workflow run. CI's `build` gate will validate the Dockerfile.

## Verification

- [x] Confirmed `/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe` exists in the running container
- [x] Confirmed package.json `bin.claude = "bin/claude.exe"`
- [x] Secret scan clean
- [ ] Quality pipeline (CI) — `build` gate is the authoritative test here
- [ ] Auto-merge at score ≥ 90
- [ ] Post-merge: Nomad pulls the new image → `claude` resolves → Scout's tool works end-to-end