### PR TITLE
fix(gh-token): merge DB config + lazy radbot import

### DIFF
--- a/radbot/__init__.py
+++ b/radbot/__init__.py
@@ -4,4 +4,21 @@ RadBot - A modular AI agent framework using Google ADK, Qdrant, MCP, and A2A.
 
 __version__ = "0.1.0"
 
-from radbot.agent import RadBotAgent, create_agent, create_memory_enabled_agent
+# Lazy re-exports: avoid eagerly building the full agent (and its DB pool,
+# scheduler init, etc.) just because something imported a leaf submodule like
+# ``radbot.tools.github.github_app_client``. Resolve on first attribute access.
+_LAZY_EXPORTS = {
+    "RadBotAgent": ("radbot.agent", "RadBotAgent"),
+    "create_agent": ("radbot.agent", "create_agent"),
+    "create_memory_enabled_agent": ("radbot.agent", "create_memory_enabled_agent"),
+}
+
+
+def __getattr__(name):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'radbot' has no attribute {name!r}")
+    import importlib
+
+    module = importlib.import_module(target[0])
+    return getattr(module, target[1])

--- a/scripts/gh_token.py
+++ b/scripts/gh_token.py
@@ -15,6 +15,14 @@ import sys
 
 
 def main() -> int:
+    # Merge DB-stored config (admin UI saves integrations.github there) into
+    # the in-memory ConfigLoader. Without this, only file-based config.yaml is
+    # visible — and integrations.github lives in the credential store, not the
+    # bootstrap config.
+    from radbot.config.config_loader import config_loader
+
+    config_loader.load_db_config()
+
     from radbot.tools.github.github_app_client import get_github_client
 
     client = get_github_client()


### PR DESCRIPTION
## Summary

Two bugs in the \`gh-token\` helper installed by PT79:

1. The script never called \`load_db_config()\`, so \`integrations.github\` (saved by the admin UI into the credential store as \`config:integrations\`) was invisible to it. Only file-based \`config.yaml\` was consulted — which has nothing for github — so the script always reported \"GitHub App not configured\" even when prod had valid credentials.

2. \`radbot/__init__.py\` eagerly imported from \`radbot.agent\`, meaning every \`gh-token\` invocation rebuilt the full agent (8 sub-agents, fresh DB pool, scheduler init, singleton clients). Concurrent invocations could exhaust postgres \`max_connections\` and wedge the running web app — observed in prod when running \`gh-token\` from the container shell.

## Fixes

- \`scripts/gh_token.py\`: call \`config_loader.load_db_config()\` before resolving the GitHub client, so DB-stored \`integrations.github\` is merged in.
- \`radbot/__init__.py\`: switch to PEP 562 lazy attribute access for the three re-exported symbols (\`RadBotAgent\`, \`create_agent\`, \`create_memory_enabled_agent\`). No callers in the tree import them at module-load time.

## Specs updated

None — no shape change. \`gh-token\` interface is unchanged; only its internal config resolution path is fixed.

## Test plan

- [x] Local: \`uv run python scripts/gh_token.py\` no longer triggers full agent build (~1.4s vs ~5s+, no sub-agent factory logs)
- [ ] Prod: rebuild image, deploy, run \`gh-token\` inside container — expect a token printed to stdout (after admin UI \`Save\` of GitHub App)
- [ ] Prod: confirm running \`gh-token\` does not destabilize the web process

🤖 Generated with [Claude Code](https://claude.com/claude-code)