### PR TITLE
[pt99-fix-forward] fix v0.164 boot: ASGI lifespan, anyio<5, ws=wsproto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ dependencies = [
     # Removed gcsa due to dependency conflict with ADK (tzlocal version conflict)
     "youtube-transcript-api>=1.2.4",
     "pydantic-ai>=0.0.14",                  # Required for SemanticDistiller strict-schema LLM calls
+    # Pin anyio < 5: anyio 5.0.0 (released 2026-04-23) tightened thread/event-loop
+    # coupling for Python 3.14 in a way that breaks fastapi.run_in_threadpool —
+    # every HTTP request hits `anyio.NoEventLoopError` under our 3.14-slim image.
+    # Caught in production by the v0.164 deploy. Pin until anyio 5 + fastapi 0.110+
+    # ship a compatible release.
+    "anyio>=4.0.0,<5.0.0",
 ]
 
 [project.optional-dependencies]
@@ -67,6 +73,7 @@ dev = [
 web = [
     "fastapi>=0.110.0",
     "uvicorn>=0.27.1",
+    "wsproto>=1.2.0",   # uvicorn ws=wsproto — see start_server() comment
     "jinja2>=3.1.4",
     "starlette>=0.36.0",
     "python-multipart>=0.0.9",

--- a/radbot/web/app.py
+++ b/radbot/web/app.py
@@ -19,6 +19,7 @@ import logging
 import os
 import time
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -72,6 +73,24 @@ from radbot.web.api.webhooks import router as webhooks_router
 logger = logging.getLogger(__name__)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """ASGI lifespan: build state on startup, tear it down on shutdown.
+
+    Replaces the previous `@app.on_event("startup"/"shutdown")` decorator
+    pattern. The legacy decorators are deprecated in modern FastAPI and
+    were observed silently no-op'ing under the production runtime
+    (Python 3.14 + new dep set), causing `build_default_assembly()` to
+    never run and every request to fail. Lifespan is the supported,
+    non-deprecated path.
+    """
+    await _startup()
+    try:
+        yield
+    finally:
+        await _shutdown()
+
+
 def create_app():
     """Create and configure the FastAPI application.
 
@@ -83,6 +102,7 @@ def create_app():
         title="RadBot Web Interface",
         description="Web interface for interacting with RadBot agent",
         version="0.1.0",
+        lifespan=lifespan,
     )
 
     # Register API routers immediately after app creation
@@ -127,10 +147,13 @@ def create_app():
 app = create_app()
 
 
-# Define a startup event to initialize database schema and MCP servers
-@app.on_event("startup")
-async def initialize_app_startup():
-    """Initialize database schema and MCP server tools on application startup."""
+async def _startup():
+    """Initialize database schema, agent assembly, and MCP servers on startup.
+
+    Invoked by the ASGI lifespan context manager. Logs explicit progress
+    so a silent no-op (the v0.164 incident) is visible from the alloc logs.
+    """
+    logger.info("Lifespan startup: begin")
     try:
         # Log environment banner
         from radbot.config.config_loader import config_loader as _cl
@@ -370,11 +393,19 @@ async def initialize_app_startup():
 
     except Exception as e:
         logger.error(f"Failed during application startup: {str(e)}", exc_info=True)
+        raise
+
+    # Mount static files now that all routes are registered.
+    try:
+        mount_static_files()
+    except Exception as static_err:
+        logger.error(f"Error mounting static files: {static_err}", exc_info=True)
+
+    logger.info("Lifespan startup: complete")
 
 
-@app.on_event("shutdown")
-async def shutdown_scheduler():
-    """Shut down the scheduler engine gracefully."""
+async def _shutdown():
+    """Tear down scheduler, ntfy subscriber, and terminal sessions."""
     try:
         from radbot.tools.scheduler.engine import SchedulerEngine
 
@@ -385,10 +416,6 @@ async def shutdown_scheduler():
     except Exception as e:
         logger.error(f"Error shutting down scheduler engine: {e}", exc_info=True)
 
-
-@app.on_event("shutdown")
-async def shutdown_ntfy_subscriber():
-    """Stop the ntfy subscriber on shutdown."""
     try:
         from radbot.tools.ntfy.ntfy_subscriber import stop_ntfy_subscriber
 
@@ -397,10 +424,6 @@ async def shutdown_ntfy_subscriber():
     except Exception as e:
         logger.error(f"Error shutting down ntfy subscriber: {e}", exc_info=True)
 
-
-@app.on_event("shutdown")
-async def shutdown_terminals():
-    """Kill all terminal PTY sessions on shutdown."""
     try:
         TerminalManager.get_instance().kill_all()
     except Exception as e:
@@ -461,13 +484,6 @@ def mount_static_files():
         logger.debug("Static files mounted successfully")
     except Exception as e:
         logger.error(f"Error mounting static files: {str(e)}", exc_info=True)
-
-
-# Schedule static files mounting after all other routes are registered
-@app.on_event("startup")
-async def mount_static_files_on_startup():
-    """Mount static files during application startup after routes are registered."""
-    mount_static_files()
 
 
 # WebSocket connection manager
@@ -1198,4 +1214,15 @@ def start_server(host: str = "0.0.0.0", port: int = 8000, reload: bool = False):
     # Events router is already registered during module initialization
 
     logger.info(f"Starting RadBot web server on {host}:{port}")
-    uvicorn.run("radbot.web.app:app", host=host, port=port, reload=reload)
+    # ws="wsproto" forces the wsproto WebSocket protocol implementation.
+    # The default `auto` picks the legacy `websockets` library when installed,
+    # whose handler raises `RuntimeError: Timeout should be used inside a task`
+    # under Python 3.14. wsproto is unaffected. We can't drop the `websockets`
+    # dep — it's used for the Home Assistant WebSocket client.
+    uvicorn.run(
+        "radbot.web.app:app",
+        host=host,
+        port=port,
+        reload=reload,
+        ws="wsproto",
+    )

--- a/tests/unit/test_web_startup.py
+++ b/tests/unit/test_web_startup.py
@@ -1,0 +1,125 @@
+"""Smoke tests for `radbot.web.app` lifespan startup.
+
+The v0.164 production incident on 2026-05-01 was caused by the deprecated
+`@app.on_event("startup")` decorator silently no-op'ing under the new
+runtime, so `build_default_assembly()` never ran and every request 500'd.
+
+These tests close the gap by importing `radbot.web.app`, driving the ASGI
+lifespan from a stub manifest, and asserting the cached assembly exists
+and the static-file mount executed.
+
+We can't run the full lifespan (DB / MCP / scheduler / ntfy require live
+infra), so we mock at the seams that are pure infra (`init_all_schemas`,
+`SchedulerEngine`, `start_ntfy_subscriber`, `mount_static_files`,
+`reload_filesystem_config`, `setup_vertex_environment`, the migration
+script) and let the actual `_startup` body run for the parts that matter
+(building the assembly, applying model overrides).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def patched_startup_seams():
+    """Patch the heavy-infra seams of `_startup` so we can run it offline."""
+    with (
+        patch("radbot.tools.schemas.init_all_schemas") as p_schema,
+        patch("scripts.migrate_todo_to_telos.main"),
+        patch("radbot.filesystem.adapter.reload_filesystem_config"),
+        patch("radbot.config.adk_config.setup_vertex_environment"),
+        patch("radbot.web.app.mount_static_files") as p_static,
+        patch("radbot.tools.scheduler.engine.SchedulerEngine") as p_engine,
+        patch(
+            "radbot.tools.ntfy.ntfy_subscriber.start_ntfy_subscriber",
+            new_callable=AsyncMock,
+        ) as p_ntfy,
+        patch("radbot.tools.tts.tts_service.TTSService"),
+        patch("radbot.tools.stt.stt_service.STTService"),
+        patch("radbot.tools.mcp.mcp_client_factory.MCPClientFactory"),
+        patch("radbot.config.config_loader.config_loader.load_db_config") as p_db_cfg,
+        patch(
+            "radbot.config.config_loader.config_loader.get_enabled_mcp_servers",
+            return_value=[],
+        ),
+        patch(
+            "radbot.config.config_loader.config_loader.get_mcp_servers",
+            return_value=[],
+        ),
+    ):
+        # Make scheduler engine async no-ops
+        engine = MagicMock()
+        engine.start = AsyncMock()
+        engine.shutdown = AsyncMock()
+        p_engine.create_instance.return_value = engine
+        p_engine.get_instance.return_value = engine
+
+        yield {
+            "schema": p_schema,
+            "static": p_static,
+            "engine": p_engine,
+            "load_db_config": p_db_cfg,
+            "ntfy": p_ntfy,
+        }
+
+
+def _reset_assembly_cache():
+    from radbot.agent import assembly
+
+    assembly._cached_assembly = None
+
+
+@pytest.mark.asyncio
+async def test_lifespan_startup_runs_init_all_schemas_and_builds_assembly(
+    patched_startup_seams,
+):
+    """The ASGI lifespan must invoke `init_all_schemas` and build the assembly.
+
+    This is the precise failure mode the v0.164 incident exhibited: lifespan
+    completed silently, schemas were not initialized, and assembly was never
+    built. Asserting on the call counts ensures the lifespan body actually
+    runs end-to-end.
+    """
+    _reset_assembly_cache()
+    seams = patched_startup_seams
+
+    from radbot.web.app import lifespan
+
+    app = MagicMock()  # the lifespan only uses app for typing
+    async with lifespan(app):
+        # Inside the lifespan: startup completed, app would be serving.
+        seams["schema"].assert_called()
+        seams["load_db_config"].assert_called()
+        seams["static"].assert_called_once()
+
+        # Most important assertion: the agent assembly was actually built
+        # and cached. If this fails, the production incident recurs.
+        from radbot.agent.assembly import _resolve_assembly
+
+        assembly = _resolve_assembly()
+        assert assembly.root_agent.name == "beto"
+        assert len(assembly.root_agent.sub_agents) >= 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_startup_failure_propagates(patched_startup_seams):
+    """If schema init raises, the lifespan must surface it (not swallow).
+
+    Pre-fix, `_startup` swallowed exceptions in a bare `except` and let the
+    app boot in a half-initialized state. The fix re-raises, so a busted
+    deploy refuses to bind the port and the orchestrator reschedules.
+    """
+    _reset_assembly_cache()
+    seams = patched_startup_seams
+    seams["schema"].side_effect = RuntimeError("simulated schema failure")
+
+    from radbot.web.app import lifespan
+
+    app = MagicMock()
+
+    with pytest.raises(RuntimeError, match="simulated schema failure"):
+        async with lifespan(app):
+            pass  # should not be reached

--- a/uv.lock
+++ b/uv.lock
@@ -1780,9 +1780,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
     { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
     { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
     { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
     { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
     { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
@@ -1790,9 +1788,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1800,9 +1796,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -1810,9 +1804,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -1820,9 +1812,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -4410,6 +4400,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
+    { name = "anyio" },
     { name = "apscheduler" },
     { name = "atlassian-python-api" },
     { name = "cryptography" },
@@ -4456,11 +4447,13 @@ web = [
     { name = "python-multipart" },
     { name = "starlette" },
     { name = "uvicorn" },
+    { name = "wsproto" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.0" },
+    { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "apscheduler", specifier = ">=3.10.0" },
     { name = "atlassian-python-api", specifier = ">=3.41.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
@@ -4499,6 +4492,7 @@ requires-dist = [
     { name = "tzdata" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.27.1" },
     { name = "websockets", specifier = ">=12.0.0" },
+    { name = "wsproto", marker = "extra == 'web'", specifier = ">=1.2.0" },
     { name = "youtube-transcript-api", specifier = ">=1.2.4" },
 ]
 provides-extras = ["dev", "web"]
@@ -5384,6 +5378,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fix-forward for the PT99 / v0.164 production incident this morning. After PR #97 merged and the new image deployed, every HTTP request returned 500 (`anyio.NoEventLoopError`) and every WebSocket handshake failed (`RuntimeError: Timeout should be used inside a task`). Production was rolled back to v0.163 manually.

Three independent regressions stacked:

1. **`@app.on_event("startup")` silently stopped firing** under Python 3.14 + the new fastapi/starlette/anyio versions resolved by pip on the v0.164 build. `build_default_assembly()` never ran → lazy proxy raised on every request. Pre-PR-97 the agent was assembled at module-import time, so this dormant bug was invisible.
2. **anyio 5.0** (released 2026-04-23) tightened thread/event-loop coupling and broke `fastapi.run_in_threadpool` on Python 3.14.
3. **uvicorn `ws=auto`** picked the `websockets` library legacy server class, whose handler invokes `asyncio.timeout()` outside a Task — broken under 3.14.

Fixes:

- **Migrate four `@app.on_event(...)` decorators to a single ASGI `lifespan` async context manager.** FastAPI's supported pattern, invoked regardless of `on_event` deprecation status. `_startup()` now re-raises on failure (was: bare except), so a busted deploy refuses the port and Nomad reschedules instead of bind-and-500'ing.
- **Pin `anyio>=4.0.0,<5.0.0`** until anyio 5 + fastapi ship a 3.14-compatible release.
- **Force `uvicorn.run(..., ws="wsproto")`** and add `wsproto>=1.2.0` to the `web` extra. The `websockets` library stays installed (Home Assistant client needs it).
- **Add `tests/unit/test_web_startup.py`** — drives the lifespan with infra mocked, asserts `init_all_schemas` runs, the assembly is built, the static mount fires, and a schema-init failure propagates. Closes the gap that let v0.164 ship.

## Specs updated

None needed — the assembly lifecycle is described in `specs/agents.md` § Assembly lifecycle as part of PR #97; the on_event → lifespan migration is an internal implementation detail.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `tests/unit/test_web_startup.py` — 2 new tests passing (lifespan runs end-to-end; failure propagates)
- [x] Full unit suite: 554 passing locally
- [x] Lint (flake8 + mypy + black) clean
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90
- [ ] Deploy v0.165, verify `/healthz` + `/ws/{session_id}` work in prod

## Followup (not in this PR)

A CI gate that boots the production Docker image (Python 3.14-slim, real pip-resolved deps) and hits `/healthz` + a WebSocket. The unit test here catches the silent-no-op failure mode but not the dep-resolution-on-3.14 surface that caused the upstream symptoms (anyio/wsproto/websockets versions). Track via a follow-up PT.