### PR TITLE
fix(repo-sync): use GitHub App token for github.com clones

### DIFF
--- a/radbot/tools/repo_exploration.py
+++ b/radbot/tools/repo_exploration.py
@@ -126,13 +126,42 @@ def _git_env() -> Dict[str, str]:
     }
 
 
+def _authenticate_github_url(url: str) -> str:
+    """Rewrite a github.com URL to use a GitHub App installation token.
+
+    Non-github hosts pass through unchanged. For github.com, the GitHub App
+    MUST be configured — we don't silently fall back to anonymous clones,
+    because that hides config drift and fails confusingly on private repos.
+    Raises RuntimeError if the App can't mint a token.
+    """
+    parsed = urlparse(url)
+    if (parsed.hostname or "").lower() != "github.com":
+        return url
+
+    from radbot.config.config_loader import config_loader
+
+    config_loader.load_db_config()
+    from radbot.tools.github.github_app_client import get_github_client
+
+    client = get_github_client()
+    if client is None:
+        raise RuntimeError(
+            "GitHub App not configured — set integrations.github via the admin UI "
+            "(/admin/) or GITHUB_APP_ID/GITHUB_INSTALLATION_ID/GITHUB_APP_PRIVATE_KEY env vars"
+        )
+    token = client._get_installation_token()
+    return f"https://x-access-token:{token}@github.com{parsed.path}"
+
+
 def repo_sync(repo_url: str, repo_name: str) -> Dict[str, Any]:
-    """Clone or fast-forward-pull a public git repo into ``/data/repos/<repo_name>``.
+    """Clone or fast-forward-pull a git repo into ``/data/repos/<repo_name>``.
 
     Args:
-        repo_url: Full https URL to a public repo. Allowlisted hosts:
-            github.com, gitlab.com, bitbucket.org, codeberg.org, git.sr.ht.
-            Credentials embedded in the URL are rejected.
+        repo_url: Full https URL. Allowlisted hosts: github.com, gitlab.com,
+            bitbucket.org, codeberg.org, git.sr.ht. Credentials embedded in
+            the URL are rejected. github.com URLs are transparently rewritten
+            to use the configured GitHub App installation token, which enables
+            cloning private repos the App has access to.
         repo_name: Local directory name (alnum, dot, dash, underscore — no slashes).
 
     Returns:
@@ -149,12 +178,26 @@ def repo_sync(repo_url: str, repo_name: str) -> Dict[str, Any]:
     if not git:
         return {"status": "error", "error": "git binary not found on PATH"}
 
+    try:
+        auth_url = _authenticate_github_url(url)
+    except RuntimeError as e:
+        return {"status": "error", "error": str(e)}
+
     if (target / ".git").exists():
         action = "pull"
+        # Refresh the remote URL so a previously-minted (now-expired) token is
+        # replaced with a fresh one before pulling.
+        subprocess.run(
+            [git, "-C", str(target), "remote", "set-url", "origin", auth_url],
+            check=False,
+            capture_output=True,
+            timeout=10,
+            env=_git_env(),
+        )
         cmd = [git, "-C", str(target), "pull", "--ff-only", "--depth=1", "origin"]
     else:
         action = "clone"
-        cmd = [git, "clone", "--depth=1", "--single-branch", url, str(target)]
+        cmd = [git, "clone", "--depth=1", "--single-branch", auth_url, str(target)]
 
     try:
         proc = subprocess.run(
@@ -171,11 +214,15 @@ def repo_sync(repo_url: str, repo_name: str) -> Dict[str, Any]:
             "error": f"{action} timed out after {_GIT_TIMEOUT_S}s",
         }
 
+    # Strip any leaked installation token from git's output before returning.
+    def _redact(s: str) -> str:
+        return re.sub(r"x-access-token:[A-Za-z0-9_]+@", "x-access-token:***@", s)
+
     if proc.returncode != 0:
         return {
             "status": "error",
             "action": action,
-            "error": (proc.stderr or proc.stdout or "").strip()[:2000],
+            "error": _redact((proc.stderr or proc.stdout or "").strip())[:2000],
         }
 
     head = subprocess.run(
@@ -191,7 +238,7 @@ def repo_sync(repo_url: str, repo_name: str) -> Dict[str, Any]:
         "path": str(target),
         "action": action,
         "commit": head.stdout.strip(),
-        "output": (proc.stdout + proc.stderr).strip()[:2000],
+        "output": _redact((proc.stdout + proc.stderr).strip())[:2000],
     }
 
 


### PR DESCRIPTION
## Summary

Scout's \`repo_sync\` tool was hard-coded for unauthenticated public clones (\`GIT_ASKPASS=/bin/true\`, \`GIT_TERMINAL_PROMPT=0\`, no \`GH_TOKEN\` passthrough), so cloning private repos the GitHub App has access to (e.g. \`perrymanuk/claude-skills\`) failed with \"Repository not found\".

When the clone URL host is github.com, the URL is now rewritten to \`https://x-access-token:<token>@github.com/...\` using a fresh installation token from \`get_github_client()\`. The GitHub App **must** be configured — github.com URLs fail loudly with a remediation message when it isn't, rather than silently falling back to anonymous (which hid config drift and produced confusing \"Repository not found\" errors for private repos).

## Changes

- New \`_authenticate_github_url\` helper — rewrites github.com URLs to include an installation-token-bearing https URL. Raises \`RuntimeError\` when the App isn't configured.
- \`repo_sync\` calls it after the URL validator; surfaces the \`RuntimeError\` as a structured tool error.
- On \`pull\`, refreshes the remote URL first so an expired token is replaced with a fresh one.
- Any leaked token is redacted from git's stdout/stderr before returning to the agent.
- Non-github hosts (gitlab, codeberg, etc.) still clone anonymously as before.

## Specs updated

None — no shape change. Same tool surface, stricter and now-authenticated behavior.

## Depends on

Builds on #83 (merged) — requires \`config_loader.load_db_config()\` to be callable from short-lived scripts, which that PR enabled by making \`radbot/__init__.py\` lazy.

## Test plan

- [x] Local: \`_authenticate_github_url('https://gitlab.com/...')\` returns unchanged
- [x] Local: \`_authenticate_github_url('https://github.com/...')\` raises \"GitHub App not configured\" when no App set
- [ ] Prod: with App configured, Scout's \`repo_sync('https://github.com/perrymanuk/claude-skills', 'claude-skills')\` succeeds
- [ ] Prod: \`repo_sync\` of a public github repo succeeds (token still works on public)
- [ ] Prod: \`repo_sync\` of a gitlab repo still works unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)