### PR TITLE
[drill-me] add drill-me Claude Code skill + Scout drill mode (PT97)

### DIFF
--- a/.claude/skills/drill-me/SKILL.md
+++ b/.claude/skills/drill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: drill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "drill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead. Limit codebase exploration to a maximum of 3 tool calls per question to prevent getting stuck.

--- a/radbot/config/default_configs/instructions/scout.md
+++ b/radbot/config/default_configs/instructions/scout.md
@@ -217,6 +217,30 @@ biological and architectural metaphors. Ask for the underlying structural
 forcing functions rather than accepting vague intentions. Map his current
 problem to broader, reusable meta-patterns.
 
+## Drill mode
+
+When Perry says "drill me", "drill-me", "stress-test this plan", or
+otherwise asks to be grilled, switch out of plan-drafting and into
+adversarial interview mode. The goal is to walk down each branch of the
+plan's decision tree, resolve dependencies one-by-one, and end at shared
+understanding before any plan is persisted to Telos.
+
+Rules:
+- **One question at a time.** No multi-question lists, no preamble. One
+  question per turn, then wait for Perry's answer.
+- **Recommend an answer.** With each question, give your own best guess
+  so Perry can redirect rather than starting from scratch.
+- **Empirical questions go to tools, not to Perry.** If a question can
+  be answered from the codebase, the wiki, or the web, run the search
+  yourself. Cap at **3 tool calls per question** — if you can't resolve
+  it in 3, ask Perry directly. This prevents token-burn loops.
+- **Skip the council.** Drill mode is pre-plan probing, not plan
+  drafting. Don't `should_convene_council` or run critics from inside
+  drill mode — that's for the synthesized plan that comes out of it.
+- **Exit cleanly.** When the decision tree feels resolved or Perry says
+  to stop, summarize the answers we landed on in 3–6 bullets and ask
+  whether to fold them into a 5-role plan and run the council.
+
 ## Memory tools
 
 - `search_agent_memory(query)` — recall past research threads, plans,


### PR DESCRIPTION
## Summary

Implements PT97 (per EX36): a "drill me" capability modeled on Matt Pocock's `grill-me` — a relentless interviewer that walks down a plan's decision tree one question at a time, recommending an answer for each, with a 3-tool-call cap per question to prevent token-burn loops.

Two surfaces, one prompt:

- **`.claude/skills/drill-me/SKILL.md`** — verbatim content from EX36 (Claude Code skill).
- **`radbot/config/default_configs/instructions/scout.md`** — new "Drill mode" section, sibling to "Rubber-duck mode". Adapted to Scout's research-tool surface and pre-Plan-Council position so Scout can stress-test plans natively (it can't invoke Claude Code skills as an ADK agent).

Closes PT97.

## Specs updated

None needed.

- `.claude/skills/` is local Claude Code config — not on the spec ↔ code map.
- `radbot/config/default_configs/instructions/scout.md` is referenced by `specs/agents.md` and `specs/config.md` only as a file location; specs don't enumerate the inner sections (e.g. "Rubber-duck mode"). No change to Scout's tool inventory, factory, callbacks, or routing.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local lint (flake8 + mypy) green
- [x] Local unit tests green (558 passed)
- [x] Skill registered (visible in Claude Code's available-skills list)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

## Manual rubric (per EX36)

- [ ] Fresh Claude Code session in this repo + "drill me on a plan to add a new CLI command" → skill activates, asks exactly one question with a recommended answer.
- [ ] Scout in radbot web UI + "drill me on the plan to add a fancy CLI command" → asks one question at a time, recommends an answer, doesn't fire >3 tool calls per question, doesn't trigger the council.

🤖 Generated with [Claude Code](https://claude.com/claude-code)