### PR TITLE
[chat-history] load most recent messages, not oldest

### DIFF
--- a/radbot/web/api/session/session_runner.py
+++ b/radbot/web/api/session/session_runner.py
@@ -1164,8 +1164,9 @@ class SessionRunner:
 
             from radbot.web.db import chat_operations
 
-            db_messages = chat_operations.get_messages_by_session_id(
-                self.session_id, limit=30
+            MAX_HISTORY = 15
+            db_messages = chat_operations.get_recent_messages_by_session_id(
+                self.session_id, limit=MAX_HISTORY
             )
             if not db_messages:
                 logger.debug("No DB history found for session %s", self.session_id)
@@ -1176,8 +1177,7 @@ class SessionRunner:
                 if hasattr(self._root_agent, "name")
                 else self.agent_name
             )
-            MAX_HISTORY = 15
-            recent = db_messages[-MAX_HISTORY:]
+            recent = db_messages
 
             loaded = 0
             current_invocation_id = str(uuid.uuid4())

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -949,14 +949,14 @@ async def websocket_endpoint(
             )
 
         # Process history_request messages
-        async def handle_history_request(limit=50):
+        async def handle_history_request(limit=200):
             logger.debug(
                 f"Handling history request for session {session_id}, limit={limit}"
             )
 
             # Try to load history from persistent database first
             try:
-                db_messages = chat_operations.get_messages_by_session_id(
+                db_messages = chat_operations.get_recent_messages_by_session_id(
                     session_id=session_id, limit=limit
                 )
                 if db_messages:

--- a/radbot/web/db/chat_operations.py
+++ b/radbot/web/db/chat_operations.py
@@ -313,6 +313,58 @@ def get_messages_by_session_id(
         return []
 
 
+def get_recent_messages_by_session_id(
+    session_id: str, limit: int = 50
+) -> List[Dict[str, Any]]:
+    """
+    Get the most recent N messages for a session, returned in chronological (ASC) order.
+
+    Used by WebSocket history load and agent-context rehydration, where the
+    tail of the conversation matters — not the head. Unlike
+    get_messages_by_session_id (which is ASC + offset-paginated for forward
+    scrollback), this runs DESC LIMIT then re-sorts ASC so the caller can feed
+    the result straight into the UI / LLM context.
+    """
+    if isinstance(session_id, str):
+        try:
+            session_id = uuid.UUID(session_id)
+        except ValueError:
+            logger.error(f"Invalid session_id format: {session_id}")
+            return []
+
+    sql = f"""
+        SELECT * FROM (
+            SELECT message_id, session_id, role, content, agent_name,
+                   timestamp, user_id, metadata
+            FROM {CHAT_SCHEMA}.chat_messages
+            WHERE session_id = %s
+            ORDER BY timestamp DESC
+            LIMIT %s
+        ) sub
+        ORDER BY timestamp ASC;
+    """
+
+    try:
+        with get_chat_db_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, (session_id, limit))
+                results = cursor.fetchall()
+
+                messages = []
+                for row in results:
+                    message = dict(row)
+                    message["message_id"] = str(message["message_id"])
+                    message["session_id"] = str(message["session_id"])
+                    if message["timestamp"]:
+                        message["timestamp"] = message["timestamp"].isoformat()
+                    messages.append(message)
+
+                return messages
+    except Exception as e:
+        logger.error(f"Error getting recent messages for session {session_id}: {e}")
+        return []
+
+
 def create_or_update_session(
     session_id: str,
     name: Optional[str] = None,

--- a/radbot/web/frontend/src/hooks/use-websocket.ts
+++ b/radbot/web/frontend/src/hooks/use-websocket.ts
@@ -97,7 +97,7 @@ export function useWebSocket(sessionId: string | null) {
 
         // Request history
         ws.send(
-          JSON.stringify({ type: "history_request", limit: 50 }),
+          JSON.stringify({ type: "history_request", limit: 200 }),
         );
       };
 


### PR DESCRIPTION
## Summary

Chat history was being loaded via `ORDER BY timestamp ASC LIMIT N`, which returns the *oldest* N messages. For any session that grew past the limit, restarting the app caused the visible chat (and the agent's rehydrated LLM context) to "rewind" to the beginning of the session — recent turns still existed in the DB but were never fetched.

Added `get_recent_messages_by_session_id` (DESC LIMIT, re-sorted ASC) and wired it into the two tail-of-conversation reads: WebSocket `handle_history_request` and session-runner context rehydration. The existing `get_messages_by_session_id` is retained for the paginated scrollback REST endpoint where ASC+offset is correct.

## Specs updated

None needed — pure bug fix in the history read path. No new tools, routers, DB schema, config keys, or agent-shape changes. New helper is a sibling of an existing function with the same signature.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local lint, mypy, black, isort green
- [x] 494 unit tests pass
- [x] Frontend tsc + build green
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)