### PR TITLE
[scout-model-header] display session agent's model, not beto's

### DIFF
--- a/radbot/web/frontend/src/components/chat/ChatHeader.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatHeader.tsx
@@ -92,7 +92,13 @@ export default function ChatHeader() {
     }
   };
 
-  const modelName = agentInfo?.model ?? "";
+  const agentKey = sessionAgent.endsWith("_agent") ? sessionAgent : `${sessionAgent}_agent`;
+  const modelName =
+    (sessionAgent === "beto"
+      ? agentInfo?.model
+      : agentInfo?.agent_models?.[agentKey]) ??
+    agentInfo?.model ??
+    "";
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes a display bug where the chat header showed beto's model (from `agentInfo.model`) regardless of which agent owned the active session. In a scout session the header therefore showed beto's model even when scout was configured to use a different model in the admin panel. The backend already returns per-agent models in `agent_models` on `/api/agent-info`; this just wires the frontend to read the right field based on the current session's agent.

## Specs updated

None needed — not a shape change. No new/renamed agents, tools, routers, DB tables, config keys, admin panels, NAV_ITEMS/PANEL_MAP entries, or `data-test` convention changes. Per-CLAUDE.md's spec ↔ code map, behavioral fixes to an existing React component don't require a spec update.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `make lint` clean
- [x] `make test-unit` — 497 passed
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Quality pipeline (CI) — full Playwright e2e runs there
- [ ] Auto-merge at score ≥ 90