### PR TITLE
[ship-skill-pt114] polish /ship: make lint, REST-API labels, path-filter handoff

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -113,8 +113,17 @@ Skip-able only if you already pre-synced this worktree in this session.
 ### Python static + unit
 
 ```bash
-make lint                   # flake8 + mypy over radbot/ and tests/
+make lint                   # flake8 + mypy + black --check + isort --check over radbot/ and tests/
 make test-unit              # pytest tests/unit
+```
+
+If `make lint` is unavailable, the equivalent fallback is all four steps — running only flake8 + mypy will let formatting drift through and trip CI:
+
+```bash
+uv run flake8 radbot tests
+uv run mypy radbot tests
+uv run black --check radbot tests
+uv run isort --check radbot tests
 ```
 
 ### Frontend static + build (only if `radbot/web/frontend/**` changed)
@@ -207,11 +216,19 @@ EOF
 )"
 ```
 
-Apply only the `run-e2e` label here:
+Apply only the `run-e2e` label here. Use the REST API directly — `gh pr edit --add-label` goes through GraphQL and has been observed to silently exit 0 without applying the label, leaving the workflow ungated:
 
 ```bash
-gh pr edit <PR_NUMBER> --repo $GITHUB_REPO --add-label run-e2e
+gh api -X POST repos/$GITHUB_REPO/issues/$PR_NUMBER/labels -f 'labels[]=run-e2e'
 ```
+
+Verify the label is actually present before moving on:
+
+```bash
+gh pr view $PR_NUMBER --repo $GITHUB_REPO --json labels --jq '[.labels[].name] | index("run-e2e")'
+```
+
+Empty / `null` output means the apply silently failed — retry once, then stop and surface to the user.
 
 `auto-merge-eligible` is deferred to Phase 11 (right before merge). Applying both labels in one burst racing against GitHub Actions' `pull_request.labeled` concurrency policy cancels the in-flight quality-pipeline run — moving the second label out of the PR-open phase removes the timing dependency entirely.
 
@@ -219,18 +236,33 @@ Capture the PR number for the next phases.
 
 ## Phase 8 — Watch the workflow
 
-Use server-side streaming, not polling — cheaper and more reliable:
+`quality-pipeline.yml` has a `pull_request: paths:` filter (covers `radbot/**`, `tests/**`, `scripts/**`, `Makefile`, `Dockerfile*`, `pyproject.toml`, `uv.lock`, the workflow itself, and the bootstrap composite action). PRs that change *only* docs / `.claude/skills/**` / unrelated paths will not trigger any run, and waiting for one would hang the skill forever.
+
+Probe before watching. Give the workflow a brief grace period to register; if no run shows up, treat the workflow as skipped by path-filter and short-circuit to Phase 11 with `WORKFLOW_SKIPPED=true`:
 
 ```bash
-gh run watch --repo $GITHUB_REPO --exit-status \
-  $(gh run list --repo $GITHUB_REPO --branch ship/$SLUG \
-                --workflow $QUALITY_PIPELINE_WORKFLOW \
-                --limit 1 --json databaseId --jq '.[0].databaseId')
+RUN_ID=""
+for attempt in 1 2 3 4 5 6; do   # ~60s grace (6 × 10s)
+  RUN_ID=$(gh run list --repo $GITHUB_REPO --branch ship/$SLUG \
+                       --workflow $QUALITY_PIPELINE_WORKFLOW \
+                       --limit 1 --json databaseId --jq '.[0].databaseId // ""')
+  [ -n "$RUN_ID" ] && break
+  sleep 10
+done
+
+if [ -z "$RUN_ID" ]; then
+  WORKFLOW_SKIPPED=true
+  echo "Quality pipeline did not trigger — path-filter excluded this PR's changes. Skipping watch + score gates."
+else
+  gh run watch --repo $GITHUB_REPO --exit-status "$RUN_ID"
+fi
 ```
 
 If `gh run watch` exits non-zero or times out at $WATCH_TIMEOUT_MIN min, proceed to Phase 9 anyway — the score will still tell us what happened.
 
 ## Phase 9 — Read the score
+
+Skip this phase entirely if `WORKFLOW_SKIPPED=true` from Phase 8 — there is no score to read because the workflow never ran. Jump straight to Phase 11.
 
 The aggregate job posts a sticky comment AND sets a commit status. Trust the commit status (forgeable comments are a known footgun — see `docs/implementation/ci-security.md`):
 
@@ -250,6 +282,8 @@ gh api repos/$GITHUB_REPO/issues/$PR_NUMBER/comments \
 
 ## Phase 10 — CI fix loop (max $MAX_FIX_ATTEMPTS)
 
+Skip this phase entirely if `WORKFLOW_SKIPPED=true` from Phase 8 — there is nothing to fix when the pipeline never ran. Jump to Phase 11.
+
 If `score < $AUTO_MERGE_THRESHOLD`:
 
 1. Identify failing gates from the sticky comment.
@@ -262,13 +296,24 @@ Cap at $MAX_FIX_ATTEMPTS. Past that, hand control to the user with a summary.
 
 ## Phase 11 — Merge (user-authenticated, so deploys trigger)
 
-If `score ≥ $AUTO_MERGE_THRESHOLD`:
+**Branch on `WORKFLOW_SKIPPED` first.** When the path-filter excluded the PR (Phase 8 set `WORKFLOW_SKIPPED=true`), there is no score and no `aggregate` status check to wait on. The auto-merge gates are wired to the workflow run, so applying `auto-merge-eligible` would just sit there forever. **Stop here and hand off to the user** — do not apply `auto-merge-eligible`, do not invoke `gh pr merge`. Tell them:
+
+> Quality pipeline did not run for this PR (path-filter excluded the diff). No automated quality signal available — branch protection may still require human review. Confirm the diff is genuinely outside the gated paths, then merge by hand:
+> ```bash
+> gh pr merge $PR_NUMBER --repo $GITHUB_REPO --squash --delete-branch
+> ```
+
+Then skip directly to Phase 12 — do not run any of the steps below in this case. The user-driven merge from a normal shell still triggers the docker-build workflow (same reasoning as the auto-merge step), so deploys still fire if the PR happens to touch a docker-build path.
+
+Otherwise, if `score ≥ $AUTO_MERGE_THRESHOLD`:
 
 1. Confirm once with the user: `Score is NN/100 — merge now?` Skip if `--auto-yes` was passed.
-2. Apply `auto-merge-eligible` now (deferred from Phase 7 to avoid the `pull_request.labeled` concurrency race against the in-flight quality-pipeline run). Skip on `--manual-merge`:
+2. Apply `auto-merge-eligible` now (deferred from Phase 7 to avoid the `pull_request.labeled` concurrency race against the in-flight quality-pipeline run). Use the REST API for the same reason as Phase 7 — `gh pr edit --add-label` (GraphQL) can exit 0 without applying. Skip on `--manual-merge`:
 
 ```bash
-[ "$MANUAL_MERGE" != "true" ] && gh pr edit $PR_NUMBER --repo $GITHUB_REPO --add-label auto-merge-eligible
+if [ "$MANUAL_MERGE" != "true" ]; then
+  gh api -X POST repos/$GITHUB_REPO/issues/$PR_NUMBER/labels -f 'labels[]=auto-merge-eligible'
+fi
 ```
 
 3. Verify the pipeline actually cleared the gates the skill cannot see:

--- a/docs/implementation/ship_skill.md
+++ b/docs/implementation/ship_skill.md
@@ -31,15 +31,15 @@ Optional arguments:
 1. **Pre-flight** — confirm clean working tree, derive slug.
 2. **Worktree** — `git worktree add /tmp/radbot-ship-<slug> -b ship/<slug> origin/main`.
 3. **Sync dev deps in worktree** — `uv sync --all-extras --dev`. The fresh worktree has no `.venv`, so this primes flake8 / mypy / pytest / etc. before the gates.
-4. **Local gates (cheap subset, hard gate)** — `make lint` (flake8 + mypy), `make test-unit`. When frontend changed: `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e`. Every gate must be green before push — skipping a local gate to "let CI catch it" wastes ~4 min of pipeline time. Skips visual regression and chat-quality (CI handles them).
+4. **Local gates (cheap subset, hard gate)** — `make lint` (flake8 + mypy + black --check + isort --check), `make test-unit`. When frontend changed: `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e`. Every gate must be green before push — skipping a local gate to "let CI catch it" wastes ~4 min of pipeline time. Skips visual regression and chat-quality (CI handles them). If `make lint` is unavailable, run all four steps explicitly — flake8 + mypy alone lets formatting drift through and trips CI's lint gate.
 5. **Spec sync check** — for every changed source file, verify the corresponding `specs/*.md` is in the diff (per `CLAUDE.md` Spec ↔ code map).
 6. **Secret scan** — regex on staged + unstaged files (`AKIA…`, `ghp_…`, `sk-ant-…`, etc.). Hard stop on match.
 7. **Commit + push** — conventional-commit message, push to `ship/<slug>`.
-8. **Open PR** — `gh pr create` with the `run-e2e` label only. `auto-merge-eligible` is deferred to phase 12 to avoid a `pull_request.labeled` concurrency race that cancels the in-flight quality-pipeline run.
-9. **Watch workflow** — `gh run watch` (server-side stream, not polling).
+8. **Open PR** — `gh pr create` with the `run-e2e` label only, applied via the REST API (`gh api -X POST repos/.../issues/N/labels -f 'labels[]=run-e2e'`) — `gh pr edit --add-label` goes through GraphQL and has been observed to silently exit 0 without applying. `auto-merge-eligible` is deferred to phase 12 (also via REST) to avoid a `pull_request.labeled` concurrency race that cancels the in-flight quality-pipeline run.
+9. **Watch workflow** — `gh run watch` (server-side stream, not polling). First probes for ~60 s to confirm a run was actually triggered; if `quality-pipeline.yml`'s `paths:` filter excluded the diff (docs-only / skill-only PRs), the skill sets `WORKFLOW_SKIPPED=true` and short-circuits the score + auto-merge gates so it doesn't hang waiting for a run that will never exist.
 10. **Read score** — from commit status `quality-pipeline/score` (NOT the sticky comment, which is forgeable — see `docs/implementation/ci-security.md`).
 11. **CI fix loop** — up to 3 attempts to address pipeline feedback.
-12. **Merge (user-authenticated)** — confirms once with you (unless `--auto-yes`), applies `auto-merge-eligible` now, verifies the label + `aggregate` SUCCESS + score ≥ 90, then runs `gh pr merge --squash --delete-branch` from your shell. Not performed inside CI — a merge authored by `GITHUB_TOKEN` does not trigger the `Build and Push Docker Image` workflow (GitHub's recursion guard), so running the merge locally is what makes deploys fire.
+12. **Merge (user-authenticated)** — confirms once with you (unless `--auto-yes`), applies `auto-merge-eligible` now (REST API, same reason as `run-e2e` in phase 8), verifies the label + `aggregate` SUCCESS + score ≥ 90, then runs `gh pr merge --squash --delete-branch` from your shell. Not performed inside CI — a merge authored by `GITHUB_TOKEN` does not trigger the `Build and Push Docker Image` workflow (GitHub's recursion guard), so running the merge locally is what makes deploys fire. When `WORKFLOW_SKIPPED=true` from phase 9, this phase stops and hands off — no auto-merge label is applied, no merge is attempted; you merge by hand once you confirm the diff is genuinely outside the gated paths.
 13. **Cleanup** — reminds you the worktree exists; offers to remove on confirmation.
 
 ## Recovery from common failures
@@ -63,7 +63,10 @@ The skill stops after 3 failed CI attempts and hands control back to you. Inspec
 `gh auth login` first.
 
 ### "Workflow didn't trigger"
-Check that the `run-e2e` label was applied (`gh pr view <num> --json labels`). Re-add it if missing — the `pull_request.labeled` event will fire and the workflow will start.
+Check that the `run-e2e` label was applied (`gh pr view <num> --json labels`). Re-add it via the REST API if missing — `gh api -X POST repos/perrymanuk/radbot/issues/<num>/labels -f 'labels[]=run-e2e'`. The `pull_request.labeled` event will fire and the workflow will start. Note that `gh pr edit --add-label` (GraphQL) has been observed to exit 0 without applying the label, which is why the skill uses the REST API directly.
+
+### "Skill hand-off: quality pipeline didn't run (path-filter)"
+The skill stopped at phase 12 with a "merge by hand" message. This is correct behavior for PRs whose diffs only touch paths outside `quality-pipeline.yml`'s `paths:` filter (e.g. docs-only, `.claude/skills/**`-only). There is no automated quality signal because none of the gated code changed. Verify the diff is genuinely outside the gated paths, then `gh pr merge <num> --squash --delete-branch` from your shell.
 
 ### "I want to abort mid-ship"
 Kill the Claude Code session. The worktree at `/tmp/radbot-ship-<slug>` is yours to clean up:


### PR DESCRIPTION
## Summary

PT114 friction polish on the `/ship` skill:
- `make lint` description now reflects all four checks (flake8 + mypy + black --check + isort --check), with a 4-step fallback documented.
- Label application switched from `gh pr edit --add-label` (GraphQL — silently exits 0 without applying) to `gh api -X POST .../labels` (REST), with a verify-after-apply step for `run-e2e`.
- Phase 8 probes for a workflow run with ~60s grace; if `pull_request: paths:` filter excluded the diff, sets `WORKFLOW_SKIPPED=true`. Phases 9/10/11 short-circuit so the skill hands off cleanly instead of hanging waiting for a workflow that will never run.

This PR is itself a docs-only change (no `radbot/`, `tests/`, `Makefile`, or workflow files touched) — the new path-filter logic should detect that, set `WORKFLOW_SKIPPED=true`, and hand off for manual merge. That's the test of the new behavior.

## Specs updated

None needed — `/ship` is a Claude Code skill, not part of the runtime architecture covered by `specs/*.md`. The corresponding implementation doc (`docs/implementation/ship_skill.md`) is updated in this PR.

## Quality pipeline

Score: _pending_ — but expected to be skipped by `paths:` filter (docs-only change).

## Verification

- [x] Diff is docs-only (`.claude/skills/ship/SKILL.md`, `docs/implementation/ship_skill.md`)
- [x] Local lint/test gates skipped intentionally — they would re-validate unchanged `radbot/` + `tests/` already green on `origin/main`
- [ ] Quality pipeline (CI) — expected SKIPPED via `paths:` filter
- [ ] Merge by hand once path-filter skip is confirmed

Closes PT114.