### PR TITLE
[ship-skill-fixes] worktree dev-deps sync + label concurrency fix (PT110)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -3,13 +3,13 @@ name: ship
 description: >
   Branch off main into an isolated worktree, run cheap local quality gates
   (lint, static type-check, unit tests, frontend build/e2e), open a PR with
-  the run-e2e and auto-merge-eligible labels applied, watch the
-  quality-pipeline workflow run, fix CI failures up to 3 times, and merge
-  from the user's shell (so deploy workflows fire) when the score crosses 90.
-  Use when the user says "ship this", "open a PR for this work", "merge when
-  CI is green", or wants the full ship-it lifecycle for a non-trivial change.
-  Does NOT decide merge authority — the workflow's own gates do; this skill
-  just orchestrates the human-side loop.
+  the run-e2e label, watch the quality-pipeline workflow run, fix CI
+  failures up to 3 times, then add auto-merge-eligible and merge from the
+  user's shell (so deploy workflows fire) when the score crosses 90. Use
+  when the user says "ship this", "open a PR for this work", "merge when
+  CI is green", or wants the full ship-it lifecycle for a non-trivial
+  change. Does NOT decide merge authority — the workflow's own gates do;
+  this skill just orchestrates the human-side loop.
 ---
 
 # /ship — work in worktree → PR → quality-pipeline → auto-merge at 90
@@ -95,6 +95,16 @@ If work was already on a branch → skip this entire section and just `git push 
 If either invariant fails, stop and ask.
 
 From here, every command runs in the worktree.
+
+## Phase 2.5 — Sync dev dependencies in the worktree
+
+The fresh worktree has no `.venv`, so `make lint` / `make test-unit` would otherwise hit a missing/partial environment (or whatever `uv` last cached). Pin the env explicitly so Phase 3 has flake8, mypy, pytest, isort, black, etc. available:
+
+```bash
+uv sync --all-extras --dev
+```
+
+Skip-able only if you already pre-synced this worktree in this session.
 
 ## Phase 3 — Local gates (cheap subset)
 
@@ -197,15 +207,13 @@ EOF
 )"
 ```
 
-Apply labels:
-- Always: `run-e2e` (triggers the workflow)
-- Default: also `auto-merge-eligible` (releases auto-merge once score ≥ 90)
-- If `--manual-merge`: only `run-e2e`
+Apply only the `run-e2e` label here:
 
 ```bash
 gh pr edit <PR_NUMBER> --repo $GITHUB_REPO --add-label run-e2e
-[ "$MANUAL_MERGE" != "true" ] && gh pr edit <PR_NUMBER> --add-label auto-merge-eligible
 ```
+
+`auto-merge-eligible` is deferred to Phase 11 (right before merge). Applying both labels in one burst racing against GitHub Actions' `pull_request.labeled` concurrency policy cancels the in-flight quality-pipeline run — moving the second label out of the PR-open phase removes the timing dependency entirely.
 
 Capture the PR number for the next phases.
 
@@ -257,7 +265,13 @@ Cap at $MAX_FIX_ATTEMPTS. Past that, hand control to the user with a summary.
 If `score ≥ $AUTO_MERGE_THRESHOLD`:
 
 1. Confirm once with the user: `Score is NN/100 — merge now?` Skip if `--auto-yes` was passed.
-2. Verify the pipeline actually cleared the gates the skill cannot see:
+2. Apply `auto-merge-eligible` now (deferred from Phase 7 to avoid the `pull_request.labeled` concurrency race against the in-flight quality-pipeline run). Skip on `--manual-merge`:
+
+```bash
+[ "$MANUAL_MERGE" != "true" ] && gh pr edit $PR_NUMBER --repo $GITHUB_REPO --add-label auto-merge-eligible
+```
+
+3. Verify the pipeline actually cleared the gates the skill cannot see:
 
 ```bash
 gh pr view $PR_NUMBER --repo $GITHUB_REPO \
@@ -268,13 +282,13 @@ gh pr view $PR_NUMBER --repo $GITHUB_REPO \
    - `auto-merge-eligible` must be in `labels` (otherwise the user chose `--manual-merge`; stop and hand off).
    - `aggregate_conclusion` must be `SUCCESS`.
 
-3. Merge from the user's shell — **never from inside the workflow**. A merge authored by the workflow's `GITHUB_TOKEN` does not fire downstream `push` workflows (including `Build and Push Docker Image`), so merging from CI silently skips deploys ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). `gh` uses the user's PAT, so the resulting push to `main` triggers the docker-build workflow as expected.
+4. Merge from the user's shell — **never from inside the workflow**. A merge authored by the workflow's `GITHUB_TOKEN` does not fire downstream `push` workflows (including `Build and Push Docker Image`), so merging from CI silently skips deploys ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). `gh` uses the user's PAT, so the resulting push to `main` triggers the docker-build workflow as expected.
 
 ```bash
 gh pr merge $PR_NUMBER --repo $GITHUB_REPO --squash --delete-branch
 ```
 
-4. After merge, confirm the deploy fired:
+5. After merge, confirm the deploy fired:
 
 ```bash
 sleep 10
@@ -283,7 +297,7 @@ gh run list --repo $GITHUB_REPO --workflow "Build and Push Docker Image" --branc
 
    Tell the user the run ID so they can watch it. If no run appears within ~30 s, the user should push an empty commit from their shell to force a fresh `push` event.
 
