### PR TITLE
feat(terse-memory): two-tier length guard on store_important_informat…

### DIFF
--- a/radbot/config/default_configs/instructions/scout.md
+++ b/radbot/config/default_configs/instructions/scout.md
@@ -209,3 +209,10 @@ problem to broader, reusable meta-patterns.
   sources
 - `store_agent_memory(information, memory_type)` — persist durable
   findings (not ephemeral turn-level detail)
+
+**Memory storage hygiene (EX28):** `store_important_information` enforces
+a 500-char soft limit. Before calling it, compress the content: drop
+articles, conjunctions, and filler phrases; keep only structural facts.
+Example: "The user has a preference for dark mode in all applications" →
+"user prefers dark mode". If content won't compress below 500 chars,
+split it into multiple focused calls (one fact per call).

--- a/radbot/tools/memory/memory_tools.py
+++ b/radbot/tools/memory/memory_tools.py
@@ -308,6 +308,21 @@ def store_important_information(
                 ),
             }
 
+        # EX28 two-tier terse-memory length guard (stateless, no LLM call).
+        info_len = len(information)
+        _truncated = False
+        if 500 < info_len <= 1000:
+            return (
+                "Error: Memory too long (max 500 chars). Rewrite using terse semantic "
+                "compression (drop articles, keep facts) and retry, or split into multiple calls."
+            )
+        if info_len > 1000:
+            information = information[:1000] + "...[TRUNCATED]"
+            logger.warning(
+                "store_important_information: input exceeded 1000 chars and was truncated"
+            )
+            _truncated = True
+
         # Create metadata if not provided
         metadata = metadata or {}
         metadata["memory_type"] = memory_type
@@ -322,6 +337,9 @@ def store_important_information(
         memory_service.client.upsert(
             collection_name=memory_service.collection_name, points=[point], wait=True
         )
+
+        if _truncated:
+            return "Success (Warning: Memory exceeded 1000 chars and was truncated)."
 
         return {
             "status": "success",

--- a/tests/unit/test_memory_tools.py
+++ b/tests/unit/test_memory_tools.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for EX28 terse-memory storage constraints in store_important_information.
+"""
+
+from unittest.mock import MagicMock
+
+from radbot.tools.memory.memory_tools import store_important_information
+
+
+def _make_context():
+    mock_context = MagicMock()
+    mock_memory_service = MagicMock()
+    mock_invocation_ctx = MagicMock()
+    mock_invocation_ctx.memory_service = mock_memory_service
+    mock_invocation_ctx.user_id = "user123"
+    mock_context._invocation_context = mock_invocation_ctx
+    mock_memory_service._create_memory_point.return_value = MagicMock()
+    return mock_context, mock_memory_service
+
+
+class TestTerseMemoryConstraints:
+    """EX28: two-tier stateless length guard on store_important_information."""
+
+    def test_store_important_information_under_limit_succeeds(self):
+        """Content under 500 chars is stored and returns a success dict."""
+        mock_context, mock_memory_service = _make_context()
+        info = "a" * 400
+
+        result = store_important_information(
+            information=info, tool_context=mock_context
+        )
+
+        assert isinstance(result, dict)
+        assert result["status"] == "success"
+        mock_memory_service._create_memory_point.assert_called_once()
+        stored_text = mock_memory_service._create_memory_point.call_args.kwargs["text"]
+        assert stored_text == info
+
+    def test_store_important_information_mid_range_returns_error_string(self):
+        """Content between 501–1000 chars returns a plain error string (no Qdrant write)."""
+        mock_context, mock_memory_service = _make_context()
+        info = "b" * 750
+
+        result = store_important_information(
+            information=info, tool_context=mock_context
+        )
+
+        assert isinstance(result, str)
+        assert result.startswith("Error: Memory too long")
+        mock_memory_service._create_memory_point.assert_not_called()
+        mock_memory_service.client.upsert.assert_not_called()
+
+    def test_store_important_information_over_limit_truncates_and_warns(self):
+        """Content over 1000 chars is truncated, stored, and returns a warning string."""
+        mock_context, mock_memory_service = _make_context()
+        info = "c" * 1500
+
+        result = store_important_information(
+            information=info, tool_context=mock_context
+        )
+
+        assert isinstance(result, str)
+        assert "Warning" in result
+        assert "truncated" in result.lower()
+        mock_memory_service._create_memory_point.assert_called_once()
+        stored_text = mock_memory_service._create_memory_point.call_args.kwargs["text"]
+        assert stored_text == "c" * 1000 + "...[TRUNCATED]"
+        mock_memory_service.client.upsert.assert_called_once()


### PR DESCRIPTION
…ion (EX28/PT83)

Add stateless 500-char soft limit and 1000-char hard truncation to store_important_information so LLMs are nudged toward terse semantic compression before writing to Qdrant. Tier 1 (501–1000 chars) returns a plain error string guiding the agent to rewrite or split the content. Tier 2 (>1000 chars) hard-truncates with a [TRUNCATED] marker, logs a warning, stores immediately, and returns a warning string.

Scout's instruction (scout.md) gains an explicit memory hygiene rule describing the 500-char target and the caveman-compression technique. Three unit tests verify all three tiers.