### PR TITLE
[cron-handoff-chips] strip handoff fences + prefer root agent final text

### DIFF
--- a/radbot/tools/scheduler/engine.py
+++ b/radbot/tools/scheduler/engine.py
@@ -7,6 +7,7 @@ Results are pushed to active WebSocket connections.
 """
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -15,6 +16,22 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 
 logger = logging.getLogger(__name__)
+
+_HANDOFF_FENCE_RE = re.compile(
+    r"```radbot:handoff\s*\n\{[^`]*?\}\s*\n```\s*", re.DOTALL
+)
+
+
+def _strip_handoff_chips(text: str) -> str:
+    """Remove UI-only ``radbot:handoff`` fenced blocks from captured text.
+
+    These fences are prepended by session_runner for the live web UI; they
+    render as raw JSON in notifications, ntfy, and chat history.
+    """
+    if not text:
+        return text
+    return _HANDOFF_FENCE_RE.sub("", text).lstrip()
+
 
 # Singleton instance
 _instance: Optional["SchedulerEngine"] = None
@@ -285,7 +302,7 @@ class SchedulerEngine:
             )
             result = await runner.process_message(prompt)
 
-            response = result.get("response", "")
+            response = _strip_handoff_chips(result.get("response", ""))
             events = result.get("events", [])
 
             # 5. Persist assistant response to DB

--- a/radbot/web/api/session/session_runner.py
+++ b/radbot/web/api/session/session_runner.py
@@ -425,10 +425,12 @@ class SessionRunner:
 
             # Initialize variables for collecting event data
             final_response = None
+            root_final_response = None  # Prefer text authored by the root agent
             last_text_response = None  # Track last non-empty text from any model event
             processed_events = []
             raw_response = None
             handoffs: list[dict] = []  # collected agent transfers for inline chips
+            root_agent_name = (self.agent_name or "beto").lower()
 
             for event in events:
                 # Extract event type and create a base event object
@@ -466,6 +468,9 @@ class SessionRunner:
                     ):
                         if text:
                             final_response = text
+                            author = str(getattr(event, "author", "")).lower()
+                            if author == root_agent_name:
+                                root_final_response = text
                         # Save raw response for later use if needed
                         if hasattr(event, "raw_response"):
                             raw_response = event.raw_response
@@ -538,6 +543,12 @@ class SessionRunner:
                         f"Error processing malformed function call: {str(e)}",
                         exc_info=True,
                     )
+
+            # Prefer the root agent's final response over a sub-agent's stray
+            # final text (e.g. a greeting from a transferred-to agent that
+            # never returned control to the root).
+            if root_final_response:
+                final_response = root_final_response
 
             # Fall back to last non-empty text from any model response event
             if not final_response and last_text_response:


### PR DESCRIPTION
## Summary

Scheduled cron deliveries were surfacing raw ```radbot:handoff``` JSON fences plus a stray sub-agent greeting instead of the actual briefing content. Root cause was two independent defects: (1) `session_runner` prepends handoff chips to `final_response` for UI rendering and the scheduler persisted that string verbatim into ntfy / notifications / offline queue; (2) `final_response` was overwritten by the last agent to emit final text, so when Beto transferred to Planner (and Planner returned a greeting without transferring back) Planner's greeting clobbered Beto's synthesis.

Fix 1 adds `_strip_handoff_chips()` in `scheduler/engine.py` and applies it once at response capture. Fix 2 tracks `root_final_response` alongside `final_response` in `session_runner` and prefers the root-agent-authored text after the event loop.

## Specs updated

None needed — both edits are internal behavior (response post-processing + final-text selection), not new tools, routers, WS types, or schemas. The Spec ↔ code map in CLAUDE.md does not cover internal logic of this shape.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local lint, mypy, unit tests (497 passed) all green on changed files
- [x] `_strip_handoff_chips` verified against a reproduction of the actual bad payload (three handoff fences + greeting → greeting only)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90
- [ ] Follow-up: investigate why Planner is being transferred to for briefing prompts and not returning to Beto — routing/instructions issue in `main_agent.md` / `planner.md`, out of scope for this PR