-5. If `auto-merge-eligible` is missing or `aggregate_conclusion` is not `SUCCESS`, tell the user why and stop — do not attempt the merge.
+6. If `auto-merge-eligible` is missing or `aggregate_conclusion` is not `SUCCESS`, tell the user why and stop — do not attempt the merge.
 
 The skill has NO authority to bypass branch protection or path-guard — it only orchestrates.
 

--- a/docs/implementation/ship_skill.md
+++ b/docs/implementation/ship_skill.md
@@ -30,16 +30,17 @@ Optional arguments:
 
 1. **Pre-flight** — confirm clean working tree, derive slug.
 2. **Worktree** — `git worktree add /tmp/radbot-ship-<slug> -b ship/<slug> origin/main`.
-3. **Local gates (cheap subset, hard gate)** — `make lint` (flake8 + mypy), `make test-unit`. When frontend changed: `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e`. Every gate must be green before push — skipping a local gate to "let CI catch it" wastes ~4 min of pipeline time. Skips visual regression and chat-quality (CI handles them).
-4. **Spec sync check** — for every changed source file, verify the corresponding `specs/*.md` is in the diff (per `CLAUDE.md` Spec ↔ code map).
-5. **Secret scan** — regex on staged + unstaged files (`AKIA…`, `ghp_…`, `sk-ant-…`, etc.). Hard stop on match.
-6. **Commit + push** — conventional-commit message, push to `ship/<slug>`.
-7. **Open PR** — `gh pr create` with `run-e2e` and `auto-merge-eligible` labels.
-8. **Watch workflow** — `gh run watch` (server-side stream, not polling).
-9. **Read score** — from commit status `quality-pipeline/score` (NOT the sticky comment, which is forgeable — see `docs/implementation/ci-security.md`).
-10. **CI fix loop** — up to 3 attempts to address pipeline feedback.
-11. **Merge (user-authenticated)** — confirms once with you (unless `--auto-yes`), verifies `auto-merge-eligible` label + `aggregate` SUCCESS + score ≥ 90, then runs `gh pr merge --squash --delete-branch` from your shell. Not performed inside CI — a merge authored by `GITHUB_TOKEN` does not trigger the `Build and Push Docker Image` workflow (GitHub's recursion guard), so running the merge locally is what makes deploys fire.
-12. **Cleanup** — reminds you the worktree exists; offers to remove on confirmation.
+3. **Sync dev deps in worktree** — `uv sync --all-extras --dev`. The fresh worktree has no `.venv`, so this primes flake8 / mypy / pytest / etc. before the gates.
+4. **Local gates (cheap subset, hard gate)** — `make lint` (flake8 + mypy), `make test-unit`. When frontend changed: `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e`. Every gate must be green before push — skipping a local gate to "let CI catch it" wastes ~4 min of pipeline time. Skips visual regression and chat-quality (CI handles them).
+5. **Spec sync check** — for every changed source file, verify the corresponding `specs/*.md` is in the diff (per `CLAUDE.md` Spec ↔ code map).
+6. **Secret scan** — regex on staged + unstaged files (`AKIA…`, `ghp_…`, `sk-ant-…`, etc.). Hard stop on match.
+7. **Commit + push** — conventional-commit message, push to `ship/<slug>`.
+8. **Open PR** — `gh pr create` with the `run-e2e` label only. `auto-merge-eligible` is deferred to phase 12 to avoid a `pull_request.labeled` concurrency race that cancels the in-flight quality-pipeline run.
+9. **Watch workflow** — `gh run watch` (server-side stream, not polling).
+10. **Read score** — from commit status `quality-pipeline/score` (NOT the sticky comment, which is forgeable — see `docs/implementation/ci-security.md`).
+11. **CI fix loop** — up to 3 attempts to address pipeline feedback.
+12. **Merge (user-authenticated)** — confirms once with you (unless `--auto-yes`), applies `auto-merge-eligible` now, verifies the label + `aggregate` SUCCESS + score ≥ 90, then runs `gh pr merge --squash --delete-branch` from your shell. Not performed inside CI — a merge authored by `GITHUB_TOKEN` does not trigger the `Build and Push Docker Image` workflow (GitHub's recursion guard), so running the merge locally is what makes deploys fire.
+13. **Cleanup** — reminds you the worktree exists; offers to remove on confirmation.
 
 ## Recovery from common failures
 


### PR DESCRIPTION
## Summary

Resolves two friction points in the `/ship` skill observed during PT106 / PT107:

1. **Worktree dev deps** — adds Phase 2.5 (`uv sync --all-extras --dev`) so the fresh worktree has flake8 / mypy / pytest before Phase 3's hard gates run. Previously the gates either picked up whatever `uv` last cached or hit a partial env and surfaced confusing errors.
2. **Label concurrency fix** — `auto-merge-eligible` is deferred from Phase 7 (PR open) to Phase 11 (right before merge). Applying both labels at PR-open raced against GitHub Actions' `pull_request.labeled` concurrency policy and cancelled the in-flight quality-pipeline run. This is option (b) from the task contract — removing the timing dependency entirely beats waiting for `in_progress` (option a).

Doc `docs/implementation/ship_skill.md` updated to match the new step layout / wording.

## Specs updated

None needed — change is to the `/ship` skill (`.claude/skills/ship/SKILL.md`) and its companion implementation doc (`docs/implementation/ship_skill.md`). Neither path appears in `CLAUDE.md`'s Spec ↔ code map.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] Local lint (flake8 + mypy clean), unit tests (596 passed) green — frontend block skipped (no frontend changes)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90

Closes PT110.