### PR TITLE
[chat-db] defer credential check from import-time to pool init (PT102)

### DIFF
--- a/.github/workflows/quality-pipeline.yml
+++ b/.github/workflows/quality-pipeline.yml
@@ -242,14 +242,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: uv sync --all-extras
-      # Dummy DB creds satisfy the import-time check in
-      # radbot/web/db/connection.py — unit tests don't actually connect, but
-      # the module raises at import unless creds are present.
       - name: Run unit + integration tests
-        env:
-          POSTGRES_DB: radbot_test
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
         run: make test-unit && make test-integration
       - id: score
         if: always()

--- a/radbot/web/db/connection.py
+++ b/radbot/web/db/connection.py
@@ -22,81 +22,99 @@ from radbot.config import config_loader
 logger = logging.getLogger(__name__)
 
 # --- Connection Pool Setup ---
+#
+# Credential resolution and validation are deferred to pool init (see
+# initialize_connection_pool below) so simply importing this module is safe
+# in environments that never connect — e.g. unit tests that import
+# radbot.web.app transitively. Sibling pool in radbot/db/connection.py uses
+# the same pattern.
 
-# Get database configuration from config.yaml
-database_config = config_loader.get_config().get("database", {})
-chat_db_config = database_config.get("chat_history", {})
-
-# Load schema name with a default fallback
-CHAT_SCHEMA = chat_db_config.get("schema", "radbot_chathistory")
-
-# Load connection details from config or environment
-DB_NAME = (
-    chat_db_config.get("db_name")
-    or database_config.get("db_name")
-    or os.getenv("POSTGRES_DB")
-)
-DB_USER = (
-    chat_db_config.get("user")
-    or database_config.get("user")
-    or os.getenv("POSTGRES_USER")
-)
-DB_PASSWORD = (
-    chat_db_config.get("password")
-    or database_config.get("password")
-    or os.getenv("POSTGRES_PASSWORD")
-)
-DB_HOST = (
-    chat_db_config.get("host")
-    or database_config.get("host")
-    or os.getenv("POSTGRES_HOST", "localhost")
-)
-DB_PORT = (
-    chat_db_config.get("port")
-    or database_config.get("port")
-    or os.getenv("POSTGRES_PORT", "5432")
+# Schema name uses a stable default. Reading config here is cheap and
+# side-effect-free.
+CHAT_SCHEMA = (
+    config_loader.get_config()
+    .get("database", {})
+    .get("chat_history", {})
+    .get("schema", "radbot_chathistory")
 )
 
-# Basic validation
-if not all([DB_NAME, DB_USER, DB_PASSWORD]):
-    error_msg = "Database credentials (database.chat_history.db_name, database.chat_history.user, database.chat_history.password) must be set in config.yaml or as environment variables"  # noqa: E501
-    logger.error(error_msg)
-    raise ValueError(error_msg)
+# Pool sizing (overridable via environment variables)
+MIN_CONN = int(os.environ.get("RADBOT_DB_POOL_MIN", "1"))
+MAX_CONN = int(os.environ.get("RADBOT_DB_POOL_MAX", "10"))
 
 # Register UUID adapter for psycopg2
 psycopg2.extensions.register_adapter(
     uuid.UUID, lambda u: psycopg2.extensions.adapt(str(u))
 )
 
-# Configure and initialize the connection pool
-# Adjust minconn and maxconn based on expected load (overridable via environment variables)
-MIN_CONN = int(os.environ.get("RADBOT_DB_POOL_MIN", "1"))
-MAX_CONN = int(os.environ.get("RADBOT_DB_POOL_MAX", "10"))
-
 # Global pool reference
 chat_pool = None
 _pool_lock = threading.Lock()
+
+
+def _resolve_chat_db_credentials() -> dict:
+    """Resolve chat-history DB credentials from config + environment."""
+    database_config = config_loader.get_config().get("database", {})
+    chat_db_config = database_config.get("chat_history", {})
+
+    return {
+        "db_name": (
+            chat_db_config.get("db_name")
+            or database_config.get("db_name")
+            or os.getenv("POSTGRES_DB")
+        ),
+        "user": (
+            chat_db_config.get("user")
+            or database_config.get("user")
+            or os.getenv("POSTGRES_USER")
+        ),
+        "password": (
+            chat_db_config.get("password")
+            or database_config.get("password")
+            or os.getenv("POSTGRES_PASSWORD")
+        ),
+        "host": (
+            chat_db_config.get("host")
+            or database_config.get("host")
+            or os.getenv("POSTGRES_HOST", "localhost")
+        ),
+        "port": (
+            chat_db_config.get("port")
+            or database_config.get("port")
+            or os.getenv("POSTGRES_PORT", "5432")
+        ),
+    }
 
 
 def initialize_connection_pool():
     """Initialize the connection pool for chat history database."""
     global chat_pool
 
+    creds = _resolve_chat_db_credentials()
+    if not all([creds["db_name"], creds["user"], creds["password"]]):
+        error_msg = "Database credentials (database.chat_history.db_name, database.chat_history.user, database.chat_history.password) must be set in config.yaml or as environment variables"  # noqa: E501
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
     try:
         chat_pool = psycopg2.pool.ThreadedConnectionPool(
             minconn=MIN_CONN,
             maxconn=MAX_CONN,
-            database=DB_NAME,
-            user=DB_USER,
-            password=DB_PASSWORD,
-            host=DB_HOST,
-            port=DB_PORT,
+            database=creds["db_name"],
+            user=creds["user"],
+            password=creds["password"],
+            host=creds["host"],
+            port=creds["port"],
         )
         logger.info(
             f"Chat history database connection pool initialized (Min: {MIN_CONN}, Max: {MAX_CONN})"
         )
         logger.info(
-            f"Connected to PostgreSQL database '{DB_NAME}' using schema '{CHAT_SCHEMA}' at {DB_HOST}:{DB_PORT}"
+            "Connected to PostgreSQL database '%s' using schema '%s' at %s:%s",
+            creds["db_name"],
+            CHAT_SCHEMA,
+            creds["host"],
+            creds["port"],
         )
         return True
     except psycopg2.OperationalError as e:


### PR DESCRIPTION
## Summary

Resolves **PT102** — fixes the 6 pre-existing unit-test failures the EX38 PR2 friction notes surfaced.

`radbot/web/db/connection.py` was raising `ValueError` at module import time when DB env vars were missing. Any test that transitively imported `radbot.web.app` or its API routers crashed before fixtures could run — 4 in `test_mcp_setup_endpoint`, 2 in `test_web_startup`, plus `test_session_naming` on a clean dev machine. CI papered over it by injecting dummy `POSTGRES_DB/USER/PASSWORD` on the unit-tests job; the comment there literally named it a workaround.

The fix mirrors the sibling pool in `radbot/db/connection.py`: credential resolution + validation move into `initialize_connection_pool()` via a new `_resolve_chat_db_credentials()` helper. Module imports cleanly; pool init still raises loudly when called without credentials. Production boot still hard-fails on missing env vars (the lifespan calls pool init early); tests that don't actually hit the chat DB now run on a bare machine with no env wiring.

Drops the now-redundant dummy `POSTGRES_*` env block + workaround comment from `.github/workflows/quality-pipeline.yml` unit-tests job.

## Specs updated

None needed.

- `specs/storage.md` describes the chat-history pool at module level (its existence and table list), not at credential-resolution-lifecycle level — the change is an internal refactor that doesn't alter what the spec describes.
- `specs/testing.md` does not mention the dummy-env workaround; removing it is invisible to the spec.

## Verification

- [x] 559/559 unit tests pass with `POSTGRES_DB/USER/PASSWORD` unset and no `.env` file present (was 536 + 4 failed + 2 errored + 1 skipped on `origin/main`).
- [x] `uv run flake8 radbot tests` — clean
- [x] `uv run mypy radbot tests` — `Success: no issues found in 368 source files`
- [x] `uv run black --check radbot tests` — clean
- [x] `uv run isort --check radbot tests` — clean
- [ ] Quality pipeline (CI) — the deletion of the dummy env block should still pass since the import-time check is gone
- [ ] Auto-merge at score ≥ 90