### PR TITLE
fix(repo-sync): require GH App for github.com (no anon fallback)

### DIFF
--- a/radbot/tools/repo_exploration.py
+++ b/radbot/tools/repo_exploration.py
@@ -126,29 +126,30 @@ def _git_env() -> Dict[str, str]:
     }
 
 
-def _maybe_authenticate_github_url(url: str) -> str:
+def _authenticate_github_url(url: str) -> str:
     """Rewrite a github.com URL to use a GitHub App installation token.
 
-    No-op for non-github hosts or when the App is not configured. Lets us
-    clone private repos the App has been granted access to (e.g. perrymanuk/*)
-    and lifts the unauthenticated-rate-limit ceiling for public ones.
+    Non-github hosts pass through unchanged. For github.com, the GitHub App
+    MUST be configured — we don't silently fall back to anonymous clones,
+    because that hides config drift and fails confusingly on private repos.
+    Raises RuntimeError if the App can't mint a token.
     """
     parsed = urlparse(url)
     if (parsed.hostname or "").lower() != "github.com":
         return url
-    try:
-        from radbot.config.config_loader import config_loader
 
-        config_loader.load_db_config()
-        from radbot.tools.github.github_app_client import get_github_client
+    from radbot.config.config_loader import config_loader
 
-        client = get_github_client()
-        if client is None:
-            return url
-        token = client._get_installation_token()
-    except Exception as e:
-        logger.debug("GitHub App token mint failed, falling back to anon clone: %s", e)
-        return url
+    config_loader.load_db_config()
+    from radbot.tools.github.github_app_client import get_github_client
+
+    client = get_github_client()
+    if client is None:
+        raise RuntimeError(
+            "GitHub App not configured — set integrations.github via the admin UI "
+            "(/admin/) or GITHUB_APP_ID/GITHUB_INSTALLATION_ID/GITHUB_APP_PRIVATE_KEY env vars"
+        )
+    token = client._get_installation_token()
     return f"https://x-access-token:{token}@github.com{parsed.path}"
 
 
@@ -177,7 +178,10 @@ def repo_sync(repo_url: str, repo_name: str) -> Dict[str, Any]:
     if not git:
         return {"status": "error", "error": "git binary not found on PATH"}
 
-    auth_url = _maybe_authenticate_github_url(url)
+    try:
+        auth_url = _authenticate_github_url(url)
+    except RuntimeError as e:
+        return {"status": "error", "error": str(e)}
 
     if (target / ".git").exists():
         action = "pull"


### PR DESCRIPTION
## Summary

Builds on #83. The first pass at this added \`_maybe_authenticate_github_url\` that *tried* to mint a GitHub App installation token for github.com URLs but silently fell back to anonymous clone if the App wasn't configured. That hides config drift and produces confusing \"Repository not found\" failures on private repos.

Since we ship and configure the GitHub App for radbot, the right default is to **assume the token is required** for github.com and fail loudly when it's not available.

## Changes

- Renamed \`_maybe_authenticate_github_url\` → \`_authenticate_github_url\`
- For github.com hosts: raise \`RuntimeError\` with a clear remediation message when the App isn't configured (instead of silent anon fallback)
- For other hosts (gitlab, codeberg, etc.): still pass through to anonymous clone as before
- \`repo_sync\` catches the \`RuntimeError\` and returns it as a structured error to the agent

## Specs updated

None — no shape change. Same tool surface, stricter behavior.

## Test plan

- [x] Local: \`_authenticate_github_url('https://gitlab.com/...')\` returns unchanged
- [x] Local: \`_authenticate_github_url('https://github.com/...')\` raises with the configured-via-admin-UI message when no App configured
- [ ] Prod: with App configured, Scout's \`repo_sync('https://github.com/perrymanuk/claude-skills', 'claude-skills')\` succeeds

## Branching

Targets \`fix/gh-token-db-config\` (#83). Rebase / merge after #83 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)