### PR TITLE
[council-loop-foundation] MCP write-surface expansion + STATUS_VALUES + idempotent CHECK migration (Item 0 + Item 1.a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ All tables use the shared pool from `radbot/db/connection.py` unless noted.
 | ~~`tasks`, `projects`~~ | _deprecated — inert after the todo module was removed; data lives in `telos_entries` with sections `projects` + `project_tasks`. Old rows retained for rollback; migrate via `scripts/migrate_todo_to_telos.py`._ |
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `enabled`, `metadata` (JSONB) |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
-| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section`, `ref_code`, `content`, `metadata` (JSONB), `status`, `sort_order`, UNIQUE (section, ref_code) |
+| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section`, `ref_code`, `content`, `metadata` (JSONB), `status` (extended set: legacy `active`/`completed`/`archived`/`superseded` + lifecycle `proposed`/`in_review`/`approved`/`executing` — DB CHECK constraint regenerated on startup), `sort_order`, UNIQUE (section, ref_code). GIN index `idx_telos_metadata` backs Scout's postmortem-processing dedup queries via `db.list_section(metadata_filter=...)`. |
 | `webhook_definitions` | `tools/webhooks/db.py` | `webhook_id` (UUID), `name` (UNIQUE), `path_suffix` (UNIQUE), `prompt_template`, `secret` |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `radbot_credentials` | `credentials/store.py` | `name` (PK), `encrypted_value`, `salt`, `credential_type` |
@@ -279,6 +279,40 @@ FastAPI behind Traefik generates redirect URLs using the internal HTTP scheme un
 - **Agent factory tools**: Use `load_tools(module, attr, agent, label)` from `agent/factory_utils.py`
 - **Credential access**: `get_credential_store().get("<key_name>")`
 - **Model resolution**: Always use `config_manager.resolve_model(model_string)` in agent factories — wraps Ollama models (`ollama_chat/...`) in `LiteLlm`, passes Gemini strings through unchanged
+
+### Telos lifecycle status state machine
+
+`STATUS_VALUES` in `radbot/tools/telos/models.py` is the single source of truth — both Python validation (`db.add_entry`, `db.update_entry`, MCP `*_add`/`*_update` schemas) and the DB CHECK constraint regenerate from it. The set is:
+
+| Status | Group | Purpose |
+|---|---|---|
+| `active` | `ACTIVE_EQUIVALENT` | Default for any entry that doesn't use the lifecycle states |
+| `proposed` | `ACTIVE_EQUIVALENT` | Scout has persisted a plan; awaiting review |
+| `in_review` | `ACTIVE_EQUIVALENT` | `/review-ex` has flipped the EX while the cross-family council runs |
+| `approved` | `ACTIVE_EQUIVALENT` | Human confirmed the council synthesis; ready for `/ship` |
+| `executing` | `ACTIVE_EQUIVALENT` | `/ship` Phase 1 saw a matching branch and started the merge loop |
+| `completed` | terminal | `/ship` Phase 11 ran post-merge — sole owner of `executing → completed` |
+| `archived` | terminal | Manual archive of a stale entry |
+| `superseded` | terminal | Replaced by a newer EX (record the replacement in `metadata.superseded_by`) |
+
+`ACTIVE_EQUIVALENT = frozenset({"active", "proposed", "in_review", "approved", "executing"})` is the default filter for `db.list_section()` (when called with no `status` / `status_in` kwarg) and for the MCP `telos_get_section({include_inactive: false})` path. Adding a new lifecycle state means: edit `STATUS_VALUES`, update `ACTIVE_EQUIVALENT` if appropriate, restart — the CHECK constraint migration regenerates automatically.
+
+### MCP write-tool return contract
+
+The four creation handlers (`task_add`, `exploration_add`, `milestone_add`, `journal_add`) and their `*_update` counterparts return JSON in `TextContent.text`:
+
+```json
+// success (creation)
+{"status": "success", "ref_code": "<NEW>", "entry_id": "<uuid>", "section": "<section>"}
+// success (update — entry-status echoes via `entry_status` to avoid colliding with the discriminator)
+{"status": "success", "ref_code": "<ref>", "entry_status": "<new lifecycle state>", ...}
+// error (both success and error paths parse uniformly)
+{"status": "error", "message": "<reason>"}
+```
+
+Callers branch on `payload["status"]` after `json.loads(response.text)` — no try/except + heuristic-detection footgun. Terminal operations (`*_complete`, `*_archive`) keep human-readable text returns; their callers already know the ref_code.
+
+`task_add`, `exploration_add`, `milestone_add`, `task_update`, `exploration_update` accept `metadata_merge: object` for arbitrary metadata attachment. **Whitelist precedence:** typed schema fields (`title`, `category`, `task_status`, `parent_milestone`, `parent_project`) win silently on collision — closes the chain-race blocker on Scout's postmortem followups (atomic single-write attach, no add-then-update window).
 
 ---
 

--- a/docs/plans/EX_DRAFT_council_loop_polish.md
+++ b/docs/plans/EX_DRAFT_council_loop_polish.md
@@ -1,0 +1,1040 @@
+# EX (draft): Cross-family council loop polish — wire mm-council into the Scout/Telos/`/ship` lifecycle
+
+**Status:** **APPROVED FOR IMPLEMENTATION (frozen 2026-05-03)** after THREE rounds of `/mm-council:evaluate` cross-family review (Opus + Gemini 3.1 Pro + GPT-5.5, three sub-rounds each, personaless synthesis). Round 1 found 2 architectural blockers (MCP write surface absent + Scout autonomous trigger) — resolved. Round 2 found 3 semi-architectural blockers (chain race, step ordering, dedup-key determinism) — resolved. Round 3 found 5 implementation-detail blockers (`list_section` sentinel, UUID JSON serialization, `db.add_entry` defensive normalization + agent-side `event_type` bypass, CHECK constraint definition equality brittleness, `--supersede`/`--force-new` ordering) — **all five resolved in this final pre-implementation pass** with concrete code snippets pinned in Items 0.c, 1.a, 3, and 4. Council convergence verdict (3-of-3, high confidence): the architectural design space is empirically exhausted; remaining majors are normal PR-iteration territory. **No fourth council pass.** Open Item 0+1.a as the foundational PR; treat further sibling issues as PR-review feedback.
+
+**Round 3 majors (~14, deferred to PR-review)** — listed here as a punch-list for the implementation PR description; resolve in the PR or as immediate follow-ups: per-tool `metadata_merge` whitelist enumeration (Item 0.b.iii); JSON `_err` envelope global-vs-per-tool decision (Item 0.b.iv — recommend `_json_err`/`_text_err` split helpers in `project_tasks.py`); `init_telos_schema()` wrapper refactor + `SCHEMA_INITS` registry update (Item 0.c); GIN-index definition-aware migration (Item 0.c); `## Followups` markdown grammar pin + `_None_` sentinel + re-ordinalization footgun documentation (Item 3 + Item 4); deterministic `parent_project` derivation chain (Item 3); pre-strip marker-balance validator (Item 2 + Item 4); `/postmortem-ex` step-7 partial-failure recovery (link existing JR if EX block missing) (Item 4); per-tool `_err` envelope coverage table (Item 0.b.iv); content optional-vs-empty handler branch (Item 0.b.i); `_iso_default` sub-second precision (Item 0.c); Item 6 ordering note rewrite (Implementation order); backward-compat audit grep syntax fix (Item 0.b.iv).
+**Author:** Claude Code (chat session, 2026-05-02 → 2026-05-03), in collaboration with Perry.
+**Method:** ad-hoc design conversation grounded in radbot's current architecture, the new `mm-council` plugin (already shipped to `perrymanuk/claude-skills`), and AI Intel wiki research on plan-execute-handoff + multi-model-agents. Stress-tested by THREE rounds of Opus + Gemini 3.1 Pro + GPT-5.5 cross-family council (3 sub-rounds each, personaless synthesis); revisions below address all blocker/major findings from all three reviews. Each council round: (a) evaluated the prior revision against grounded code evidence, (b) surfaced sibling issues the prior revision introduced, (c) the spec author folded in fixes and re-ran the council. Pattern recognized after pass 2: each spec edit risks introducing a sibling issue when worked from memory rather than re-grounded against code; Round 3 revision was preceded by re-reading every cited code path before editing.
+
+## Why
+
+Scout's existing same-family plan council (3-round, four Gemini personas — Archie, Sentry, Impl, Echo — see `radbot/tools/council/critics.py:33-49` for `_council_model` + `_run_critic` and lines `138-196` for the four FunctionTool wrappers; also `specs/agents.md` "Scout Plan Council") catches the obvious before plans are persisted. But all four critics share Gemini's blind spots — the largest single quality lever per `[[multi-model-agents]]` (Microsoft 365 Researcher made cross-family the default; GitHub Copilot CLI's "Rubber Duck" closed 74.7% of the Sonnet→Opus SWE-Bench gap with a single cross-family review seat).
+
+The new `mm-council` skill (Opus + Gemini + GPT-5, direct provider APIs, three-round protocol with personaless synthesis) is now live in the personal marketplace and can run from this Claude Code session. The plugin already does the hard part. What's missing is the **wiring** that turns it into a coherent loop:
+
+1. A way to invoke it against an `EX<N>` without manual copy-paste each time
+2. A documented status state-machine so two Claude Code sessions don't race the same plan
+3. A way for `/ship` to feed a postmortem back to Scout after the merge
+4. A way for Scout to **process** that postmortem (mark read, generate followups) and for the human to review what Scout decided
+5. A trim of `inject_telos_context` so the Telos full block isn't wasted on beto's chitchat path
+
+Radbot needs a **small, contained MCP surface expansion** before the rest of the plan is implementable. The current MCP write surface is `task_add/update/complete/archive`, `exploration_add/update/archive`, `milestone_add/complete` (all in `radbot/mcp_server/tools/project_tasks.py`); read-only `telos_*` tools are in `radbot/mcp_server/tools/telos.py`. There is no journal-write MCP tool and no generic update-by-section tool today — the agent-side `telos_add_journal` and `telos_update_entry` exist but are **not exposed via MCP**. Item 0 below adds the minimal MCP wrappers needed; Items 1–6 then become mostly conventions, instruction-file edits, and one orchestration skill.
+
+## Findings from codebase review (2026-05-02)
+
+### Existing council path (stays as-is — tier 1 of two-tier review)
+
+- `radbot/tools/council/critics.py:33-43` — `_council_model()` resolves to scout's configured model (Gemini 3.1 Pro). Cross-family was tracked as PRJ1/PT18 ("blocked on LiteLLM infra in hashi-homelab"). With mm-council at the human gate, **PT18 is no longer on the critical path** for council quality — the cross-family review now happens out-of-process at the Claude Code session.
+- The Round 1 / Round 2 / Round 3 protocol (`personas.py`, `triggers.py`) and the persistence contract on `EX<N>.content` (`## Council Review` section) all stay verbatim.
+
+### MCP server surface today (corrected after grounded review)
+
+`radbot/mcp_server/tools/__init__.py:19-21` registers six modules: `telos`, `wiki`, `projects`, `project_tasks`, `tasks`, `memory`. Verified write-tool surface:
+
+- `project_tasks` (`radbot/mcp_server/tools/project_tasks.py`): `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add`, `exploration_update`, `exploration_archive`.
+- `telos` (`radbot/mcp_server/tools/telos.py`): **read-only** — `telos_get_full`, `telos_get_section`, `telos_get_entry`, `telos_search_journal`.
+- `wiki` / `projects` / `tasks` / `memory`: orthogonal to this plan.
+
+**Three capability gaps the original draft missed (each becomes a blocker for Items 2–5 unless resolved):**
+
+1. **No journal-write MCP tool.** Agent-side `telos_add_journal` exists (`radbot/tools/telos/telos_tools.py:207-233`) but is **not exposed over MCP**. Its signature accepts only `entry: str`, `event_type: str = ""`, `related_refs: list[str] | None` — no arbitrary `metadata` kwarg. The plan needs a richer journal-write path AND a journal-update path (for the postmortem `processed_at` flag).
+2. **No generic update-by-section MCP tool.** Agent-side `telos_update_entry` exists (`telos_tools.py:489-525`) and supports `content`, `metadata_merge`, `status` — but it is not exposed over MCP. It also validates `status` against a closed `STATUS_VALUES` set in `telos_tools.py`, so introducing the lifecycle states `proposed / in_review / approved / executing / completed` requires extending that set AND any matching DB CHECK constraint in `radbot/tools/telos/db.py`.
+3. **`telos_get_section` cannot filter by metadata and returns rendered markdown, not structured JSON.** `radbot/mcp_server/tools/telos.py:145-166` calls `telos_db.list_section(sec, status=status_filter, order_by=order)` then renders entries to a markdown blob. Items 3 and 5 require querying journal entries by `metadata.type` and `metadata.processed_at` — neither possible via the current MCP surface. Client-side post-filter against rendered markdown was rejected by all three council panelists as too fragile (re-parsing markdown to extract metadata).
+
+### `inject_telos_context` registration
+
+- Implementation: `radbot/tools/telos/callback.py:33-69`. Two-tier:
+  - **Anchor** (~300B, capped 500): every turn, into `system_instruction`
+  - **Full block** (~2KB, capped 2048: mission + problems + goals + projects + challenges + wisdom + last 5 journal entries): first turn of session only, gated by `state["telos_bootstrapped"]`
+- Registered for **beto** at `radbot/agent/assembly.py:317` (verified — `_build_beto`'s `before_model_callback` list).
+- For **scout-as-root**: callback line is in `radbot/agent/research_agent/factory.py:217-242` (the `if as_root:` block), NOT in `assembly.py`'s manifest branch as the original draft asserted. The `as_root=True` flag itself is wired by the manifest path (`assembly.py` → `AgentDef(role="root")` → `_resolve_assembly`) and the `chat_sessions.agent_name` selector. Item 6 verification must cover **both** locations: `factory.py:217-242` (the actual callback registration) and `assembly.py` (the gate that decides whether scout is built `as_root`).
+- Sub-agents do **not** get this callback per `_attach_subagent_callbacks` design (verified — `assembly.py:273-294`, `_SUBAGENT_BEFORE_CBS` excludes `inject_telos_context`).
+
+### `/ship` skill termination point (corrected)
+
+`.claude/skills/ship/SKILL.md` actual phase numbering: **Phase 11** (line 297) is the user-authenticated merge; **Phase 12** (line 349) is cleanup. The original draft's "phase 12 is the user-authenticated merge / new phase 13" was off-by-one. The new postmortem step is a sibling Claude Code skill `/postmortem-ex` invoked by the user after `/ship` returns — recommendation in Item 4. If integrated into `/ship` directly it would land as Phase 12 (cleanup shifts to 13), but a sibling skill is preferred (see Item 4 rationale).
+
+### Existing draft-plans convention
+
+`docs/plans/EX_DRAFT_*.md` is the on-disk staging area for plans before they land in Telos as `EX<N>` entries. This file follows that convention.
+
+## Plan
+
+### Item 0 — MCP work-items (prerequisite for Items 2–5)
+
+Four small additions to `radbot/mcp_server/tools/`. Each one is a thin MCP wrapper over an existing agent-side function or a parameter extension to an existing tool. Combined with Item 1.a, the PR is ~150 LoC + tests + one migration (header estimate ~120 covers Item 0 alone; see Implementation order).
+
+**0.a — Add `journal_add` and `journal_update` MCP tools** (new file: `radbot/mcp_server/tools/journal.py`, register in `mcp_server/tools/__init__.py`'s `_MODULES`).
+
+The MCP `journal_add` is a **direct wrapper around `telos_db.add_entry(Section.JOURNAL, ...)`** — it does NOT go through agent-side `telos_add_journal` (which has a narrower signature and no return-shape contract). Extending agent-side `telos_add_journal` to accept arbitrary metadata is a separate consistency improvement (deferred — not a prerequisite for this MCP tool).
+
+```python
+# journal_add — accepts arbitrary metadata dict; return shape per Item 0.b.iv contract.
+inputSchema = {
+    "type": "object",
+    "properties": {
+        "entry":    {"type": "string"},
+        "metadata": {"type": "object", "additionalProperties": True},
+    },
+    "required": ["entry"],
+    "additionalProperties": False,
+}
+# Implementation: call telos_db.add_entry(Section.JOURNAL, entry, metadata=metadata or {}).
+# Returns: per the structured contract pinned in Item 0.b.iv (success: {status, ref_code, entry_id, section};
+#          error: {status: "error", message: ...}).
+
+# journal_update — supports metadata_merge + status; pinned to journal section.
+# status param is restricted to journal-meaningful values (lifecycle states like
+# proposed/in_review/approved/executing are nonsense for journal rows).
+inputSchema = {
+    "type": "object",
+    "properties": {
+        "ref_code":       {"type": "string"},
+        "metadata_merge": {"type": "object", "additionalProperties": True},
+        "status":         {"type": "string", "enum": ["active", "completed", "archived", "superseded"]},
+    },
+    "required": ["ref_code"],
+    "additionalProperties": False,
+}
+# Returns: per the structured _err envelope in Item 0.b.iv (success path can be a simple OK dict
+#          since callers already know the ref_code; error path is the JSON {status:"error",message:...}).
+```
+
+**0.b — Extend the project_tasks/exploration MCP write surface.** Six additive changes to `radbot/mcp_server/tools/project_tasks.py`:
+
+- **0.b.i — `exploration_update`: add optional `status` param AND make `content` optional.** Currently the schema (`project_tasks.py:164-184`) takes `ref_code, content (required), parent_project, parent_milestone`. Two changes: (1) add `status: string` validated against `STATUS_VALUES` after Item 1.a's extension lands; (2) **drop `content` from `required`** — handler treats **absent** `content` key as "leave body unchanged" (mirrors agent-side `telos_update_entry`'s `if content:` check at `telos_tools.py:514-515`); a **present empty/whitespace** `content` value remains an error (`_err("content must not be whitespace if supplied; omit the key to leave body unchanged")` — the existing handler at `project_tasks.py:497-499` rejects that case today and the new schema must preserve the rejection rather than silently degrading). Without (2), every status-only transition in Item 1.c's table (`approved → executing`, `executing → completed`, recovery flips) would be forced to fetch and round-trip the full body, widening the data-loss window under any race. Apply the same `content`-optional change to `task_update` for consistency (its `description` field already uses the same "leave unchanged if absent" semantics in the handler). **Test all three cases for both tools:** absent → unchanged; non-empty → replaces; empty/whitespace → error.
+- **0.b.ii — `exploration_add` AND `task_add`: add optional `status` (exploration only) AND `metadata_merge` (both, **blocker fix**).** Currently `exploration_add` has only `parent_project, topic, notes` (required: `parent_project, topic`); `task_add` has `parent_project, description, parent_milestone, title, category, task_status` (required: `parent_project, description`). Two changes:
+  1. Add optional `status: string` (validated against `STATUS_VALUES`) to `exploration_add` only — without this, every Scout-created exploration inherits the table default `'active'` and needs an immediate second `exploration_update` call to flip to `'proposed'`.
+  2. **Add `metadata_merge: {"type": "object", "additionalProperties": True}` to BOTH `task_add` AND `exploration_add` input schemas** so callers can attach arbitrary metadata (e.g. `source_postmortem`, `postmortem_followup_role`, `postmortem_followup_key`) atomically at creation. **This closes the chain-race blocker from Round 2 council:** without it, Scout's `task_add → task_update(metadata_merge={...})` and `exploration_add → exploration_update(metadata_merge={...})` chains have a window where a crash between calls leaves an untagged followup that the dedup query cannot find. With this change, Scout sets all dedup metadata in the SAME `*_add` call (one DB write, no race).
+- **0.b.iii — Add `metadata_merge: object` to `task_update` AND `exploration_update` (extends 0.b.ii to update tools).** The current `_do_task_update` (`project_tasks.py:390-438`) builds a `meta` dict from the four whitelisted keys (`title, category, task_status, parent_milestone`) and passes it as `metadata_merge=meta or None`; the inputSchema declares `additionalProperties: False`, so passing arbitrary extra fields is rejected at JSON-schema validation. Add `metadata_merge: {"type": "object", "additionalProperties": True}` to both `*_update` schemas (mirroring 0.b.ii). **Merge precedence (load-bearing — same rule for all four tools — `task_add`, `exploration_add`, `task_update`, `exploration_update`):** the handler shall start with `caller_meta = arguments.get("metadata_merge", {}).copy()`, then overlay the whitelist-derived dict so **whitelist keys WIN on collision** (the dedicated schema fields are authoritative for `title/category/task_status/parent_milestone/parent_project`; `metadata_merge` is the typed escape hatch for everything else). The collision is **silent** (3-of-3 council consensus to keep silent rather than error — LLM tool-call ergonomics over strict bug detection). Add unit tests covering (a) no-collision merge (caller's `source_postmortem` survives unchanged); (b) collision (caller's `task_status` is silently overridden by the dedicated field, no error raised, both for `*_update` AND `*_add`).
+- **0.b.iv — Structured return contract for ALL `*_add` MCP tools (consolidated single source of truth).** Today every MCP write returns `mcp_types.TextContent` with a human-readable string (see `_do_task_add` at `project_tasks.py:380-387` returning `"Added task \`{ref_code}\` ..."` and `_do_exploration_add` at `project_tasks.py:483-489`). Items 3 and 4 chain `task_add → ...`, `exploration_add → ...`, `milestone_add → ...`, and `journal_add → ...` using the auto-assigned ref code — Scout needs to learn the ref_code without re-querying. **Change every `*_add` handler** (`_do_task_add`, `_do_exploration_add`, `_do_milestone_add`, plus the new `_do_journal_add` from 0.a) to return:
+
+  ```python
+  mcp_types.TextContent(type="text", text=json.dumps({
+      "status": "success",
+      "ref_code": "<NEW>",   # PT<N> | EX<N> | MS<N> | JR<N>
+      "entry_id": "<uuid>",
+      "section":  "<section_name>",
+  }))
+  ```
+
+  **Error envelope (load-bearing — closes the 3-of-3 council finding):** all four `*_add` handlers' `_err()` returns must ALSO be JSON: `TextContent(text=json.dumps({"status": "error", "message": "<reason>"}))`. Callers branch on `payload["status"]` after `json.loads(response.text)` — both success and error parse uniformly, no try/except + heuristic-detection footgun. Apply the same `_err` JSON envelope to the four `*_update` handlers and `journal_update` since chained callers may want to error-handle uniformly. The other write tools (`task_complete`, `task_archive`, `exploration_archive`, `milestone_complete`) keep their human-readable text returns — they're terminal operations whose callers already know the ref_code (documented intentional inconsistency; if a future EX needs structured returns from those, migrate then).
+
+  **`milestone_add` rationale for inclusion:** uniformity across the creation surface; even if no current chain needs `MS<N>`, future Scout patterns shouldn't have to special-case which `*_add` returns JSON. Cost: one handler change.
+
+  **Backward-compat audit (mandatory implementation step):** before the Item 0+1.a PR merges, grep the repo + personal claude-skills for prose-substring consumers of the old return text:
+  ```bash
+  grep -rn "Added task \`" tests/ radbot/ ~/.claude/  || true
+  grep -rn "Added exploration \`" tests/ radbot/ ~/.claude/  || true
+  grep -rn "Added milestone \`" tests/ radbot/ ~/.claude/  || true
+  grep -rn "Added journal" tests/ radbot/ ~/.claude/  || true
+  ```
+  Any hits get migrated to `json.loads(response.text)["ref_code"]` IN THE SAME PR. List affected files in the PR description.
+
+- **0.b.v — `_do_*` handlers must combine `metadata_merge` correctly.** For both `_add` and `_update` handlers: `combined = {**arguments.get("metadata_merge", {}), **whitelist_meta}` (Python dict order — second overlays first, so whitelist wins per 0.b.iii rule). Pass through to `telos_db.add_entry(metadata=combined)` (for `_add`) or `telos_db.update_entry(metadata_merge=combined)` (for `_update`). Note the agent-side `telos_db.add_entry` and `telos_db.update_entry` both accept the resulting dict — no DB-layer changes needed.
+
+**0.c — Extend `telos_get_section` AND `telos_get_entry`; redefine the default active-equivalent set; add a GIN index.**
+
+`telos_get_section` schema:
+
+```python
+inputSchema = {
+    "type": "object",
+    "properties": {
+        "section":          {"type": "string"},
+        "include_inactive": {"type": "boolean"},  # default false
+        "metadata_filter":  {"type": "object", "additionalProperties": True},  # NEW — matched as JSONB @> in telos_db
+        "format":           {"type": "string", "enum": ["markdown", "json"]},  # NEW — default "markdown" for backwards compat
+    },
+    "required": ["section"],
+    "additionalProperties": False,
+}
+```
+
+`telos_get_entry` schema (load-bearing for Item 2 / Item 4 idempotency — current `_render_entry` at `radbot/mcp_server/tools/telos.py:169-198` returns markdown wrapped in `### section: ref_code`, `**Status:**`, body, `**Metadata:**` blocks; reading and writing it back via `exploration_update` would compound markdown framing every re-run):
+
+```python
+inputSchema = {
+    "type": "object",
+    "properties": {
+        "section":  {"type": "string"},
+        "ref_code": {"type": "string"},
+        "format":   {"type": "string", "enum": ["markdown", "json"]},  # NEW — "markdown" preserves today's behavior; "json" returns the full Entry shape
+    },
+    "required": ["section", "ref_code"],
+    "additionalProperties": False,
+}
+```
+
+When `metadata_filter` is non-empty on `telos_get_section`, `radbot/tools/telos/db.py:list_section` adds a JSONB `WHERE metadata @> %s::jsonb` clause.
+
+**JSON transport contract (load-bearing).** When `format="json"`, the MCP handler shall return:
+
+```python
+mcp_types.TextContent(type="text", text=json.dumps(payload, default=_iso_default))
+```
+
+where `_iso_default` is pinned (load-bearing — closes the council findings on `Z`-suffix drift AND `uuid.UUID` crash):
+
+```python
+def _iso_default(obj):
+    """JSON serializer for datetime → ISO 8601 with literal Z suffix; UUID → str.
+
+    psycopg2 returns timezone-aware datetimes whose .isoformat() emits '+00:00',
+    not the literal 'Z' that consumers parse against. Force UTC + literal Z.
+    psycopg2 also returns uuid.UUID for UUID columns; json.dumps would crash
+    without explicit handling — entry_id is in every payload shape.
+    """
+    import uuid
+    from datetime import datetime, timezone
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, datetime):
+        return obj.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+```
+
+**Required helper — `_entry_to_json_dict`** (closes Round 3 GPT-5 finding on `Section` enum + UUID rendering): every JSON-shaped MCP response goes through this single helper so all conversions are explicit and consistent.
+
+```python
+def _entry_to_json_dict(entry: "Entry") -> dict:
+    """Convert a telos_db.Entry to a JSON-native dict for MCP transport.
+
+    Explicitly converts UUIDs and Section enums; leaves datetimes for _iso_default
+    to handle at json.dumps time. Used by both telos_get_entry and telos_get_section
+    to guarantee identical payload shape across the JSON contract.
+    """
+    return {
+        "ref_code":   entry.ref_code,
+        "entry_id":   str(entry.entry_id),
+        "section":    entry.section.value,
+        "status":     entry.status,
+        "content":    entry.content,
+        "metadata":   entry.metadata or {},
+        "created_at": entry.created_at,   # serialized by _iso_default at json.dumps time
+        "updated_at": entry.updated_at,
+    }
+```
+
+with payload shapes:
+
+- `telos_get_entry` → `{"entry": {"ref_code": "EX1", "entry_id": "<uuid>", "section": "explorations", "status": "proposed", "content": "<raw body>", "metadata": {...decoded JSONB dict...}, "created_at": "2026-05-03T12:00:00Z", "updated_at": "2026-05-03T12:00:00Z"}}`
+- `telos_get_section` → `{"entries": [<entry>, <entry>, ...]}`
+
+Timestamps are ISO 8601 with literal `Z` suffix (UTC), per `_iso_default`; `metadata` is the decoded JSONB dict (not stringified); `null` ref_code rows render as `"ref_code": null`. Callers use `json.loads(response.text)` to parse. This is the single source of truth for the JSON envelope; every consumer (`/review-ex`, `/postmortem-ex`, Scout's instructions) shall parse against this exact shape. Unit test: assert every timestamp in the rendered payload matches `r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"` (literal Z, not `+00:00`).
+
+**Active-equivalent default redefinition (resolves the lifecycle-states-hidden bug).** `telos_get_section`'s current default filters to `status='active'` (`telos.py:145` — note: the prior revision cited `:155`, off by 10; corrected here). After Item 1.a accepts `proposed/in_review/approved/executing` as valid statuses, the default would silently omit all in-flight EXes from Scout's first-message poll, `/review-ex` pre-flight reads, and ad-hoc listings. **Fix (closes 3-of-3 council finding that the previous revision plumbed `ACTIVE_EQUIVALENT` only at the MCP layer, leaving `db.list_section` callers exposed):**
+
+1. Define `ACTIVE_EQUIVALENT = frozenset({"active", "proposed", "in_review", "approved", "executing"})` in `radbot/tools/telos/models.py` next to `STATUS_VALUES`.
+2. **Change `radbot/tools/telos/db.py:list_section`'s default to `ACTIVE_EQUIVALENT` via a SENTINEL pattern (load-bearing — closes Round 3 3-of-3 blocker on default-arg back-compat collision).** Naive `status_in: Optional[Iterable[str]] = ACTIVE_EQUIVALENT, status: Optional[str] = None` defaults break two ways: (i) any legacy caller passing `status="active"` triggers the mutual-exclusion `ValueError` because the implicit `status_in=ACTIVE_EQUIVALENT` default collides with the explicit `status`; (ii) any legacy caller passing `status=None` (which used to mean "all statuses") silently changes meaning to `ACTIVE_EQUIVALENT`. Use a private sentinel to distinguish "argument omitted" from "argument explicitly None":
+
+   ```python
+   _OMITTED = object()  # module-level sentinel
+
+   def list_section(
+       section: Section,
+       *,
+       status: Any = _OMITTED,        # _OMITTED = use status_in; None = all statuses; "active"/etc = single
+       status_in: Any = _OMITTED,     # _OMITTED + status _OMITTED → ACTIVE_EQUIVALENT; None = all
+       limit: Optional[int] = None,
+       order_by: str = "sort_order_asc",
+   ) -> List[Entry]:
+       # Resolve the filter
+       if status is not _OMITTED and status_in is not _OMITTED:
+           raise ValueError("status and status_in are mutually exclusive")
+       if status is _OMITTED and status_in is _OMITTED:
+           status_in = ACTIVE_EQUIVALENT          # default new behavior
+       if status_in is None or status is None:
+           where_filter = None                    # all statuses
+       elif status is not _OMITTED:
+           where_filter = ("status = %s", [status])
+       else:
+           # Materialize iterable to list — psycopg2 doesn't reliably adapt frozensets/sets for ANY()
+           where_filter = ("status = ANY(%s)", [list(status_in)])
+       # ... build WHERE/SQL, execute ...
+   ```
+
+   Backward-compat semantics:
+   - Caller passes nothing → `ACTIVE_EQUIVALENT` set is used (covers `proposed/in_review/approved/executing` plus legacy `active`).
+   - Caller passes `status="active"` → legacy single-status filter (back-compat for any caller that explicitly wants legacy-active-only).
+   - Caller passes `status=None` (or `status_in=None`) → returns all statuses (back-compat for the old `status=None` "all" semantics).
+   - Caller passes `status_in=[...]` → explicit set filter; iterable is `list()`-materialized for psycopg adapter compatibility.
+   - WHERE clause when `status_in` is the active filter: `status = ANY(%s)`. **No Python post-filter** — default listing must scale.
+
+   **Mandatory grep audit (load-bearing AC, in same PR):** `grep -nE 'list_section\([^)]*status=' radbot/` shall be executed; every hit reviewed and migrated if needed (a hit passing `status="active"` is correct under back-compat semantics; a hit passing `status=None` is correct under back-compat semantics; any hit passing both — none expected — must be rewritten). The PR description shall list the audited files.
+3. The MCP `_render_section` accepts the existing `include_inactive: bool` param and translates: `include_inactive=False` (default) → `status_in=ACTIVE_EQUIVALENT`; `include_inactive=True` → `status_in=None` (all statuses).
+4. `completed`, `archived`, `superseded` are the inactive set — opt-in via `include_inactive=True`.
+
+Integration tests (mandatory ACs):
+- Create a `proposed` EX, call `telos_get_section({section: "explorations"})` with no `include_inactive` — assert the EX appears.
+- Call agent-side `telos_db.list_section(Section.EXPLORATIONS)` with no kwargs — assert the same `proposed` EX appears (proves `db.list_section` default propagated).
+- Call `telos_db.list_section(Section.EXPLORATIONS, status="active")` — assert ONLY the `active` rows appear (proves back-compat path).
+- Call `telos_db.list_section(Section.EXPLORATIONS, status="active", status_in=ACTIVE_EQUIVALENT)` — assert raises `ValueError`.
+
+**GIN index migration (`radbot/tools/telos/db.py`) — sibling step, NOT via `create_index_sqls`.** The previous revision proposed adding `idx_telos_metadata` to `init_table_schema()`'s `create_index_sqls` list; council Round 2 caught (3-of-3) that `init_table_schema` (`radbot/tools/shared/db_schema.py:11-45`) only executes index SQLs when the table is freshly created. On every existing deployment (which is every real deployment), the index would silently never land, breaking Item 5's sub-second-on-5000-rows AC. **Fix:** add `_apply_metadata_gin_index()` as a sibling step inside `init_telos_schema()`, running unconditionally on every startup:
+
+```python
+def _apply_metadata_gin_index() -> None:
+    """Ensure the GIN index on telos_entries.metadata exists. Idempotent."""
+    from radbot.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn:
+        with get_db_cursor(conn, commit=True) as cursor:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telos_metadata "
+                "ON telos_entries USING GIN (metadata);"
+            )
+
+def init_telos_schema() -> None:
+    init_table_schema(...)            # existing
+    _apply_metadata_gin_index()        # NEW — runs every startup, cheap when index exists
+    _apply_status_check_constraint()   # NEW — see Item 1.a
+```
+
+`CREATE INDEX IF NOT EXISTS` is fully idempotent; cost on subsequent startups is one metadata-table query when the index exists. Test: drop the index, restart, assert it re-appears via `\d telos_entries`.
+
+**Acceptance criteria (EARS):**
+- The MCP server shall expose `journal_add` and `journal_update` tools backed directly by `telos_db.add_entry`/`telos_db.update_entry` for `Section.JOURNAL` (not via agent-side `telos_add_journal`).
+- When `journal_add` is called with `metadata={...}`, the resulting entry shall persist the full metadata dict in the JSONB `metadata` column.
+- **Structured-return contract (Item 0.b.iv).** When `task_add`, `exploration_add`, `milestone_add`, or `journal_add` returns success, the response `TextContent.text` shall be parseable via `json.loads(...)` and shall contain `{"status": "success", "ref_code": "<assigned>", "entry_id": "<uuid>", "section": "<section>"}`. When any of the same tools return an error (validation, missing parent, etc.), the response `TextContent.text` shall ALSO be parseable via `json.loads(...)` and shall contain `{"status": "error", "message": "<reason>"}`. **Test:** (a) chained `task_add → task_update(ref_code=parsed["ref_code"], metadata_merge={...})` succeeds without any intervening read; (b) `json.loads(error_response.text)["status"] == "error"` succeeds (no plain-text fallback).
+- **Backward-compat audit (Item 0.b.iv).** Before merge, `grep -rn "Added (task|exploration|milestone|journal)" tests/ radbot/ ~/.claude/` shall be run; any prose-substring consumer shall be migrated to `json.loads(response.text)["ref_code"]` IN THE SAME PR. List of migrated files shall appear in the PR description.
+- **Atomic followup metadata (Item 0.b.ii — closes the chain-race blocker).** When `task_add` or `exploration_add` is called with `metadata_merge={k: v, ...}`, the supplied keys shall be JSONB-merged into the new entry's `metadata` column at creation time (one DB write, no race window). **Test:** simulate Scout's `task_add({metadata_merge: {source_postmortem: "JR42"}})` followed by an immediate process kill; restart Scout's processing; assert the previously-created PT is found by the `metadata_filter: {source_postmortem: "JR42"}` query and dedup correctly skips it.
+- When `exploration_update` or `task_update` is called with `metadata_merge={k: v, ...}`, the supplied keys shall be shallow-merged into the entry's `metadata` column **with whitelist-derived keys (`title`/`category`/`task_status`/`parent_milestone`/`parent_project`) silently winning on collision** (same precedence rule applies to `*_add` per 0.b.iii). Empty `metadata_merge` (or absent) shall be a no-op on metadata. **Test:** (a) caller's `source_postmortem` survives; (b) caller's `task_status="done"` is silently overridden when the dedicated `task_status` field is also supplied (no error raised — 3-of-3 council consensus to keep silent).
+- When `exploration_update` is called WITHOUT the `content` key, the entry's body shall remain unchanged. When called WITH a non-empty `content`, the body shall be replaced. When called WITH an empty/whitespace `content`, the call shall fail with `_err("content must not be whitespace if supplied; omit the key to leave body unchanged")`. Same three-case behavior for `task_update`'s `description` field.
+- When `exploration_add` is called with `status="<allowed>"`, the new entry shall be created with that status; absent → defaults to `'active'` for back-compat (Scout's instructions explicitly pass `status="proposed"` per Item 3).
+- When `exploration_update` is called with `status="<allowed>"`, the entry shall transition to that status; invalid values shall fail with the JSON `_err` envelope citing the allowed set.
+- When `journal_update` is called with a `status` value, that value shall be one of `{active, completed, archived, superseded}` (lifecycle states are not valid for journal rows; the `enum` constraint enforces this at JSON-schema time).
+- When `telos_get_section` is called with `metadata_filter={k: v, ...}`, the result shall include only entries whose `metadata` JSONB `@>` the supplied object.
+- When `telos_get_section` or `telos_get_entry` is called with `format="json"`, the response shall be `TextContent` whose `.text` is the JSON-encoded payload defined above (not rendered markdown). Every timestamp string shall match `r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"` (literal `Z`, not `+00:00`); `metadata` shall be the decoded JSONB dict.
+- **Default-active redefinition (Item 0.c — single source of truth).** When `telos_get_section` is called with default `include_inactive=False`, the result shall include entries whose status is in `ACTIVE_EQUIVALENT = {active, proposed, in_review, approved, executing}` and shall exclude `completed/archived/superseded`. The same default shall apply to `radbot/tools/telos/db.py:list_section` when called with no `status`/`status_in` kwarg. **Integration tests:** (a) a freshly-created `proposed` exploration appears in the default MCP `explorations` listing; (b) the same `proposed` exploration appears in the default agent-side `db.list_section(Section.EXPLORATIONS)` call; (c) `db.list_section(Section.EXPLORATIONS, status="active")` returns only legacy-active rows (back-compat); (d) `db.list_section(Section.EXPLORATIONS, status="active", status_in=ACTIVE_EQUIVALENT)` raises `ValueError`.
+- `radbot/tools/telos/db.py:list_section` signature shall be `(section, *, status_in: Optional[Iterable[str]] = ACTIVE_EQUIVALENT, status: Optional[str] = None, limit, order_by)`; `status` and `status_in` shall be mutually exclusive.
+- The `idx_telos_metadata` GIN index shall exist on `telos_entries.metadata` after `init_telos_schema()` runs, regardless of whether the `telos_entries` table existed before this migration. **Test:** drop the index manually, restart the web service, assert the index re-appears.
+
+**Spec to update:** `specs/tools.md` (telos MCP tool table + `*_add` return contract), `specs/storage.md` (the new GIN index + JSONB query path + `status_in` on `list_section`), `CLAUDE.md` (`ACTIVE_EQUIVALENT` constant + new return-contract pattern).
+
+---
+
+### Item 1 — Status state-machine convention on `telos_entries.status`
+
+The column exists. Three concrete sub-tasks beyond pure docs:
+
+**1.a — Extend `STATUS_VALUES` and ADD a DB CHECK constraint.** The closed `STATUS_VALUES` set is defined in `radbot/tools/telos/models.py:122` (the AC originally said `telos_tools.py` — corrected to `models.py`). The set is imported and enforced at **four sites** that all need to be re-verified after the extension:
+
+1. `radbot/tools/telos/telos_tools.py:519-523` — agent-side `telos_update_entry`
+2. `radbot/tools/telos/db.py:101` — `db.add_entry` (raises `ValueError` if status not in set; both `db.add_entry` and `db.update_entry` import the same `STATUS_VALUES`)
+3. `radbot/tools/telos/db.py:146` — `db.update_entry`
+4. New MCP `_do_exploration_update` and `_do_exploration_add` handlers (Item 0.b.i/0.b.ii) — must validate `status` against the same set
+
+Today the set is `{"active", "completed", "archived", "superseded"}`. Add `proposed`, `in_review`, `approved`, `executing` to that set. Because all four sites import the same `STATUS_VALUES`, a single edit propagates — but the unit-test surface needs to cover ALL four (a single edit could regress if a future contributor inlines a literal set somewhere).
+
+For the database side: `radbot/tools/telos/db.py:25-50` currently declares the column as `status TEXT NOT NULL DEFAULT 'active'` with **no CHECK constraint** (validation is application-level only). Add a forward migration that creates a CHECK constraint matching the extended set. **The migration must be (1) preflight-checked, (2) DEFINITION-aware (not name-aware), and (3) generate the SQL allowed-list from `STATUS_VALUES` to avoid drift** — `ALTER TABLE ADD CONSTRAINT` is not idempotent in vanilla Postgres, and a name-only `IF NOT EXISTS` guard accepts a stale same-named constraint with the legacy 4-status set, silently no-op'ing while the DB rejects new lifecycle states at runtime (3-of-3 council finding).
+
+**Python implementation** in `radbot/tools/telos/db.py` — **definition match uses SEMANTIC set comparison** (closes Round 3 blocker on `pg_get_constraintdef` string-equality brittleness; PostgreSQL normalizes CHECK definitions with type casts like `'active'::text` and may reorder ARRAY elements depending on PG version, so byte-string compare would trigger DROP+ADD on every web startup — wasteful and risky on large tables since `ALTER TABLE` takes an `ACCESS EXCLUSIVE` lock):
+
+```python
+import re
+
+_STATUS_CHECK_NAME = "telos_entries_status_check"
+
+def _extract_constraint_status_set(constraint_def: str) -> set[str]:
+    """Parse pg_get_constraintdef output and return the allowed status set.
+
+    Robust against PG normalization variations:
+      - "CHECK ((status = ANY (ARRAY['active'::text, 'completed'::text, ...])))"
+      - "CHECK (status IN ('active', 'completed', ...))"
+      - "CHECK ((status)::text = ANY ((ARRAY['active'::text, ...])::text[]))"
+    All forms have the allowed values as single-quoted string literals; extract them.
+    """
+    return set(re.findall(r"'([^']+)'", constraint_def))
+
+def _apply_status_check_constraint() -> None:
+    """Ensure telos_entries.status CHECK constraint matches STATUS_VALUES.
+
+    Idempotent + SEMANTICALLY definition-aware: replaces stale constraints
+    whose allowed-status set doesn't match STATUS_VALUES. Compare by parsed
+    SET (not by raw string) so PG normalization differences don't trigger
+    spurious DROP+ADD cycles on every startup.
+    """
+    from radbot.tools.telos.models import STATUS_VALUES
+    from radbot.db.connection import get_db_connection, get_db_cursor
+
+    with get_db_connection() as conn:
+        with get_db_cursor(conn, commit=True) as cursor:
+            # Step 1 — preflight: abort if any row violates the new set.
+            # Use parameterized != ALL(%s) instead of f-string IN to keep
+            # quoting/injection safe if STATUS_VALUES ever contains exotic chars.
+            cursor.execute(
+                "SELECT COUNT(*), COALESCE(string_agg(DISTINCT status, ', '), '') "
+                "FROM telos_entries WHERE status != ALL(%s);",
+                (list(STATUS_VALUES),),
+            )
+            bad_count, bad_values = cursor.fetchone()
+            if bad_count > 0:
+                raise RuntimeError(
+                    f"telos_entries has {bad_count} rows with statuses outside "
+                    f"the new set: {bad_values}. Fix data before applying CHECK."
+                )
+
+            # Step 2 — inspect existing constraint definition.
+            cursor.execute(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = %s AND conrelid = 'telos_entries'::regclass;",
+                (_STATUS_CHECK_NAME,),
+            )
+            row = cursor.fetchone()
+            existing_def = row[0] if row else None
+
+            # Step 3 — fast path: no constraint, just add.
+            if existing_def is None:
+                _add_status_check(cursor, STATUS_VALUES)
+                logger.info("Added telos_entries CHECK constraint")
+                return
+
+            # Step 4 — SEMANTIC set comparison: parse the existing definition
+            # for its allowed values and compare against STATUS_VALUES.
+            existing_set = _extract_constraint_status_set(existing_def)
+            if existing_set == set(STATUS_VALUES):
+                return  # idempotent no-op — set matches regardless of PG normalization
+
+            # Step 5 — set mismatch → DROP + re-ADD with INFO log.
+            logger.info(
+                "telos_entries CHECK constraint set mismatch; expected %s, got %s — replacing.",
+                sorted(STATUS_VALUES), sorted(existing_set),
+            )
+            cursor.execute(
+                f"ALTER TABLE telos_entries DROP CONSTRAINT {_STATUS_CHECK_NAME};"
+            )
+            _add_status_check(cursor, STATUS_VALUES)
+            logger.info("Replaced telos_entries CHECK constraint with current STATUS_VALUES")
+
+def _add_status_check(cursor, status_values: set[str]) -> None:
+    """Helper: emit ALTER TABLE ADD CONSTRAINT with parameterized values.
+
+    Uses Postgres ARRAY constructor with %s expansion so we never f-string
+    user-controllable strings into raw SQL.
+    """
+    quoted_csv = ", ".join(f"'{s}'" for s in sorted(status_values))
+    # Note: ALTER TABLE doesn't accept parameterized constraint definitions;
+    # the quoted_csv interpolation is safe here because STATUS_VALUES is a
+    # closed set defined in models.py — never user input.
+    cursor.execute(
+        f"ALTER TABLE telos_entries ADD CONSTRAINT "
+        f"{_STATUS_CHECK_NAME} CHECK (status IN ({quoted_csv}));"
+    )
+```
+
+The semantic comparison reduces re-deployment risk: even if a contributor uses an older PG version that normalizes the constraint differently, or rewrites the constraint via a manual `psql` session in a way that re-orders elements, the migration only fires when the actual allowed-set differs.
+
+**Migration mechanism:** `_apply_status_check_constraint()` is called as a sibling step inside `init_telos_schema()` (not inside `init_table_schema`, which only runs on table creation). It runs on every web startup; cost is two metadata-table queries when the constraint already matches. Same shape as the GIN index migration in Item 0.c.
+
+**Tests:**
+- Unit test: drop the constraint manually, restart, assert it re-appears with the correct definition.
+- Unit test: seed a stale constraint with only the legacy 4 statuses (simulating an upgrade from a stale on-disk schema), restart, assert the constraint is replaced and contains all 8 statuses.
+- Unit test: insert a row with `status = 'bogus'` directly via raw SQL (bypassing `db.add_entry`'s validation), restart, assert the migration aborts with the preflight error.
+- Unit test: assert `_expected_status_check_clause()` output stays in sync with `STATUS_VALUES` after a future widening (add a new state to `STATUS_VALUES` in a fixture, assert the generated SQL contains it).
+
+**Rollback (operational note — load-bearing per council Round 2 disagreement resolution):**
+- **DB rollback** (additive change is safe to drop): `ALTER TABLE telos_entries DROP CONSTRAINT IF EXISTS telos_entries_status_check;` followed by re-running the new migration after fixing any data.
+- **Code rollback** (UNSAFE once any row holds a new status): if the production DB has any row with `status` ∈ `{proposed, in_review, approved, executing}` and the application code is rolled back to a build whose `STATUS_VALUES` only contains the legacy 4 states, `db.add_entry` and `db.update_entry` validation will reject new writes that touch those rows with a cryptic `ValueError`. **Rollback procedure if needed:** (i) run `UPDATE telos_entries SET status='active' WHERE status IN ('proposed','in_review','approved','executing');` to normalize statuses (loses lifecycle state but preserves rows), THEN (ii) drop the CHECK constraint, THEN (iii) deploy the older build. Document this in the release notes for the Item 0+1.a PR.
+
+This whole change is additive forward — nothing to drop in v1. **Ship Item 1.a in the same PR as Item 0.b** so the new status param and the extended `STATUS_VALUES` land atomically; otherwise Item 0.b would briefly accept only the legacy four states, breaking `/review-ex` for any session that runs between the two PRs.
+
+**1.b — Documented convention** — written into:
+- `specs/agents.md` § Scout / lifecycle
+- `config/default_configs/instructions/scout.md`
+- `.claude/skills/ship/SKILL.md` (Phase 11 hook for `completed`, postmortem step)
+- `CLAUDE.md` § Telos lifecycle (new sub-section)
+
+**1.c — Pin every transition to an actor.**
+
+| From → To | Actor | Trigger |
+|---|---|---|
+| (new) → `proposed` | Scout | `exploration_add` from her instruction file when persisting a plan post-tier-1-council |
+| `proposed` → `in_review` | `/review-ex` skill | First step before `/mm-council:evaluate` fires |
+| `in_review` → `approved` | Claude Code session (this loop) | After capturing the council synthesis, on user confirmation |
+| `in_review` → `in_review` (stays) | n/a | If council verdict is `revise` or `reject` — the EX remains in review until the human edits and re-runs `/review-ex`. Does NOT roll back to `proposed`; rolling back would hide that review happened and that there are blockers to address. |
+| `approved` → `executing` | `/ship` skill | Phase 1 (pre-flight) when the branch matches the EX-linkage convention (Risks #2) |
+| `executing` → `completed` | `/ship` skill | Phase 11 immediately post-merge, before cleanup |
+| `executing` → `approved` | Manual / `/ship --abort` | If the user kills `/ship` before merge — recovery path |
+| `completed` → `archived` | Manual (user via `mcp__radbot__exploration_update`) | When the EX is no longer a useful reference (e.g. supplanted by a follow-up EX). `completed` is **terminal** otherwise — the postmortem step does NOT auto-archive and **does NOT mutate status** (see `/postmortem-ex` § Item 4 — `/ship` is the sole owner of `executing → completed`). |
+| (any non-terminal) → `superseded` | Manual (user via `mcp__radbot__exploration_update`) | When a newer EX replaces this one before it ever shipped. Document the replacement EX ref in `metadata.superseded_by` (string ref code, e.g. `"EX42"`, must point to an existing EX in the same `explorations` section — convention only, no DB-level FK). The new EX MAY symmetrically set `metadata.supersedes: "EX<N>"` pointing back; not required. |
+
+**Single ownership of `executing → completed` (resolves Round 2 council finding):** `/ship` Phase 11 is the **sole owner** of this transition. `/postmortem-ex` MUST NOT mutate status — it only writes EX content (the `## Postmortem` block) and creates the journal entry. AC: `/postmortem-ex` calls to `mcp__radbot__exploration_update` shall NOT include the `status` field.
+
+**Concurrency invariant (resolved):** Single user, single active session per EX. **Item 3's Scout postmortem-processing trigger is changed to user-driven** (see Item 3) so it cannot fire in the background while the user is running `/review-ex` on the same EX in another session. Combined with the dedup-by-`source_postmortem` guard in Item 3 rule 2, this preserves the single-user invariant honestly without needing optimistic concurrency control on `update_entry`. **Stuck-state recovery:** if an EX sits in `in_review` or `executing` for >24h, the user can manually flip it back via `mcp__radbot__exploration_update` (with the new `status` param from Item 0.b.i and `content` left absent). **Telemetry follow-up:** track as a sibling project task PT (`telemetry_concurrent_telos_update_writes_alert`) — file under PRJ1 alongside Item 1.b's docs pass. ACs and the OCC decision get re-evaluated only if that telemetry ever fires.
+
+**Acceptance criteria (EARS):**
+- The `STATUS_VALUES` set in **`radbot/tools/telos/models.py`** (the source-of-truth location) shall include `{proposed, in_review, approved, executing, completed, active, archived, superseded}`. All four enforcement sites listed in 1.a shall use this same imported set (verified by `grep -rn "STATUS_VALUES" radbot/`).
+- The `telos_entries.status` CHECK constraint shall match `STATUS_VALUES` after migration.
+- The migration shall be idempotent: re-running `init_telos_schema()` on a database that already has the constraint shall be a no-op (no error).
+- The migration shall preflight-check existing rows: if any row carries a status outside the new set, the migration shall raise an exception with the offending values (rather than silently failing the constraint add).
+- A unit test shall assert `db.add_entry(section, content, status="proposed")` (and the same for `in_review`, `approved`, `executing`) succeeds with each new lifecycle state.
+- When Scout persists a new exploration via `mcp__radbot__exploration_add({..., status: "proposed"})`, the resulting entry shall have `status = "proposed"`. Scout's instruction file (Item 3 compensating edit) shall pass `status="proposed"` explicitly on creation.
+- When `/review-ex <N>` runs, it shall update the exploration's status to `in_review` before invoking mm-council.
+- When `/ship` merges a PR linked to `EX<N>`, it shall update the exploration's status to `completed` post-merge before cleanup.
+- The system shall NOT add concurrency control (CAS or locks) for v1; the single-user invariant is preserved by Item 3's user-driven trigger + dedup-by-`source_postmortem` guard. The invariant is documented in `CLAUDE.md` and Scout's instruction file.
+
+### Item 2 — `/review-ex <N>` orchestration skill
+
+A new Claude Code command in the personal marketplace (recommended location: `~/git/perrymanuk/claude-skills/plugins/radbot/commands/review-ex.md` since it's radbot-specific). Steps using the **real** MCP surface (post-Item-0):
+
+```
+1.  mcp__radbot__telos_get_entry({section: "explorations", ref_code: "EX<N>", format: "json"})
+    — uses the new `format="json"` parameter from Item 0.c. Returns
+      TextContent whose .text is JSON: {"entry": {ref_code, entry_id,
+      section, status, content, metadata, created_at, updated_at}}.
+      Parse via json.loads(response.text)["entry"]. The `content` field
+      is the raw body, no markdown framing. The default
+      `format="markdown"` is NOT used because round-tripping the rendered
+      `### explorations: EX<N>` / `**Status:**` / `**Metadata:**` wrapping
+      back through `exploration_update(content=...)` would compound the
+      framing every re-run.
+2.  Strip any prior cross-family block from the raw content using the
+    regex below (idempotency — see marker convention). **Marker validation
+    runs both BEFORE and AFTER the strip** — closes the Round 2 council
+    finding that "no change after sub" alone misses cases like one valid
+    block PLUS an extra unmatched marker.
+
+    Strip:
+        cleaned = re.sub(
+            r"\n*<!-- cross-family -->.*?<!-- /cross-family -->\n*",
+            "\n",
+            content,
+            flags=re.DOTALL,
+        )
+
+    Then validate: count remaining occurrences of BOTH markers in `cleaned`:
+        n_open  = cleaned.count("<!-- cross-family -->")
+        n_close = cleaned.count("<!-- /cross-family -->")
+    If either > 0, ABORT with a clear error: "Malformed cross-family
+    marker pair in EX<N> (n_open=<X>, n_close=<Y>); manually clean the
+    EX body before re-running /review-ex." Do NOT mutate status or
+    content. Write `cleaned` to /tmp/EX_<N>.md for inlining.
+
+3.  mcp__radbot__exploration_update({ref_code: "EX<N>", status: "in_review"})
+    — uses the new status param from Item 0.b.i. `content` is omitted
+      (Item 0.b.i makes it optional — the body is left unchanged). Pure
+      status flip, minimal blast radius.
+4.  /mm-council:evaluate /tmp/EX_<N>.md
+    — fires 3-round debate + synthesis. Returns markdown to stdout AND a
+      machine-readable verdict line (see contract below).
+5.  Parse the COUNCIL_VERDICT line, then read the file at
+    synthesis_markdown_path. If the file is missing, unreadable, has a
+    relative path, or is not a regular file, log a warning, leave status
+    at `in_review`, do NOT mutate content, and prompt the user manually.
+6.  mcp__radbot__exploration_update({
+        ref_code: "EX<N>",
+        content: <stripped raw from step 2> +
+                 "\n\n<!-- cross-family -->\n" +
+                 "## Council Review (Cross-Family) — <iso8601>\n" +
+                 <synthesis> +
+                 "\n<!-- /cross-family -->\n"
+    })
+    — the cross-family block is **always normalized to the end of the
+      body** (not preserved at its prior position). The HTML-comment
+      delimiters are the idempotency markers consumed by step 2 on re-run.
+7.  Branch on verdict:
+    - verdict in {proceed, proceed_with_changes}: ask the user whether to
+      flip status to `approved` (single confirmation prompt; on yes →
+      `mcp__radbot__exploration_update({ref_code, status: "approved"})`,
+      content omitted).
+    - verdict in {revise, reject}: do NOT auto-flip; print the synthesis
+      blockers section verbatim, leave status at `in_review` so the user
+      knows the EX needs work.
+```
+
+**mm-council output contract** — `/mm-council:evaluate` must emit, as its **last** stdout line, a machine-readable JSON record so `/review-ex` can branch deterministically:
+
+```
+COUNCIL_VERDICT: {"verdict": "proceed"|"proceed_with_changes"|"revise"|"reject", "confidence": "high"|"medium"|"low", "panelist_count": <int>, "synthesis_markdown_path": "<absolute path>"}
+```
+
+**`synthesis_markdown_path` file contract (load-bearing — closes Round 2 council finding on lifecycle/uniqueness):**
+
+- **Location:** `${XDG_RUNTIME_DIR:-/tmp}/mm-council/<EX_or_uuid>-<iso8601-utc-Z>.md`. The directory is created with mode `0700` if missing.
+- **Filename uniqueness:** the `<EX_or_uuid>` segment is the EX ref (e.g. `EX42`) when `/review-ex` invoked `/mm-council:evaluate`, OR a fresh UUID4 when run on an arbitrary file path. The `<iso8601-utc-Z>` segment uses the same `_iso_default` format as Item 0.c (literal `Z` suffix). Two parallel `/review-ex` runs against different EXes by the same user — explicitly allowed by the concurrency invariant — never collide.
+- **Ownership:** `/mm-council:evaluate` creates and owns the file. The caller (`/review-ex`) is responsible for deleting it after a successful read at step 6. On caller failure (e.g. step 6's `exploration_update` errors), the file remains for debugging — `/mm-council:evaluate` does NOT clean up. A separate `mm-council` housekeeping pass MAY garbage-collect files older than 7 days; not required for v1.
+- **Path absoluteness:** the `synthesis_markdown_path` value in `COUNCIL_VERDICT` is always absolute. If `/review-ex` parses the line and finds the path missing, unreadable, relative, or not a regular file, behavior follows the AC below (leave status at `in_review`, no mutation, prompt user).
+
+If the COUNCIL_VERDICT line is absent or unparseable, `/review-ex` shall log a warning, leave status at `in_review`, and prompt the user manually. The `synthesis_markdown_path` is what step 5 reads to populate step 6's content. **Specs to update:** `~/git/perrymanuk/claude-skills/plugins/mm-council/skills/evaluate/SKILL.md` § Step 5 (emit the contract line at end of synthesis AND honor the file-location convention above).
+
+**Acceptance criteria (Given/When/Then):**
+- **Given** an `EX<N>` with `status="proposed"`, **when** `/review-ex N` runs, **then** the EX content shall gain exactly one `## Council Review (Cross-Family)` section delimited by `<!-- cross-family -->` ... `<!-- /cross-family -->` HTML comments, placed at the end of the body, leaving all other sections byte-identical.
+- **Given** an `EX<N>` already containing a `<!-- cross-family --> ... <!-- /cross-family -->` block, **when** `/review-ex N` re-runs, **then** the prior block shall be removed and the new block shall be appended at the end of the body (always normalized to end — not preserved at its prior position) — the EX content shall NOT accumulate duplicate cross-family sections across re-runs.
+- **Given** an `EX<N>` whose content contains `<!-- cross-family -->` but no matching `<!-- /cross-family -->` (malformed marker pair), **when** `/review-ex N` runs step 2, **then** the skill shall abort with a clear error message and shall NOT mutate the EX status or content. Test: seed a malformed EX, invoke `/review-ex`, assert exit code != 0 and assert the EX entry is byte-identical pre/post.
+- **Given** `/mm-council:evaluate` returns `verdict ∈ {revise, reject}`, **when** `/review-ex` parses the contract line, **then** the skill shall NOT prompt for an `approved` flip and the EX status shall remain `in_review`.
+- **Given** `/mm-council:evaluate` returns no parseable `COUNCIL_VERDICT:` line, **when** `/review-ex` reaches step 7, **then** the skill shall log a warning, leave status at `in_review`, and ask the user how to proceed manually.
+- **Given** `/mm-council:evaluate` emits a parseable `COUNCIL_VERDICT:` line but the `synthesis_markdown_path` it references is missing, unreadable, relative (not absolute), or not a regular file, **when** `/review-ex` reaches step 5, **then** the skill shall log a warning citing the path error, leave status at `in_review`, NOT mutate content (skip step 6), and prompt the user how to proceed.
+- **Given** the radbot MCP server returns a transport-level error (connection refused, request timeout, or `tool not found`) on the step-1 `telos_get_entry` call, **when** `/review-ex` is invoked, **then** it shall exit with a non-zero code and a `MCP unreachable: <reason>` message **before** invoking `/mm-council:evaluate` and **before** mutating any EX status. Test: point the MCP client at an unreachable URL, invoke, assert exit code != 0 and message format matches.
+- **Given** `/review-ex` succeeded at step 3 (status flipped to `in_review`) but a later step (4-7) fails, **when** the failure surfaces, **then** the skill shall NOT roll back the status to `proposed` (the review-attempt provenance must be visible) and shall print exact recovery instructions: "EX<N> is in `in_review` after a partial failure at step <K>. Re-run `/review-ex <N>` to retry."
+
+### Item 3 — Scout instruction update (user-driven postmortem processing)
+
+Edit `config/default_configs/instructions/scout.md` to add a "Postmortem processing" section. Uses the real (post-Item-0) MCP tool names.
+
+**Trigger model (resolved blocker):** Scout's postmortem processing is **user-driven**, NOT automatic on every session start. Risk #3's single-user concurrency invariant rests on "single active session per EX" — having Scout silently mutate EX/PT/journal entries on every new session would create a second writer that races user-initiated `/review-ex` and `/postmortem-ex` runs. The original draft's "on every new session" trigger is replaced below.
+
+1. **When the user asks Scout to process pending postmortems** (typical phrases: "Scout, process postmortems", "any pending postmortems?", "what postmortems do I have?"), run the **structured-format** query:
+
+   ```
+   mcp__radbot__telos_get_section({
+     section: "journal",
+     metadata_filter: {"type": "postmortem", "processed_at": null},
+     format: "json"
+   })
+   ```
+
+   Parse via `json.loads(response.text)["entries"]`. The `metadata_filter` and `format=json` parameters are added in **Item 0.c**; the JSON payload shape is pinned there. If the result is an empty list, reply "No pending postmortems." and stop. **Scout shall NOT poll this query autonomously on session start** — the user must ask explicitly.
+
+2. **Processing means**: for each pending postmortem, parse its `## Followups` section to derive a deterministic followup list (see "Followup-key derivation" below), then for each followup, **first query for existing followups** keyed on the deterministic `(source_postmortem, postmortem_followup_role, postmortem_followup_key)` triple to avoid duplicates from a prior partial run:
+
+   ```
+   mcp__radbot__telos_get_section({
+     section: "project_tasks",   # or "explorations" or "journal"
+     metadata_filter: {
+       "source_postmortem":         "<JR<N>>",
+       "postmortem_followup_role":  "<role>",
+       "postmortem_followup_key":   "<derived key>",
+     },
+     format: "json",
+     include_inactive: true,     # so already-completed dedup hits still match
+   })
+   ```
+
+   If the result is non-empty, **skip the create** and capture the existing ref_code for the union list in step 3. Otherwise, create the followup with all dedup metadata attached **atomically in the `*_add` call** — Item 0.b.ii makes `metadata_merge` available on `task_add` AND `exploration_add` so `source_postmortem` lands in the SAME DB write as the row insert. **No add-then-update sequence; no race window.** Parse the new ref_code from the structured response (Item 0.b.iv).
+
+   - Actionable items → single call:
+     ```
+     mcp__radbot__task_add({
+       parent_project:  "<from journal>",
+       description:     "<one-line>",
+       title:           "<short>",
+       task_status:     "backlog",
+       metadata_merge: {
+         source_postmortem:        "<JR<N>>",
+         postmortem_followup_role: "task",
+         postmortem_followup_key:  "<derived key — see below>",
+       }
+     })
+     → pt_ref = json.loads(response.text)["ref_code"]
+     ```
+   - Bigger work needing its own plan → single call:
+     ```
+     mcp__radbot__exploration_add({
+       parent_project:  ...,
+       topic:           "<short>",
+       notes:           "<full>",
+       status:          "proposed",
+       metadata_merge: {
+         source_postmortem:        "<JR<N>>",
+         postmortem_followup_role: "exploration",
+         postmortem_followup_key:  "<derived key>",
+       }
+     })
+     → ex_ref = json.loads(response.text)["ref_code"]
+     ```
+   - Insight worth remembering → single call:
+     ```
+     mcp__radbot__journal_add({
+       entry: "<insight>",
+       metadata: {
+         type:                     "postmortem_insight",
+         source_postmortem:        "<JR<N>>",
+         postmortem_followup_role: "journal_insight",
+         postmortem_followup_key:  "<derived key>",
+       }
+     })
+     → jr_ref = json.loads(response.text)["ref_code"]
+     ```
+
+   **Followup-key derivation (load-bearing — closes Round 2 council blocker on dedup determinism).** The dedup key MUST be regenerable from the postmortem markdown alone — not from any LLM-generated state — so retries produce byte-identical keys. The contract:
+
+   - The postmortem markdown (created by `/postmortem-ex` per Item 4 step 3) contains a `## Followups` section structured as three sub-sections:
+     ```markdown
+     ## Followups
+
+     ### Tasks
+     1. <one-line description for PT followup>
+     2. <one-line description for PT followup>
+
+     ### Explorations
+     1. <topic for EX followup>
+
+     ### Insights
+     1. <one-line insight to journal>
+     ```
+   - For each followup, Scout assigns:
+     - `postmortem_followup_role`: enum `task | exploration | journal_insight` — derived from the sub-section heading (`### Tasks` → `task`; `### Explorations` → `exploration`; `### Insights` → `journal_insight`).
+     - `postmortem_followup_key`: stable hash. Computed as:
+       ```python
+       import hashlib
+       material = f"{source_postmortem_jr_ref}|{role}|{ordinal}"
+       postmortem_followup_key = hashlib.sha256(material.encode()).hexdigest()[:16]
+       ```
+       where `ordinal` is the 1-based position in the numbered list (1, 2, 3, ...) within the role's sub-section. **Crucially: ordinal comes from the markdown structure, NOT from LLM whim** — re-parsing the same postmortem markdown twice produces identical (role, ordinal) tuples and therefore identical keys.
+   - **`/postmortem-ex` shall write the `## Followups` section as part of the postmortem markdown** (Item 4 step 3) — this is the input contract that Scout's processing relies on. The markdown is the source of truth; Scout MUST NOT add follow-ups not enumerated in the markdown (and MUST NOT skip ones that are).
+
+3. **Mark the postmortem processed** (only after ALL followups for this postmortem succeeded — newly created OR found by dedup):
+   ```
+   mcp__radbot__journal_update({
+     ref_code: "<JR<N>>",
+     metadata_merge: {
+       processed_at:   "<iso8601 with Z suffix>",
+       processed_by:   "scout",
+       followup_refs:  <UNION of dedup-hit refs from step 2 PLUS newly-created refs>,
+     }
+   })
+   ```
+   **`followup_refs` is the UNION** (Round 2 council finding) — any followups created in a prior partial run that step 2's dedup query found AND any newly-created followups in this pass. This preserves the audit trail across retries. If any followup create failed mid-way, do NOT mark processed — re-running step 2 will dedup against the partial state and complete the rest.
+
+Also bump the persona block in `config/default_configs/instructions/main_agent.md` (beto's instruction file) with one paragraph of identity/voice that previously came from the Telos anchor — see Item 6.
+
+**Postmortem journal-entry invariant — enforced at shared `db.add_entry` layer (closes Round 2 + Round 3 findings on agent-side bypass and `metadata=None` AttributeError).** Postgres JSONB `@>` matches `{"processed_at": null}` only when the key is **explicitly present and serialized as null** — a missing key does NOT match. Item 4 step 5 always sets `processed_at: null` explicitly, but the invariant must be enforced at the lowest shared write layer so it covers EVERY writer (MCP `journal_add`, agent-side `telos_add_journal`, direct `db.add_entry` calls).
+
+**Implementation pinned (load-bearing — Round 3 3-of-3 blocker):** at the top of `radbot/tools/telos/db.py:add_entry`:
+
+```python
+def add_entry(section, content, *, ref_code=None, metadata=None, status="active", sort_order=0):
+    # Defensive normalize FIRST — db.add_entry signature accepts metadata=None for normal entries.
+    # Without this, every non-postmortem journal write would raise AttributeError on metadata.get().
+    metadata = dict(metadata or {})
+
+    # Postmortem invariant — covers BOTH spelling conventions:
+    #   - new MCP journal_add writes metadata.type='postmortem'
+    #   - legacy agent-side telos_add_journal writes metadata.event_type='postmortem' (event_type kwarg)
+    # Either spelling triggers the invariant; both must include processed_at (initially null).
+    if section == Section.JOURNAL and (
+        metadata.get("type") == "postmortem"
+        or metadata.get("event_type") == "postmortem"
+    ):
+        if "processed_at" not in metadata:
+            raise ValueError(
+                "postmortem journal entries must include metadata.processed_at "
+                "(initially null) — this enables the unprocessed-postmortem query"
+            )
+
+    # ... existing STATUS_VALUES validation and INSERT logic ...
+```
+
+**Plus: normalize `event_type` → `type` at the agent-side layer** (defense in depth). Update `telos_add_journal` (`telos_tools.py:207-233`): when `event_type == "postmortem"`, set `metadata["type"] = "postmortem"` AND default `metadata["processed_at"] = None` if not supplied, before delegating to `db.add_entry`. This way the canonical key (`type`) is always populated AND the invariant fires on the legacy spelling regardless. Single enforcement point at `db.add_entry`; agent-side normalization is the cleanup pass.
+
+**Tests (mandatory):**
+- `db.add_entry(Section.JOURNAL, "x", metadata={"type": "postmortem"})` → `ValueError`.
+- `db.add_entry(Section.JOURNAL, "x", metadata={"event_type": "postmortem"})` → `ValueError` (covers agent-side bypass).
+- `db.add_entry(Section.JOURNAL, "x", metadata={"type": "postmortem", "processed_at": None})` → succeeds.
+- `db.add_entry(Section.JOURNAL, "x")` (no metadata kwarg) → succeeds (defensive normalize works).
+- `db.add_entry(Section.JOURNAL, "x", metadata=None)` → succeeds (explicit None).
+- `telos_add_journal(entry="x", event_type="postmortem")` → succeeds AND the resulting row has both `metadata.type == "postmortem"` AND `metadata.processed_at is None`.
+
+**Acceptance criteria:**
+- The instruction file shall include the three rules above (verbatim) using the post-Item-0 MCP tool names.
+- The instruction file shall include exact tool-call examples for each step (Scout's instruction style is example-heavy).
+- The instruction file shall state that Scout must NOT autonomously poll for pending postmortems on session start — the trigger is user-driven only.
+- The instruction file shall require dedup-by-`(source_postmortem, postmortem_followup_role, postmortem_followup_key)` query before each followup create, including `include_inactive: true` so completed followups still count as duplicates.
+- The instruction file shall pin the SHA-256-truncated-to-16-hex `postmortem_followup_key` derivation rule (verbatim Python snippet above) and assert that two re-parses of the same postmortem markdown produce byte-identical keys.
+- Scout shall NOT use the `task_add → task_update` two-call pattern for `source_postmortem` linkage — the dedup metadata MUST be set atomically in the initial `*_add` call via `metadata_merge`. Test: simulate a process kill immediately after `task_add` and assert the followup is found by the dedup query on retry.
+- The `db.add_entry` shared layer shall reject `Section.JOURNAL` writes with `metadata.type=="postmortem"` and missing `processed_at`. Test: call `db.add_entry(Section.JOURNAL, "<text>", metadata={"type": "postmortem"})` directly — assert `ValueError`; with `{"type": "postmortem", "processed_at": None}` — assert success.
+- Test: simulate a partial failure (Scout creates 2 of 3 followups via `*_add` with `metadata_merge`, then crashes); re-run step 2; assert exactly 1 new followup is created (the missing ordinal) and 0 duplicates of the prior 2 (dedup query found them by stable key).
+- Test: `journal_update` step shall record `followup_refs` as the union (e.g. simulate first run creates PT1+PT2, retry creates PT3, assert `followup_refs=[PT1,PT2,PT3]` after the retry's `journal_update`).
+
+### Item 4 — Postmortem-back via journal (sibling `/postmortem-ex` skill)
+
+A separate Claude Code skill the user invokes after `/ship` returns successfully. Not folded into `/ship` itself — `/ship` is mostly mechanical (Phase 11 = merge, Phase 12 = cleanup; postmortem-writing requires Claude Code to think about what happened, which doesn't fit that flow). The user runs `/postmortem-ex <PR#>` once `/ship` returns.
+
+Behavior using **post-Item-0** MCP names. **Step ordering revised (blocker fix from Round 2):** EX validation now runs BEFORE `journal_add` so a malformed-marker abort never leaves an orphan `JR<N>`. The dedup check ALSO runs before `journal_add` for the same reason. Sequence: resolve_ex → fetch+validate → dedup → generate_md → journal_add → write_ex.
+
+```
+1. Resolve EX from PR. Resolution order (chosen for safety — do NOT assume
+   PT-to-EX metadata links exist; defer that lookup until verified):
+   (i)   Parse the branch name with the case-insensitive path-aware regex
+         `(?i)(?:^|/)ex(\d+)\b` (matches `ex42-foo`, `EX42-foo`,
+         `perry/ex42-foo`, etc — per Round 2 council finding on worktree
+         prefixes).
+   (ii)  Grep the PR title for `(?i)EX(\d+)\b`.
+   (iii) Grep the PR body for `(?i)EX(\d+)\b`.
+
+   Conflict handling: if multiple sources resolve to DIFFERENT EX numbers,
+   ABORT with the conflict listed (do NOT silently first-wins). Example:
+   "Branch resolved EX42, PR body resolved EX17 — re-run as
+   /postmortem-ex <PR#> --ex-ref EX<N> to disambiguate."
+
+   If all of (i-iii) miss, ABORT with an actionable message — do NOT
+   prompt interactively (Claude Code skills running as shell subprocesses
+   can hang or break terminal state if they read stdin without framework
+   support; Round 2 Gemini finding):
+       "Could not resolve EX link for PR #<N>. Re-run as:
+        /postmortem-ex <PR#> --ex-ref EX<M>"
+   The skill MUST accept an `--ex-ref` flag for this fallback.
+
+   Note: if the branch matches `(?i)(?:^|/)pt(\d+)\b`, the resolver does
+   NOT look up the parent EX from PT metadata in v1 (no evidence today
+   that PT entries carry a parent-EX link). pt<N> branches fall through
+   to (ii) and (iii). A future EX may add the PT→EX lookup if a verified
+   link is established.
+
+2. Fetch the current EX body AND validate postmortem markers (BEFORE
+   creating the journal entry — closes the Round 2 step-ordering blocker):
+
+       resp = mcp__radbot__telos_get_entry({section: "explorations",
+                                            ref_code: "EX<N>",
+                                            format: "json"})
+       entry = json.loads(resp.text)["entry"]
+       raw_body = entry["content"]
+
+       cleaned = re.sub(
+           r"\n*<!-- postmortem -->.*?<!-- /postmortem -->\n*",
+           "\n",
+           raw_body,
+           flags=re.DOTALL,
+       )
+       n_open  = cleaned.count("<!-- postmortem -->")
+       n_close = cleaned.count("<!-- /postmortem -->")
+       if n_open or n_close:
+           abort(f"Malformed postmortem markers in EX<N> "
+                 f"(n_open={n_open}, n_close={n_close}); manually clean "
+                 f"the EX body before re-running /postmortem-ex.")
+
+   The cross-family block from Item 2 (delimited by `<!-- cross-family -->`
+   ... `<!-- /cross-family -->`) is left **verbatim** in `cleaned` —
+   /postmortem-ex preserves /review-ex's review provenance.
+
+3. Dedup check — query for an existing postmortem journal entry with the
+   same pr_url. **PR-URL canonicalization (load-bearing):** the URL string
+   written at step 5 must equal the URL string queried here BYTE-IDENTICALLY
+   for JSONB `@>` to hit. Canonicalize before both query AND write:
+
+       owner, repo, pr_num = parse_pr_arg(pr_arg)  # accepts "42" or full URL
+       pr_url = f"https://github.com/{owner.lower()}/{repo.lower()}/pull/{pr_num}"
+       # No trailing slash. No query string. Lowercase owner/repo. Integer PR num.
+
+   Then dedup query:
+
+       mcp__radbot__telos_get_section({
+         section: "journal",
+         metadata_filter: {"type": "postmortem", "pr_url": pr_url},
+         format: "json",
+         include_inactive: true,   # so archived JRs from prior --supersede runs still surface
+       })
+
+   If the result is non-empty, ABORT with an actionable message (do NOT
+   prompt interactively, same shell-subprocess constraint as step 1):
+       "PR #<N> already has postmortem journal entry JR<M>
+        (created <iso8601>). To create a new one anyway, re-run as:
+        /postmortem-ex <PR#> --force-new
+        Or to supersede the old entry, re-run as:
+        /postmortem-ex <PR#> --supersede"
+   The skill MUST accept `--force-new` and `--supersede` flags. **Behavior
+   and ordering for these flags is load-bearing — closes the Round 3 blocker
+   on archive-before-create leaving zero valid postmortems on partial failure
+   AND the Round 3 major on `--force-new` leaving the old JR independently
+   processable.**
+
+   **`--supersede` ordering (delayed archive):** dedup-detection RECORDS
+   the old JR ref but does NOT mutate it yet. Steps 4-7 proceed normally
+   (generate markdown, journal_add, write EX body). ONLY AFTER step 7
+   succeeds does the skill execute `_supersede_old_jr(old_ref, new_ref)`:
+
+       mcp__radbot__journal_update({
+         ref_code: <old JR ref>,
+         metadata_merge: {
+           processed_at:  "<iso8601>",
+           processed_by:  "superseded_by_<new JR ref>",
+           superseded_by: "<new JR ref>",
+         },
+         status: "archived",
+       })
+
+   This means if anything between dedup-detection and step-7-success
+   fails, the old postmortem stays visible and intact. The
+   `processed_at` write is critical: without it, future Scout queries
+   that include archived rows (e.g. an audit query) would still surface
+   the old JR as "unprocessed". With it, the old JR is unambiguously
+   replaced.
+
+   **`--force-new` ordering (mark-old-processed before create):**
+   intentional-duplicate-creation must NOT leave both JRs independently
+   processable. Before steps 4-7, mark the existing OLD JR as processed:
+
+       mcp__radbot__journal_update({
+         ref_code: <old JR ref>,
+         metadata_merge: {
+           processed_at: "<iso8601>",
+           processed_by: "replaced_by_force_new_<placeholder>",
+         },
+       })
+
+   Then proceed with steps 4-7 to create the NEW JR (which has its own
+   `processed_at: null` invariant). After step 7 succeeds, patch the old
+   JR's `processed_by` to reference the new ref:
+
+       mcp__radbot__journal_update({
+         ref_code: <old JR ref>,
+         metadata_merge: {processed_by: "replaced_by_<new JR ref>"},
+       })
+
+   If steps 4-7 fail mid-way, the old JR is left marked-processed with
+   the placeholder `processed_by` value — a follow-up `--supersede`
+   invocation OR manual repair can fix that. The key invariant is that
+   Scout's pending-postmortem query never sees TWO unprocessed JRs for
+   the same PR.
+
+4. Generate postmortem markdown from: PR diff, merged commits,
+   plan-vs-actual delta, notable events from /ship's CI fix loop log.
+   The markdown MUST include a `## Followups` section with three
+   sub-sections (### Tasks / ### Explorations / ### Insights), each a
+   numbered list — this is the input contract Scout's processing
+   relies on (Item 3 followup-key derivation). If no followups apply
+   for a sub-section, write `_None_` instead of an empty list so the
+   structure is preserved for future re-parses.
+
+5. Create the journal entry (after EX validation + dedup both passed):
+
+       mcp__radbot__journal_add({
+         entry: <postmortem markdown from step 4>,
+         metadata: {
+           type:          "postmortem",
+           ex_ref:        "EX<N>",
+           pt_refs:       ["PT<X>", "PT<Y>"],
+           pr_url:        "<github URL>",
+           processed_at:  null,                 # invariant — Item 3
+           processed_by:  null,
+           followup_refs: []
+         }
+       })
+       jr_ref = json.loads(response.text)["ref_code"]
+
+6. Append the new postmortem block to `cleaned` from step 2 (always
+   normalized to end of body — matching Item 2's pattern):
+
+       new_body = (
+           cleaned +
+           "\n\n<!-- postmortem -->\n" +
+           "## Postmortem\n" +
+           "- Journal: " + jr_ref + " (fetch via telos_get_entry).\n" +
+           "<!-- /postmortem -->\n"
+       )
+
+7. Update the EX body — content ONLY; do NOT mutate status (Item 1.c
+   single-ownership rule: /ship Phase 11 owns executing→completed,
+   /postmortem-ex preserves whatever status /ship set):
+
+       mcp__radbot__exploration_update({
+         ref_code: "EX<N>",
+         content:  new_body
+         # status: OMITTED — /ship Phase 11 already set it to "completed"
+       })
+
+8. Print final UX nudge to user (closes Round 2 council finding on
+   discoverability):
+
+       "Postmortem JR<N> created and linked to EX<M>.
+        Run 'Scout, process postmortems' when ready to generate followups."
+```
+
+**Acceptance criteria (Given/When/Then):**
+- **Given** `/ship` merges PR #N linked to `EX<M>` via the branch/title convention, **when** `/postmortem-ex N` is invoked, **then** a new journal entry shall be created with `metadata.type="postmortem"`, `metadata.processed_at=null`, `metadata.ex_ref="EX<M>"`, and `metadata.pr_url=<the PR's GitHub URL>`.
+- **Given** the user runs `/postmortem-ex N` for a PR with no resolvable EX link (no branch match AND no PR title/body match), **when** all three resolver steps miss, **then** the skill shall ABORT with the actionable message `"Could not resolve EX link for PR #<N>. Re-run as: /postmortem-ex <PR#> --ex-ref EX<M>"` and shall NOT prompt interactively. The skill shall accept the `--ex-ref` flag to bypass resolution.
+- **Given** a PR whose branch and PR body resolve to DIFFERENT EX numbers, **when** `/postmortem-ex` runs step 1, **then** the skill shall ABORT with the conflict listed and request `--ex-ref` disambiguation. Test: seed a branch `ex42-foo` with PR body containing `EX17`; assert abort + zero side effects.
+- **Given** a postmortem journal entry already exists for the same `pr_url`, **when** `/postmortem-ex` is re-invoked, **then** the skill shall ABORT with the actionable message and shall NOT silently create a duplicate. The skill shall accept `--force-new` (proceed and create another JR) and `--supersede` (archive the old JR via `journal_update(status: "archived")` then create the new one). Test: invoke `/postmortem-ex N` twice in a row without flags; assert the second invocation aborts with the existing JR ref in the message.
+- **Given** an `EX<M>` already containing a `<!-- postmortem --> ... <!-- /postmortem -->` block (from a prior successful run), **when** `/postmortem-ex N` runs, **then** the prior postmortem block shall be removed and the new one appended at the end — the EX content shall NOT accumulate duplicate `## Postmortem` sections across re-runs.
+- **Given** an `EX<M>` containing a `<!-- cross-family -->` block from a prior `/review-ex` run, **when** `/postmortem-ex N` writes the new EX body, **then** the cross-family block shall be preserved verbatim (postmortem block sits at the very end, cross-family block sits between the original body and the postmortem block).
+- **Given** an `EX<M>` whose content contains a malformed postmortem marker pair (open without close, close without open, or any odd count after strip), **when** `/postmortem-ex N` runs step 2, **then** the skill shall abort with a clear error AND shall NOT create the journal entry AND shall NOT mutate the EX. Test: seed each malformed permutation, invoke, assert abort + EX byte-identical pre/post + zero new JR<N> rows.
+- **Given** the journal entry is created at step 5, **when** the skill reaches step 7, **then** the EX body shall be updated with the new `<!-- postmortem -->` block AND the EX `status` shall be PRESERVED unchanged (single-ownership rule from Item 1.c — `/ship` Phase 11 owns the `executing → completed` transition; `/postmortem-ex` does NOT pass `status` to `exploration_update`).
+- **Given** all steps succeed, **when** the skill exits, **then** stdout shall include the UX-nudge line: `"Postmortem JR<N> created and linked to EX<M>. Run 'Scout, process postmortems' when ready to generate followups."`
+
+### Item 5 — Postmortem-processed flag + followup linking conventions
+
+Pure metadata convention. The shapes are defined in Items 3 + 4 above. The MCP enablement (originally listed here as "optional MCP enhancement") has been **promoted to Item 0.c** as a mandatory prerequisite — all three council panelists agreed that client-side post-filtering against rendered markdown is fragile and that structured JSON returns + `metadata_filter` are required for this design. The reclassification eliminates the markdown round-trip data-loss risk that was a major finding.
+
+**Convention:** every followup created from a postmortem includes `metadata.source_postmortem` set to the postmortem journal entry's `JR<N>` ref code (preferred — human-readable in journal exports). The presence of this key is the dedup signal Item 3 uses to avoid duplicate followups on retry. To make the "open followup tasks from any postmortem" query JSONB-`@>`-friendly without inventing a `$exists` operator, **followups MAY also set `metadata.has_source_postmortem: true`** (a denormalized boolean sentinel) — but this is optional. The primary lookup path is by specific `source_postmortem` value, not by key existence.
+
+**v1 design decision (resolves Item 5 disagreement):** drop the `$exists`-style "any postmortem" query from the v1 AC. The other two queries (specific `processed_at: null` filter and specific `source_postmortem: "<JR<N>>"` filter) cover Scout's actual workflow needs and are pure JSONB containment, fully GIN-indexable. Adding a generic key-existence operator (`metadata ? key`) is a separate enhancement filed as a follow-up PT if real demand surfaces.
+
+Verification queries (using Item 0.c tooling):
+
+- "Show me unprocessed postmortems" →
+  ```
+  mcp__radbot__telos_get_section({
+    section: "journal",
+    metadata_filter: {"type": "postmortem", "processed_at": null},
+    format: "json"
+  })
+  ```
+  Relies on the Item 3 invariant that postmortem journal entries always serialize `metadata.processed_at` (initially `null`) — see the `journal_add` rejection rule in Item 3.
+
+- "What followups did Scout produce from postmortem `JR<N>`?" → three queries (`project_tasks`, `explorations`, `journal`) each with `metadata_filter: {"source_postmortem": "JR<N>"}, format: "json", include_inactive: true` (so completed followups still surface).
+
+- "Open followup tasks from a SPECIFIC postmortem" → `project_tasks` section with `metadata_filter: {"source_postmortem": "JR<N>", "task_status": "backlog"}, format: "json"`.
+
+(The original draft's third query — "open followup tasks from ANY postmortem" — is dropped from v1. If/when needed, file a sibling PT for adding `metadata_keys_present: list[str]` to `metadata_filter`, translating to Postgres `metadata ? key` against the GIN index.)
+
+**Acceptance criteria:**
+- The schema migration in Item 1.a is the only schema change required by this EX; **no other migrations** for Item 5.
+- All followup entries created from a postmortem shall include `metadata.source_postmortem` set to the postmortem journal entry's ref code (e.g. `"JR42"`).
+- The two retained verification queries shall succeed against a journal section of up to 5000 entries with sub-second latency, given the GIN index on `telos_entries.metadata` from Item 0.c.
+- The dropped "any postmortem" key-existence query shall NOT be present in the AC; if the use case re-emerges, the resolution is to file a follow-up PT for `metadata_keys_present` filter — not to handwave a fallback.
+
+### Item 6 — Restrict `inject_telos_context` to scout-as-root only (Flavor 1)
+
+Two-line code change, but the verification surface is bigger than the original draft assumed:
+
+1. **Remove `inject_telos_context`** from beto's `before_model_callback` list at `radbot/agent/assembly.py:317` (verified location).
+2. **Confirm scout-as-root's callback registration in `radbot/agent/research_agent/factory.py:217-242`** — specifically, the `if as_root:` block where `inject_telos_context` is the last entry of `adk_agent.before_model_callback`. The `as_root=True` flag itself is wired by `radbot/agent/assembly.py` (`AGENT_DEFS` + `_resolve_assembly` + the `chat_sessions.agent_name` selector) — verify both ends; do not assume.
+3. **Confirm sub-agents stay excluded** — `_attach_subagent_callbacks` at `assembly.py:280-294` uses `_SUBAGENT_BEFORE_CBS` (lines 273-277) which does NOT include `inject_telos_context`. No change needed here, but the test in AC #4 below pins it.
+
+Beto loses:
+- Per-turn anchor (~300B): identity / mission / counts / tool pointer
+- First-turn full block (~2KB): mission + problems + goals + projects + challenges + wisdom + last 5 journal entries
+
+Beto retains:
+- Full Telos tool surface — he can `telos_get_section`, `telos_get_entry`, etc., on demand via the 27 `TELOS_TOOLS` already wired into `_build_beto`'s tool list (`assembly.py:304`)
+- His instruction file (`main_agent.md`) which has routing rules + a new persona/voice paragraph (Item 3 compensating edit)
+
+**Specs to update:** `specs/agents.md` § "Telos persona injection (beto only)" — flip to "scout-as-root only" and update the rationale to cite `factory.py:217-242` as the registration site and `assembly.py` as the gating site. **Also reconcile the existing internal inconsistency:** `specs/agents.md` line 139 already documents scout-as-root receiving `inject_telos_context`, but line 303 (Callback Inventory table) labels it `beto only`. This conflict pre-dates Item 6 and must be resolved in the same edit.
+
+**Acceptance criteria (Given/When/Then) — falsifiable replacements for the original AC #3:**
+
+- **Producer-side marker pinning (NEW — closes Round 2 council finding that consumer absence-test is meaningless without producer guarantee).** The function `radbot/tools/telos/callback.py:build_telos_tiers()` shall emit, as load-bearing markers, all three literal strings: `"## Mission"`, `"## Identity"`, and `"ME:"`. **Test:** unit test on `build_telos_tiers()` that asserts each of the three substrings appears in the function's output (anchor or full block). This anchors the consumer-side absence test below — if a future rename moves `## Mission` to `## My Mission` in `callback.py`, this producer test fails first, alerting the implementer that Item 6's beto absence test must be updated in the same PR.
+- **Given** a beto session is started, **when** beto receives his first user message, **then** `llm_request.config.system_instruction` shall NOT contain any output from `build_telos_tiers()`. **Test:** invoke beto with one user message; capture the `llm_request.config.system_instruction` via a one-shot before-model callback; assert that **none** of the producer-pinned markers appear in the captured text. Specifically, assert: (a) the literal substring `"## Mission"` is absent, AND (b) the literal substring `"## Identity"` is absent, AND (c) the user's identity ref `"ME:"` is absent. The producer-side AC above guarantees these markers ARE emitted by `build_telos_tiers()`; the consumer-side AC here verifies they don't reach beto.
+- **Given** a scout-as-root session is started, **when** scout receives her first user message, **then** `llm_request.config.system_instruction` shall contain both the anchor and the full block as today. **Test:** assert `"## Mission"` is present (full-block marker) AND `"ME:"` is present (anchor marker).
+- **Given** any sub-agent (`casa`, `planner`, `comms`, `axel`, `kidsvid`, `scout`-as-sub) receives its first turn, **when** the `before_model_callback` list runs, **then** `inject_telos_context` shall NOT be present in that list. **Test:** after `build_default_assembly()`, introspect each sub-agent's `before_model_callback` list (`agent.before_model_callback`) and assert `inject_telos_context` (the function reference imported from `radbot.tools.telos`) is not in the list.
+- **AC #4 — Telos read regression test (rewritten to drop the format=json dependency, closing the Round 2 ordering contradiction).** **Given** beto's existing Telos read tools (`telos_get_section`, `telos_get_entry`, `telos_get_full`), **when** a regression test suite runs against a fixed set of representative conversations, **then** the parsed Telos read responses shall match a checked-in baseline structurally. **Test:** scripted set of 5 conversations covering routing, Telos read, Telos write, `transfer_to_agent`, and chitchat. **Pass criterion:** (a) transfer-targets match the baseline exactly; (b) Telos read responses, called with `format="markdown"` (the existing default — does NOT depend on Item 0.c's `format="json"`, allowing Item 6 to ship genuinely independently of Item 0.c) and parsed via a small AST-style helper that splits on the markdown delimiters (`### section: ref_code`, `**Status:**`, body, `**Metadata:**`), match structurally on `(ref_code, body_lines_sorted, metadata_dict)` against the baseline (timestamps and rendering order ignored); (c) the chitchat conversation produces a non-empty reply. **Baseline fixture (mandatory):** the baseline lives at `tests/fixtures/item6_regression_baseline.json`; regen via `make regen-item6-baseline` (added in this EX). PR checklist: any change to beto's instruction file requires regenerating the baseline IN THE SAME PR.
+- **Specs-grep coherence AC.** **Given** the docs edits in Item 6 land, **when** `grep -n "inject_telos_context" specs/agents.md` runs, **then** every match shall agree on the same scope (scout-as-root only; not beto; not sub-agents). **Test:** automated grep + assert the resulting lines do NOT contain the substring `"beto only"` and DO contain at least one `"scout-as-root only"` mention.
+- **AC #5 (smoke test for v1; literal-regex deferred).** **Given** beto loses the per-turn anchor, **when** the user asks "what are you?" in a fresh session, **then** beto shall reply (response is non-empty, contains the agent's name `"beto"` or a first-person identity claim `"I'm "`/`"I am "`, and does not error). **Risk acknowledgment (load-bearing — Round 2 council finding):** this smoke test is intentionally weak; it would pass even if Item 3's compensating persona-paragraph edit were forgotten entirely. The stronger literal-regex AC against the persona paragraph is deferred to a follow-up PT to ship together with Item 3's persona-paragraph draft, once the paragraph text is pinned. The post-deploy observation window (Risks #5) is the only catch for a forgotten or weak persona paragraph in v1. **Mitigation:** Item 6 ship is gated on Item 3's persona-paragraph edit landing in the SAME PR — a soft gate enforced by PR checklist (not by automated test). If a future contributor removes `inject_telos_context` from beto without adding the persona paragraph, the PR review must catch it.
+
+## Risks / open questions (resolved decisions and remaining unknowns)
+
+1. **Scope of postmortem-back: sibling skill, not folded into `/ship`.** Decided. `/postmortem-ex <PR#>` is a separate Claude Code skill the user invokes after `/ship` returns. `/ship` stays mostly mechanical (Phase 11 = merge, Phase 12 = cleanup) — postmortem-writing requires Claude Code to think, which doesn't fit. (Closes original Q1.)
+2. **Linking PR → EX: best-effort branch convention; no /ship-side enforcement in v1 (downgraded after Round 2 council finding).** `/ship` already creates branches with the form `pt<N>-<slug>` or similar; the convention is extended so EX-implementing branches MAY use the prefix `ex<N>` (e.g. `ex42-council-loop`) AND/OR the PR title/body MAY contain the literal `EX<N>` token. `/postmortem-ex` resolves the EX with the case-insensitive path-aware regex from Item 4 step 1: (i) branch `(?i)(?:^|/)ex(\d+)\b`; (ii) PR title `(?i)EX(\d+)\b`; (iii) PR body `(?i)EX(\d+)\b`; (iv) if all miss, ABORT with an actionable message asking the user to re-run with `--ex-ref EX<N>` (do NOT prompt interactively — see Item 4 step 1 reasoning). **No /ship change in v1 to inject `EX<N>` into PR bodies** — this was a Round 2 council finding and is intentionally deferred: the manual fallback (`--ex-ref` flag) covers the case, /ship has its own complexity budget, and adding enforcement now would couple two skills unnecessarily. If telemetry shows the manual fallback firing >25% of the time, file a follow-up PT for /ship enforcement. **`pt<N>` branch handling:** branches matching `(?i)(?:^|/)pt(\d+)\b` do NOT trigger a PT-metadata lookup in v1 — there's no verified evidence today that PT entries carry a parent-EX link. `pt<N>` branches fall through to (ii)/(iii)/(iv). **Acceptance:** `/postmortem-ex` shall not create an orphan postmortem (one without `metadata.ex_ref`) — it aborts with the `--ex-ref` instruction before any side effects. (Closes original Q2 + Round 2 council finding on /ship enforcement gap.)
+3. **Concurrency invariant: single-user, single active session per EX.** Decided — see Item 1 § Concurrency invariant + Item 3's user-driven trigger. No CAS or advisory lock added in v1; the invariant is honestly preserved (Item 3 no longer mutates state autonomously on session start; postmortem-processing dedup-by-`source_postmortem` provides defense-in-depth). Documented as a constraint in `CLAUDE.md` and Scout's instruction file. **Telemetry follow-up:** filed as a sibling project task — `telemetry_concurrent_telos_update_writes_alert` under PRJ1, to be created alongside Item 1.b's documentation pass. Re-evaluate the OCC decision only if that telemetry ever fires (>0 concurrent `update_entry` calls on the same `entry_id` within a 30-day window).
+4. **Cycle risk if `chat_with_scout` ever lands.** Out of scope for this EX. Scout's `start_claude_session` could spawn a Claude Code subprocess that calls back to `chat_with_scout`, looping. Captured for future EX. (Same as original Q3.)
+5. **Beto's reaction to the Telos context removal.** Item 6's AC suite covers behavioral regressions on routing + Telos read paths via scripted tests against a checked-in `tests/fixtures/item6_regression_baseline.json`. The persona/voice question is covered by **AC #5's structural smoke test** for v1 (response non-empty + contains `beto`/`I'm`/`I am`); the stronger **literal-regex AC against `main_agent.md`'s persona paragraph is deferred** to a follow-up PT pending the actual persona-paragraph draft. Item 6 ship is gated on Item 3's persona-paragraph edit landing in the SAME PR — a soft PR-checklist gate, not automated. Worth instrumenting one week post-deploy via the existing `radbot/tools/telemetry/` to spot any drop in `transfer_to_agent` rate or rise in beto-handles-it-himself rate. If telemetry shows regression OR PR review missed the persona paragraph, rollback is a single-line revert of `assembly.py:317`. (Closes original Q5 with concrete tests + acknowledged v1 weak spot.)
+6. **`mm-council` output contract drift.** New question — `/mm-council:evaluate` is owned in `~/git/perrymanuk/claude-skills`. The `COUNCIL_VERDICT:` line contract from Item 2 needs a parallel commit there. Track as a sibling task in the personal marketplace repo.
+
+## Out of scope
+
+- `chat_with_scout` MCP tool (true real-time push to Scout). Captured as a future enhancement; not required for the v1 loop.
+- LiteLLM proxy in radbot (PRJ1/PT18). No longer on the critical path for council quality — mm-council bypasses it. **Disposition:** keep PT18 open in Telos but downgrade to "future infra; mm-council fills the cross-family gap at the human gate." Update PT18's description in Telos as part of Item 1.b's documentation pass.
+- `radbot/mcp_server/tools/council.py` — exposing the in-process critics over MCP. Replaced by mm-council; not needed.
+- `repo_exploration` MCP wrappers — pruned in earlier design discussion (Claude Code has Read/Grep/Glob natively).
+- Notification / push to Perry's phone when an `EX<N>` flips to `proposed`. Pruned per user preference (no ntfy).
+- A radbot-side UI for browsing postmortems and followups. Querying via Scout chat or this Claude Code session through MCP is sufficient for v1.
+- Compare-and-swap / advisory locks on `telos_update_entry`. Deferred per concurrency invariant in Item 1 + Risk #3. Re-evaluate only if telemetry surfaces concurrent same-entry writes.
+
+## Implementation order (revised)
+
+**Pre-commit verification step (NEW — Round 2 council finding on line-ref drift):** before opening the Item 0+1.a PR, re-grep every `file:line` reference in this EX against current HEAD and update any that have drifted. The Round 2 grounding pass found `_render_section` cited as `:155` when the actual line is `:145` — silent drift like this rots reviewer trust. Run:
+```bash
+grep -nE "(radbot/[^ ]+\.py|specs/[^ ]+\.md|\.claude/[^ ]+):[0-9]+" docs/plans/EX_DRAFT_council_loop_polish.md
+```
+For each match, verify the line by reading the file. Update stale refs in the same commit as the implementation.
+
+1. **Item 0 + Item 1.a (combined PR)** — the MCP write-surface expansion (`journal_add`/`journal_update`, `exploration_update.status` + `content`-optional, `exploration_add.status`, **`metadata_merge` on `task_add` + `exploration_add` (Item 0.b.ii — closes chain-race blocker)**, `metadata_merge` on `task_update` + `exploration_update` with silent whitelist-wins precedence, **structured-return contract for all four `*_add` tools incl. `milestone_add` with JSON `_err` envelope (Item 0.b.iv)**, `telos_get_section.metadata_filter` + `format=json` + `ACTIVE_EQUIVALENT` default + `status_in: list[str]` on `db.list_section`, `telos_get_entry.format=json` with `_iso_default` Z-suffix, sibling `_apply_metadata_gin_index()` step in `init_telos_schema()` (Item 0.c — closes GIN-on-existing-DB issue), `db.add_entry` postmortem `processed_at` invariant at the shared layer (Item 3 — closes agent-side-bypass)) AND the `STATUS_VALUES` extension in `models.py` + idempotent definition-aware CHECK constraint migration with preflight + generated SQL from `STATUS_VALUES` (Item 1.a — closes constraint-drift). These ship together because Item 0.b's new status params reject the new lifecycle states until Item 1.a's `STATUS_VALUES` extension lands; splitting the PRs creates a window where `/review-ex` and Scout's exploration creation would fail validation. **Mandatory PR-description backward-compat audit** (`grep -rn "Added (task|exploration|milestone|journal)"`) per Item 0.b.iv. ~250 LoC + tests + one migration (heavier than the Round 2 estimate since this PR now includes `metadata_merge` schema additions on `*_add`, JSON `_err` envelope refactor across all eight write tools, deterministic `_iso_default`, `db.list_section` signature change with default change, and a definition-aware CHECK migration). **Hard prerequisite for Items 2–5.** Release-note line: code rollback to a pre-Item-1.a build is unsafe once any row holds a new lifecycle status — see Item 1.a Rollback section.
+2. **Item 1.b + 1.c** (status state-machine: documentation + transition table) — pure docs into `specs/agents.md`, `scout.md`, `SKILL.md`, `CLAUDE.md`. Ships once Item 0+1.a is merged so the convention can reference real tool/state names. Includes `metadata.superseded_by: "EX<N>"` shape pin.
+3. **Item 3** (Scout instructions for postmortem processing) — depends on Item 0.a + 0.b.ii (atomic `metadata_merge` on `*_add`) + 0.b.iv (structured returns) + 0.c. The instruction file MUST reflect the deterministic `postmortem_followup_key` derivation rule and the union semantics for `followup_refs`.
+4. **Item 6** (remove `inject_telos_context` from beto) — depends on Item 0.c (AC #4's structural Telos-read regression test reads via the existing markdown path with a parsed comparator, NOT format="json", so technically Item 6 could ship before Item 0.c — but the `## Followups` markdown structure that AC #4 baselines against is also touched by Item 4, so ship Item 6 AFTER Item 0+1.a to avoid baseline churn). Soft-gated on Item 3's persona-paragraph edit landing in the SAME PR (PR-checklist enforcement, not automated). Smallest token-saving win once dependencies clear; isolated change. Ship and observe beto for a week.
+5. **Item 2** (`/review-ex` skill) — depends on Item 0 + Item 1. First user-facing artifact, immediately useful. Sibling change in `claude-skills` repo: emit `COUNCIL_VERDICT:` line from `/mm-council:evaluate` AND honor the `synthesis_markdown_path` file convention from Item 2.
+6. **Item 4** (`/postmortem-ex` sibling skill) — depends on Item 0.a + 0.b.i + 0.c (`telos_get_entry.format=json`) + Item 3 (deterministic followup-key derivation expects `## Followups` markdown structure that `/postmortem-ex` writes). Closes the loop. Ship after Item 3 so Scout knows what to do with postmortems when they arrive AND so the markdown contract is settled before `/postmortem-ex` writes against it.
+7. **Item 5** (followup conventions) — formalized as Items 3+4 land; the verification queries are now possible from day one because Item 0.c shipped first.
+
+Total estimated effort: ~3 days for the combined Item 0 + Item 1.a PR (heavier than the Round 2 estimate — adds `metadata_merge` schema fields on `task_add`/`exploration_add` plus the milestone_add JSON return contract, JSON `_err` envelope refactor across all eight write tools, `_iso_default` helper with literal `Z` suffix, `db.list_section` signature change with default-active-equivalent and `status_in` parameter, definition-aware CHECK migration with `pg_get_constraintdef` inspection and SQL generation from `STATUS_VALUES`, sibling `_apply_metadata_gin_index` step, `db.add_entry` postmortem invariant, plus the mandatory backward-compat audit pass), ~½ day for Items 1.b/1.c docs, ~1 day for Item 3 (deterministic followup-key derivation requires careful instruction-file rewrite + test fixtures), ~½ day for Item 6 (smaller scope but harder ACs), ~½ day for Item 2, ~1 day for Item 4 (step reorder + branch regex + abort flags), Item 5 is passive. Total ~6.5 days focused work.

--- a/radbot/mcp_server/tools/__init__.py
+++ b/radbot/mcp_server/tools/__init__.py
@@ -1,6 +1,7 @@
 """Tool registry for the radbot MCP server.
 
-Each submodule (`telos`, `wiki`, `projects`, `tasks`, `memory`) exposes:
+Each submodule (`telos`, `wiki`, `projects`, `project_tasks`, `tasks`,
+`memory`, `journal`) exposes:
 
 - `tools() -> list[mcp.types.Tool]` — tool definitions for ListTools
 - `async call(name: str, arguments: dict) -> list[TextContent]` — dispatcher
@@ -16,9 +17,9 @@ from typing import Any
 
 from mcp import types as mcp_types
 
-from . import memory, project_tasks, projects, tasks, telos, wiki
+from . import journal, memory, project_tasks, projects, tasks, telos, wiki
 
-_MODULES = [telos, wiki, projects, project_tasks, tasks, memory]
+_MODULES = [telos, wiki, projects, project_tasks, tasks, memory, journal]
 
 
 def all_tools() -> list[mcp_types.Tool]:

--- a/radbot/mcp_server/tools/journal.py
+++ b/radbot/mcp_server/tools/journal.py
@@ -1,0 +1,161 @@
+"""Journal-write MCP tools — direct wrappers around `telos_db.add_entry` /
+`telos_db.update_entry` for `Section.JOURNAL`.
+
+Item 0.a of the council-loop-polish EX. The MCP `journal_add` does NOT
+delegate to the agent-side `telos_add_journal` (which has a narrower
+signature — `entry: str`, `event_type: str = ""`, `related_refs: list[str]`
+— and no return-shape contract). Going straight to `telos_db.add_entry`
+gets us:
+
+  - Arbitrary `metadata` dict (Scout's postmortem flow needs richer
+    metadata than `event_type` + `related_refs`).
+  - The structured-return contract (Item 0.b.iv) — `TextContent.text` is
+    JSON: `{"status": "success", "ref_code": "<JR<N>>", "entry_id":
+    "<uuid>", "section": "journal"}`.
+  - The shared-layer postmortem invariant (Item 3) — when
+    `metadata.type == "postmortem"`, `metadata.processed_at` MUST be set
+    (initially `null`); the invariant is enforced inside `db.add_entry`,
+    so it covers this caller automatically.
+
+`journal_update` supports `metadata_merge` and a journal-meaningful
+`status` enum (`active`, `completed`, `archived`, `superseded` — the
+lifecycle states like `proposed/in_review/approved/executing` are nonsense
+for journal rows and excluded by the JSON-schema enum).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp import types as mcp_types
+
+# Lifecycle states are nonsense for journal rows; restrict the allowed set.
+_JOURNAL_STATUSES = ["active", "completed", "archived", "superseded"]
+
+
+def tools() -> list[mcp_types.Tool]:
+    return [
+        mcp_types.Tool(
+            name="journal_add",
+            description=(
+                "Append a Telos journal entry. Auto-assigns a `JR<N>` "
+                "ref_code. `metadata` is an arbitrary JSONB dict. "
+                "Postmortem entries (`metadata.type == 'postmortem'`) "
+                "MUST include `metadata.processed_at` (initially `null`) "
+                "or the call fails — this enables the unprocessed-postmortem "
+                "query Scout's processing pass depends on. Returns JSON: "
+                "`{status, ref_code, entry_id, section}`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "entry": {"type": "string"},
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                },
+                "required": ["entry"],
+                "additionalProperties": False,
+            },
+        ),
+        mcp_types.Tool(
+            name="journal_update",
+            description=(
+                "Update a Telos journal entry by `ref_code`. Supports "
+                "`metadata_merge` (shallow JSONB merge) and a "
+                "journal-meaningful `status` (active/completed/archived/"
+                "superseded — lifecycle states are not valid here). Returns "
+                "JSON: `{status, ref_code}` on success; `_err` envelope on "
+                "failure."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref_code": {"type": "string"},
+                    "metadata_merge": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": _JOURNAL_STATUSES,
+                    },
+                },
+                "required": ["ref_code"],
+                "additionalProperties": False,
+            },
+        ),
+    ]
+
+
+async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
+    if name == "journal_add":
+        return [_do_journal_add(arguments)]
+    if name == "journal_update":
+        return [_do_journal_update(arguments)]
+    raise KeyError(name)
+
+
+def _json_err(msg: str) -> mcp_types.TextContent:
+    return mcp_types.TextContent(
+        type="text", text=json.dumps({"status": "error", "message": msg})
+    )
+
+
+def _json_ok_add(row: Any) -> mcp_types.TextContent:
+    payload = {
+        "status": "success",
+        "ref_code": row.ref_code,
+        "entry_id": str(row.entry_id) if row.entry_id else None,
+        "section": row.section.value,
+    }
+    return mcp_types.TextContent(type="text", text=json.dumps(payload))
+
+
+def _json_ok_update(ref_code: str, **extras: Any) -> mcp_types.TextContent:
+    payload: dict[str, Any] = {"status": "success", "ref_code": ref_code}
+    if "status" in extras:
+        extras["entry_status"] = extras.pop("status")
+    payload.update(extras)
+    return mcp_types.TextContent(type="text", text=json.dumps(payload))
+
+
+def _do_journal_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    entry = (arguments.get("entry") or "").strip()
+    if not entry:
+        return _json_err("`entry` is required and must not be whitespace.")
+    metadata = arguments.get("metadata") or {}
+
+    try:
+        row = telos_db.add_entry(Section.JOURNAL, entry, metadata=metadata)
+    except ValueError as exc:
+        return _json_err(str(exc))
+    return _json_ok_add(row)
+
+
+def _do_journal_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
+    from radbot.tools.telos import db as telos_db
+    from radbot.tools.telos.models import Section
+
+    ref_code = arguments["ref_code"]
+    metadata_merge = arguments.get("metadata_merge") or None
+    status = arguments.get("status")
+
+    if status is not None and status not in _JOURNAL_STATUSES:
+        return _json_err(
+            f"invalid journal status {status!r}. valid: {_JOURNAL_STATUSES}."
+        )
+
+    update_kwargs: dict[str, Any] = {"metadata_merge": metadata_merge}
+    if status is not None:
+        update_kwargs["status"] = status
+
+    row = telos_db.update_entry(Section.JOURNAL, ref_code, **update_kwargs)
+    if row is None:
+        return _json_err(f"No journal entry with ref_code `{ref_code}`.")
+    return _json_ok_update(ref_code, status=status, metadata_merge=metadata_merge)

--- a/radbot/mcp_server/tools/project_tasks.py
+++ b/radbot/mcp_server/tools/project_tasks.py
@@ -11,10 +11,29 @@ Children all live in the single `telos_entries` table in sections
 `milestones`, `project_tasks`, `explorations`. Their ownership is stored
 as `metadata.parent_project` (+ optional `metadata.parent_milestone`
 for tasks). Never hard-deletes — archive only.
+
+Return contract (Item 0.b.iv of the council-loop-polish EX). The four
+creation handlers — `_do_task_add`, `_do_exploration_add`,
+`_do_milestone_add`, and the new `_do_journal_add` (in `journal.py`) —
+return JSON `TextContent`:
+
+    {"status": "success", "ref_code": "<NEW>", "entry_id": "<uuid>",
+     "section": "<section>"}
+
+Errors return JSON too:
+
+    {"status": "error", "message": "<reason>"}
+
+The four `*_update` handlers + `journal_update` use the same JSON `_err`
+envelope so chained callers can branch on `payload["status"]` after
+`json.loads(response.text)` without try/except + heuristic detection.
+The terminal operations (`*_complete`, `*_archive`) keep human-readable
+text returns — callers there already know the ref_code.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -22,15 +41,25 @@ from mcp import types as mcp_types
 
 _VALID_TASK_STATUSES = {"backlog", "inprogress", "done"}
 
+# Whitelist keys the typed schema fields drive — they overlay any
+# `metadata_merge` value supplied by the caller (silent collision; council
+# 3-of-3 consensus to keep silent rather than error, for LLM tool-call
+# ergonomics).
+_TASK_WHITELIST_KEYS = ("title", "category", "task_status", "parent_milestone")
+
 
 def tools() -> list[mcp_types.Tool]:
+    from radbot.tools.telos.models import STATUS_VALUES
+
+    sorted_status = sorted(STATUS_VALUES)
     return [
         mcp_types.Tool(
             name="milestone_add",
             description=(
                 "Add a milestone under a project. Auto-assigns an `MS<N>` "
                 "ref_code. `deadline` is optional ISO date. `details` is "
-                "appended below the title in content."
+                "appended below the title in content. Returns JSON: "
+                "`{status, ref_code, entry_id, section}`."
             ),
             inputSchema={
                 "type": "object",
@@ -42,6 +71,15 @@ def tools() -> list[mcp_types.Tool]:
                     "title": {"type": "string"},
                     "deadline": {"type": "string"},
                     "details": {"type": "string"},
+                    "metadata_merge": {
+                        "type": "object",
+                        "description": (
+                            "Extra keys to attach to `metadata` at creation. "
+                            "Whitelist keys (parent_project, deadline) win on "
+                            "collision."
+                        ),
+                        "additionalProperties": True,
+                    },
                 },
                 "required": ["parent_project", "title"],
                 "additionalProperties": False,
@@ -70,7 +108,9 @@ def tools() -> list[mcp_types.Tool]:
                 "Create a project task under an existing project (and "
                 "optionally a milestone). Auto-assigns a `PT<N>` ref_code. "
                 "`task_status` ∈ backlog / inprogress / done, default "
-                "backlog."
+                "backlog. `metadata_merge` attaches arbitrary metadata "
+                "atomically at creation (whitelist keys win on collision). "
+                "Returns JSON: `{status, ref_code, entry_id, section}`."
             ),
             inputSchema={
                 "type": "object",
@@ -84,6 +124,15 @@ def tools() -> list[mcp_types.Tool]:
                         "type": "string",
                         "enum": ["backlog", "inprogress", "done"],
                     },
+                    "metadata_merge": {
+                        "type": "object",
+                        "description": (
+                            "Extra keys to attach to `metadata` at creation. "
+                            "Whitelist keys (title, category, task_status, "
+                            "parent_milestone, parent_project) win on collision."
+                        ),
+                        "additionalProperties": True,
+                    },
                 },
                 "required": ["parent_project", "description"],
                 "additionalProperties": False,
@@ -92,9 +141,11 @@ def tools() -> list[mcp_types.Tool]:
         mcp_types.Tool(
             name="task_update",
             description=(
-                "Update a project task in place. `description` replaces "
-                "content; other fields shallow-merge into metadata. Pass "
-                "an empty string to clear an optional field."
+                "Update a project task in place. `description` (optional) "
+                "replaces content when present and non-whitespace; absent "
+                "= leave body unchanged. Whitelisted fields shallow-merge "
+                "into metadata; whitelist keys win on collision with "
+                "`metadata_merge`."
             ),
             inputSchema={
                 "type": "object",
@@ -108,6 +159,15 @@ def tools() -> list[mcp_types.Tool]:
                         "enum": ["backlog", "inprogress", "done"],
                     },
                     "parent_milestone": {"type": "string"},
+                    "metadata_merge": {
+                        "type": "object",
+                        "description": (
+                            "Extra keys to merge into `metadata`. "
+                            "Whitelist keys (title, category, task_status, "
+                            "parent_milestone) win on collision."
+                        ),
+                        "additionalProperties": True,
+                    },
                 },
                 "required": ["ref_code"],
                 "additionalProperties": False,
@@ -148,7 +208,12 @@ def tools() -> list[mcp_types.Tool]:
             description=(
                 "Record an open exploration / research thread under a "
                 "project. Auto-assigns an `EX<N>` ref_code. `notes` is "
-                "appended below the topic in content."
+                "appended below the topic in content. Optional `status` "
+                "lets Scout create the row directly in a lifecycle state "
+                "(e.g. `proposed`); defaults to `active` for back-compat. "
+                "`metadata_merge` attaches arbitrary metadata atomically "
+                "(whitelist key `parent_project` wins on collision). "
+                "Returns JSON: `{status, ref_code, entry_id, section}`."
             ),
             inputSchema={
                 "type": "object",
@@ -156,6 +221,18 @@ def tools() -> list[mcp_types.Tool]:
                     "parent_project": {"type": "string"},
                     "topic": {"type": "string"},
                     "notes": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": sorted_status,
+                    },
+                    "metadata_merge": {
+                        "type": "object",
+                        "description": (
+                            "Extra keys to attach to `metadata` at creation. "
+                            "Whitelist key `parent_project` wins on collision."
+                        ),
+                        "additionalProperties": True,
+                    },
                 },
                 "required": ["parent_project", "topic"],
                 "additionalProperties": False,
@@ -164,11 +241,13 @@ def tools() -> list[mcp_types.Tool]:
         mcp_types.Tool(
             name="exploration_update",
             description=(
-                "Update an exploration in place. `content` (required) "
-                "replaces the exploration's body — typically the full "
-                "5-role plan markdown, often with a `## Council Review` "
-                "trailer. Other fields shallow-merge into metadata. Pass "
-                "empty string to clear an optional field."
+                "Update an exploration in place. `content` (optional) "
+                "replaces the body when present and non-whitespace; absent "
+                "= leave body unchanged; empty/whitespace = error. "
+                "`status` flips lifecycle state (validated against the "
+                "extended STATUS_VALUES set). Whitelisted fields shallow-"
+                "merge into metadata; whitelist keys win on collision with "
+                "`metadata_merge`."
             ),
             inputSchema={
                 "type": "object",
@@ -177,8 +256,21 @@ def tools() -> list[mcp_types.Tool]:
                     "content": {"type": "string"},
                     "parent_project": {"type": "string"},
                     "parent_milestone": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": sorted_status,
+                    },
+                    "metadata_merge": {
+                        "type": "object",
+                        "description": (
+                            "Extra keys to merge into `metadata`. "
+                            "Whitelist keys (parent_project, "
+                            "parent_milestone) win on collision."
+                        ),
+                        "additionalProperties": True,
+                    },
                 },
-                "required": ["ref_code", "content"],
+                "required": ["ref_code"],
                 "additionalProperties": False,
             },
         ),
@@ -206,14 +298,7 @@ def tools() -> list[mcp_types.Tool]:
 
 async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextContent]:
     if name == "milestone_add":
-        return [
-            _do_milestone_add(
-                arguments["parent_project"],
-                arguments["title"],
-                arguments.get("deadline"),
-                arguments.get("details"),
-            )
-        ]
+        return [_do_milestone_add(arguments)]
     if name == "milestone_complete":
         return [
             _do_milestone_complete(
@@ -235,13 +320,7 @@ async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextConte
             )
         ]
     if name == "exploration_add":
-        return [
-            _do_exploration_add(
-                arguments["parent_project"],
-                arguments["topic"],
-                arguments.get("notes"),
-            )
-        ]
+        return [_do_exploration_add(arguments)]
     if name == "exploration_update":
         return [_do_exploration_update(arguments)]
     if name == "exploration_archive":
@@ -259,8 +338,47 @@ async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextConte
 # ---------------------------------------------------------------------------
 
 
-def _err(msg: str) -> mcp_types.TextContent:
+def _text_err(msg: str) -> mcp_types.TextContent:
+    """Plain-text error for terminal operations whose callers already know
+    the ref_code (`*_complete`, `*_archive`, `milestone_complete`)."""
     return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
+
+
+def _json_err(msg: str) -> mcp_types.TextContent:
+    """JSON error envelope for `*_add` and `*_update` handlers — uniform
+    with the success contract so chained callers can branch on
+    `json.loads(response.text)["status"]` without try/except."""
+    return mcp_types.TextContent(
+        type="text", text=json.dumps({"status": "error", "message": msg})
+    )
+
+
+def _json_ok_add(row: Any) -> mcp_types.TextContent:
+    """Structured success envelope for the four `*_add` handlers
+    (Item 0.b.iv contract)."""
+    payload = {
+        "status": "success",
+        "ref_code": row.ref_code,
+        "entry_id": str(row.entry_id) if row.entry_id else None,
+        "section": row.section.value,
+    }
+    return mcp_types.TextContent(type="text", text=json.dumps(payload))
+
+
+def _json_ok_update(ref_code: str, **extras: Any) -> mcp_types.TextContent:
+    """Structured success envelope for `*_update` handlers.
+
+    Envelope key is `status: "success"` — same shape as the *_add contract
+    (Item 0.b.iv) so consumers can branch on `payload["status"]` uniformly
+    across every write tool. Any `status` key in extras is renamed to
+    `entry_status` so the echoed lifecycle value never collides with the
+    envelope discriminator.
+    """
+    payload: dict[str, Any] = {"status": "success", "ref_code": ref_code}
+    if "status" in extras:
+        extras["entry_status"] = extras.pop("status")
+    payload.update(extras)
+    return mcp_types.TextContent(type="text", text=json.dumps(payload))
 
 
 def _now_iso() -> str:
@@ -273,7 +391,7 @@ def _require_project(ref_code: str):
 
     project = telos_db.get_entry(Section.PROJECTS, ref_code)
     if project is None:
-        return None, _err(f"No Telos project with ref_code `{ref_code}`.")
+        return None, _json_err(f"No Telos project with ref_code `{ref_code}`.")
     return project, None
 
 
@@ -283,35 +401,65 @@ def _require_milestone(ref_code: str):
 
     row = telos_db.get_entry(Section.MILESTONES, ref_code)
     if row is None:
-        return None, _err(f"No milestone with ref_code `{ref_code}`.")
+        return None, _json_err(f"No milestone with ref_code `{ref_code}`.")
     return row, None
 
 
-def _do_milestone_add(
-    parent_project: str, title: str, deadline: str | None, details: str | None
-) -> mcp_types.TextContent:
+def _validate_status(value: str | None):
+    """Validate a `status` argument against the extended `STATUS_VALUES`
+    set. Returns `(value, None)` on pass, `(None, error_TextContent)` on
+    fail."""
+    from radbot.tools.telos.models import STATUS_VALUES
+
+    if value is None:
+        return None, None
+    if value not in STATUS_VALUES:
+        return None, _json_err(
+            f"invalid status {value!r}. valid: {sorted(STATUS_VALUES)}."
+        )
+    return value, None
+
+
+def _merge_with_whitelist(
+    caller_metadata: dict[str, Any] | None,
+    whitelist_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Combine caller-supplied `metadata_merge` with the typed-field-derived
+    whitelist dict. Per the load-bearing precedence rule (Item 0.b.iii), the
+    whitelist keys WIN on collision — silently. Tests cover both no-collision
+    survival and silent-collision paths."""
+    combined: dict[str, Any] = {}
+    if caller_metadata:
+        combined.update(caller_metadata)
+    combined.update(whitelist_metadata)
+    return combined
+
+
+def _do_milestone_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
     from radbot.tools.telos import db as telos_db
     from radbot.tools.telos.models import Section
 
+    parent_project = arguments["parent_project"]
+    title = arguments.get("title")
+    deadline = arguments.get("deadline")
+    details = arguments.get("details")
+    caller_meta = arguments.get("metadata_merge")
+
     clean_title = (title or "").strip()
     if not clean_title:
-        return _err("`title` is required and must not be whitespace.")
+        return _json_err("`title` is required and must not be whitespace.")
     _p, err = _require_project(parent_project)
     if err is not None:
         return err
 
     content = clean_title if not details else f"{clean_title}\n\n{details}"
-    metadata: dict[str, Any] = {"parent_project": parent_project}
+    whitelist: dict[str, Any] = {"parent_project": parent_project}
     if deadline:
-        metadata["deadline"] = deadline
+        whitelist["deadline"] = deadline
+    metadata = _merge_with_whitelist(caller_meta, whitelist)
+
     row = telos_db.add_entry(Section.MILESTONES, content, metadata=metadata)
-    return mcp_types.TextContent(
-        type="text",
-        text=(
-            f"Added milestone `{row.ref_code}` under `{parent_project}` — "
-            f"{clean_title!r}"
-        ),
-    )
+    return _json_ok_add(row)
 
 
 def _do_milestone_complete(
@@ -330,7 +478,7 @@ def _do_milestone_complete(
         metadata_merge=meta,
     )
     if row is None:
-        return _err(f"No milestone with ref_code `{ref_code}`.")
+        return _text_err(f"No milestone with ref_code `{ref_code}`.")
     bits = [f"completed_at={meta['completed_at']}"]
     if resolution:
         bits.append(f"resolution={resolution!r}")
@@ -347,7 +495,7 @@ def _do_task_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
     description = (arguments.get("description") or "").strip()
     parent_project = arguments["parent_project"]
     if not description:
-        return _err("`description` is required and must not be whitespace.")
+        return _json_err("`description` is required and must not be whitespace.")
     _p, err = _require_project(parent_project)
     if err is not None:
         return err
@@ -360,31 +508,26 @@ def _do_task_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
 
     task_status = arguments.get("task_status") or "backlog"
     if task_status not in _VALID_TASK_STATUSES:
-        return _err(
+        return _json_err(
             f"invalid task_status {task_status!r}. "
             f"valid: {sorted(_VALID_TASK_STATUSES)}."
         )
 
-    metadata: dict[str, Any] = {
+    whitelist: dict[str, Any] = {
         "parent_project": parent_project,
         "task_status": task_status,
     }
     if parent_milestone:
-        metadata["parent_milestone"] = parent_milestone
+        whitelist["parent_milestone"] = parent_milestone
     if arguments.get("title"):
-        metadata["title"] = arguments["title"]
+        whitelist["title"] = arguments["title"]
     if arguments.get("category"):
-        metadata["category"] = arguments["category"]
+        whitelist["category"] = arguments["category"]
+
+    metadata = _merge_with_whitelist(arguments.get("metadata_merge"), whitelist)
 
     row = telos_db.add_entry(Section.PROJECT_TASKS, description, metadata=metadata)
-    return mcp_types.TextContent(
-        type="text",
-        text=(
-            f"Added task `{row.ref_code}` under `{parent_project}`"
-            + (f" / `{parent_milestone}`" if parent_milestone else "")
-            + f" — status={task_status}"
-        ),
-    )
+    return _json_ok_add(row)
 
 
 def _do_task_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
@@ -393,29 +536,34 @@ def _do_task_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
 
     ref_code = arguments["ref_code"]
     content: str | None = None
-    description = arguments.get("description")
-    if description is not None:
-        clean = description.strip()
-        if not clean:
-            return _err("`description` must not be whitespace if provided.")
-        content = clean
+    if "description" in arguments:
+        description = arguments["description"]
+        if description is None or (
+            isinstance(description, str) and not description.strip()
+        ):
+            return _json_err(
+                "description must not be whitespace if supplied; "
+                "omit the key to leave body unchanged."
+            )
+        content = description.strip()
 
-    meta: dict[str, Any] = {}
-    for key in ("title", "category", "task_status", "parent_milestone"):
+    whitelist: dict[str, Any] = {}
+    for key in _TASK_WHITELIST_KEYS:
         if key in arguments and arguments[key] is not None:
             value = arguments[key]
             if key == "task_status" and value and value not in _VALID_TASK_STATUSES:
-                return _err(
+                return _json_err(
                     f"invalid task_status {value!r}. "
                     f"valid: {sorted(_VALID_TASK_STATUSES)}."
                 )
-            # Empty string → remove key via shallow JSONB merge with null.
-            meta[key] = value if value != "" else None
+            whitelist[key] = value if value != "" else None
 
-    if meta.get("parent_milestone"):
-        _ms, err = _require_milestone(meta["parent_milestone"])
+    if whitelist.get("parent_milestone"):
+        _ms, err = _require_milestone(whitelist["parent_milestone"])
         if err is not None:
             return err
+
+    meta = _merge_with_whitelist(arguments.get("metadata_merge"), whitelist)
 
     row = telos_db.update_entry(
         Section.PROJECT_TASKS,
@@ -424,17 +572,9 @@ def _do_task_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
         metadata_merge=meta or None,
     )
     if row is None:
-        return _err(f"No task with ref_code `{ref_code}`.")
-    bits: list[str] = []
-    if content is not None:
-        bits.append("description updated")
-    if meta:
-        bits.append(f"metadata_merge={meta}")
-    if not bits:
-        bits.append("no-op")
-    return mcp_types.TextContent(
-        type="text",
-        text=f"Updated task `{ref_code}` — {' · '.join(bits)}",
+        return _json_err(f"No task with ref_code `{ref_code}`.")
+    return _json_ok_update(
+        ref_code, content_updated=content is not None, metadata_merge=meta
     )
 
 
@@ -448,7 +588,7 @@ def _do_task_complete(ref_code: str) -> mcp_types.TextContent:
         metadata_merge={"task_status": "done", "completed_at": _now_iso()},
     )
     if row is None:
-        return _err(f"No task with ref_code `{ref_code}`.")
+        return _text_err(f"No task with ref_code `{ref_code}`.")
     return mcp_types.TextContent(type="text", text=f"Completed task `{ref_code}`.")
 
 
@@ -458,35 +598,40 @@ def _do_task_archive(ref_code: str, reason: str | None) -> mcp_types.TextContent
 
     ok = telos_db.archive_entry(Section.PROJECT_TASKS, ref_code, reason=reason or None)
     if not ok:
-        return _err(f"No task with ref_code `{ref_code}`.")
+        return _text_err(f"No task with ref_code `{ref_code}`.")
     tail = f" (reason: {reason})" if reason else ""
     return mcp_types.TextContent(type="text", text=f"Archived task `{ref_code}`.{tail}")
 
 
-def _do_exploration_add(
-    parent_project: str, topic: str, notes: str | None
-) -> mcp_types.TextContent:
+def _do_exploration_add(arguments: dict[str, Any]) -> mcp_types.TextContent:
     from radbot.tools.telos import db as telos_db
     from radbot.tools.telos.models import Section
 
+    parent_project = arguments["parent_project"]
+    topic = arguments.get("topic")
+    notes = arguments.get("notes")
+
     clean_topic = (topic or "").strip()
     if not clean_topic:
-        return _err("`topic` is required and must not be whitespace.")
+        return _json_err("`topic` is required and must not be whitespace.")
     _p, err = _require_project(parent_project)
     if err is not None:
         return err
 
+    status, err = _validate_status(arguments.get("status"))
+    if err is not None:
+        return err
+
     content = clean_topic if not notes else f"{clean_topic}\n\n{notes}"
-    row = telos_db.add_entry(
-        Section.EXPLORATIONS, content, metadata={"parent_project": parent_project}
-    )
-    return mcp_types.TextContent(
-        type="text",
-        text=(
-            f"Added exploration `{row.ref_code}` under `{parent_project}` — "
-            f"{clean_topic!r}"
-        ),
-    )
+    whitelist: dict[str, Any] = {"parent_project": parent_project}
+    metadata = _merge_with_whitelist(arguments.get("metadata_merge"), whitelist)
+
+    add_kwargs: dict[str, Any] = {"metadata": metadata}
+    if status is not None:
+        add_kwargs["status"] = status
+
+    row = telos_db.add_entry(Section.EXPLORATIONS, content, **add_kwargs)
+    return _json_ok_add(row)
 
 
 def _do_exploration_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
@@ -494,40 +639,52 @@ def _do_exploration_update(arguments: dict[str, Any]) -> mcp_types.TextContent:
     from radbot.tools.telos.models import Section
 
     ref_code = arguments["ref_code"]
-    content = (arguments.get("content") or "").strip()
-    if not content:
-        return _err("`content` is required and must not be whitespace.")
 
-    meta: dict[str, Any] = {}
+    content: str | None = None
+    if "content" in arguments:
+        raw = arguments["content"]
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
+            return _json_err(
+                "content must not be whitespace if supplied; "
+                "omit the key to leave body unchanged."
+            )
+        content = raw.strip()
+
+    status, err = _validate_status(arguments.get("status"))
+    if err is not None:
+        return err
+
+    whitelist: dict[str, Any] = {}
     for key in ("parent_project", "parent_milestone"):
         if key in arguments and arguments[key] is not None:
-            # Empty string → remove key via shallow JSONB merge with null.
-            meta[key] = arguments[key] if arguments[key] != "" else None
+            whitelist[key] = arguments[key] if arguments[key] != "" else None
 
-    # Validate parent refs if being set (non-empty)
-    if meta.get("parent_project"):
-        _p, err = _require_project(meta["parent_project"])
+    if whitelist.get("parent_project"):
+        _p, err = _require_project(whitelist["parent_project"])
         if err is not None:
             return err
-    if meta.get("parent_milestone"):
-        _ms, err = _require_milestone(meta["parent_milestone"])
+    if whitelist.get("parent_milestone"):
+        _ms, err = _require_milestone(whitelist["parent_milestone"])
         if err is not None:
             return err
 
-    row = telos_db.update_entry(
-        Section.EXPLORATIONS,
-        ref_code,
-        content=content,
-        metadata_merge=meta or None,
-    )
+    meta = _merge_with_whitelist(arguments.get("metadata_merge"), whitelist)
+
+    update_kwargs: dict[str, Any] = {
+        "content": content,
+        "metadata_merge": meta or None,
+    }
+    if status is not None:
+        update_kwargs["status"] = status
+
+    row = telos_db.update_entry(Section.EXPLORATIONS, ref_code, **update_kwargs)
     if row is None:
-        return _err(f"No exploration with ref_code `{ref_code}`.")
-    bits = ["content updated"]
-    if meta:
-        bits.append(f"metadata_merge={meta}")
-    return mcp_types.TextContent(
-        type="text",
-        text=f"Updated exploration `{ref_code}` — {' · '.join(bits)}",
+        return _json_err(f"No exploration with ref_code `{ref_code}`.")
+    return _json_ok_update(
+        ref_code,
+        content_updated=content is not None,
+        metadata_merge=meta,
+        status=status,
     )
 
 
@@ -537,7 +694,7 @@ def _do_exploration_archive(ref_code: str, reason: str | None) -> mcp_types.Text
 
     ok = telos_db.archive_entry(Section.EXPLORATIONS, ref_code, reason=reason or None)
     if not ok:
-        return _err(f"No exploration with ref_code `{ref_code}`.")
+        return _text_err(f"No exploration with ref_code `{ref_code}`.")
     tail = f" (reason: {reason})" if reason else ""
     return mcp_types.TextContent(
         type="text", text=f"Archived exploration `{ref_code}`.{tail}"

--- a/radbot/mcp_server/tools/telos.py
+++ b/radbot/mcp_server/tools/telos.py
@@ -1,14 +1,33 @@
 """Telos MCP tools — expose radbot's user-context store to external clients.
 
-All tools return markdown `TextContent`. Heavy imports are lazy to keep
-module-import cost minimal.
+Read-only tools. Two return formats per Item 0.c of the council-loop-polish
+EX:
+  - `format="markdown"` (default, back-compat) — rendered for human/LLM eyes.
+  - `format="json"` — `TextContent.text = json.dumps(payload)` parseable via
+    `json.loads(response.text)`. Timestamps are ISO 8601 with literal `Z`
+    suffix (UTC); `metadata` is the decoded JSONB dict; UUIDs render as
+    strings; `Section` enums render as their `.value`. The single source of
+    truth is `_entry_to_json_dict` + `_iso_default` below.
+
+Heavy imports are lazy to keep module-import cost minimal.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 from mcp import types as mcp_types
+
+if TYPE_CHECKING:
+    from radbot.tools.telos.models import Entry
+
+
+_FORMAT_MARKDOWN = "markdown"
+_FORMAT_JSON = "json"
+_VALID_FORMATS = (_FORMAT_MARKDOWN, _FORMAT_JSON)
 
 
 def tools() -> list[mcp_types.Tool]:
@@ -30,11 +49,19 @@ def tools() -> list[mcp_types.Tool]:
         mcp_types.Tool(
             name="telos_get_section",
             description=(
-                "Return all entries in one Telos section as markdown. "
+                "Return all entries in one Telos section. Default format is "
+                "markdown; pass `format='json'` for `{\"entries\": [...]}` "
+                "parseable via `json.loads(response.text)`. "
+                "`metadata_filter` (JSONB `@>`) restricts to rows whose "
+                "`metadata` contains the supplied object. Default "
+                "`include_inactive=false` excludes completed/archived/"
+                "superseded — but lifecycle states (proposed/in_review/"
+                "approved/executing) are included by default. "
                 "Sections: identity, history, problems, mission, narratives, "
-                "goals, challenges, strategies, projects, wisdom, ideas, "
-                "predictions, wrong_about, best_books, best_movies, best_music, "
-                "taste, traumas, metrics, journal."
+                "goals, challenges, strategies, projects, milestones, "
+                "project_tasks, explorations, wisdom, ideas, predictions, "
+                "wrong_about, best_books, best_movies, best_music, taste, "
+                "traumas, metrics, journal."
             ),
             inputSchema={
                 "type": "object",
@@ -45,8 +72,28 @@ def tools() -> list[mcp_types.Tool]:
                     },
                     "include_inactive": {
                         "type": "boolean",
-                        "description": "Include completed/archived entries. Default false.",
+                        "description": (
+                            "Include completed/archived/superseded entries. "
+                            "Default false (active + lifecycle states)."
+                        ),
                         "default": False,
+                    },
+                    "metadata_filter": {
+                        "type": "object",
+                        "description": (
+                            "JSONB containment filter — entries whose "
+                            "`metadata` `@>` this object are returned."
+                        ),
+                        "additionalProperties": True,
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": list(_VALID_FORMATS),
+                        "description": (
+                            "Response format. `markdown` (default) for "
+                            "human-rendered; `json` for machine-parseable."
+                        ),
+                        "default": _FORMAT_MARKDOWN,
                     },
                 },
                 "required": ["section"],
@@ -58,13 +105,20 @@ def tools() -> list[mcp_types.Tool]:
             description=(
                 "Fetch one Telos entry by (section, ref_code). Use when you "
                 "know the ref_code (e.g. 'G1', 'P2', 'PRED3'). Identity's "
-                "ref_code is 'ME'."
+                "ref_code is 'ME'. Default format is markdown; pass "
+                "`format='json'` for `{\"entry\": {...}}` parseable via "
+                "`json.loads(response.text)`."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "section": {"type": "string"},
                     "ref_code": {"type": "string"},
+                    "format": {
+                        "type": "string",
+                        "enum": list(_VALID_FORMATS),
+                        "default": _FORMAT_MARKDOWN,
+                    },
                 },
                 "required": ["section", "ref_code"],
                 "additionalProperties": False,
@@ -103,10 +157,18 @@ async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextConte
             _render_section(
                 arguments["section"],
                 bool(arguments.get("include_inactive", False)),
+                arguments.get("metadata_filter") or None,
+                arguments.get("format", _FORMAT_MARKDOWN),
             )
         ]
     if name == "telos_get_entry":
-        return [_render_entry(arguments["section"], arguments["ref_code"])]
+        return [
+            _render_entry(
+                arguments["section"],
+                arguments["ref_code"],
+                arguments.get("format", _FORMAT_MARKDOWN),
+            )
+        ]
     if name == "telos_search_journal":
         return [
             _render_journal_search(
@@ -115,6 +177,54 @@ async def call(name: str, arguments: dict[str, Any]) -> list[mcp_types.TextConte
             )
         ]
     raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# JSON transport contract — single source of truth for `format="json"`.
+# Pinned by Item 0.c of the council-loop-polish EX: literal-Z timestamps,
+# explicit UUID + Section enum rendering, decoded JSONB metadata.
+# ---------------------------------------------------------------------------
+
+
+def _iso_default(obj: Any) -> str:
+    """JSON serializer for `datetime` → ISO 8601 with literal `Z` suffix;
+    `UUID` → `str`.
+
+    psycopg2 returns timezone-aware datetimes whose `.isoformat()` emits
+    `+00:00`, not the literal `Z` consumers parse against. Force UTC +
+    literal Z. psycopg2 also returns `uuid.UUID` for UUID columns;
+    `json.dumps` would crash without explicit handling — `entry_id` is in
+    every payload shape.
+    """
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, datetime):
+        return obj.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _entry_to_json_dict(entry: "Entry") -> dict:
+    """Convert a `telos_db.Entry` to a JSON-native dict for MCP transport.
+
+    Explicitly converts UUIDs and `Section` enums; leaves datetimes for
+    `_iso_default` to handle at `json.dumps` time. Used by both
+    `telos_get_entry` and `telos_get_section` to guarantee an identical
+    payload shape across the JSON contract.
+    """
+    return {
+        "ref_code": entry.ref_code,
+        "entry_id": str(entry.entry_id) if entry.entry_id else None,
+        "section": entry.section.value,
+        "status": entry.status,
+        "content": entry.content,
+        "metadata": entry.metadata or {},
+        "created_at": entry.created_at,
+        "updated_at": entry.updated_at,
+    }
+
+
+def _err_text(msg: str) -> mcp_types.TextContent:
+    return mcp_types.TextContent(type="text", text=f"**Error:** {msg}")
 
 
 def _render_full() -> mcp_types.TextContent:
@@ -129,22 +239,38 @@ def _render_full() -> mcp_types.TextContent:
     return mcp_types.TextContent(type="text", text=md)
 
 
-def _render_section(section: str, include_inactive: bool) -> mcp_types.TextContent:
+def _render_section(
+    section: str,
+    include_inactive: bool,
+    metadata_filter: dict[str, Any] | None,
+    fmt: str,
+) -> mcp_types.TextContent:
     from radbot.tools.telos import db as telos_db
     from radbot.tools.telos.models import SECTION_HEADERS, Section
+
+    if fmt not in _VALID_FORMATS:
+        return _err_text(f"unknown format `{fmt}`. Valid: {', '.join(_VALID_FORMATS)}")
 
     try:
         sec = Section(section.lower())
     except ValueError:
         valid = ", ".join(s.value for s in Section)
-        return mcp_types.TextContent(
-            type="text",
-            text=f"**Error:** unknown section `{section}`. Valid: {valid}",
-        )
+        return _err_text(f"unknown section `{section}`. Valid: {valid}")
 
-    status_filter = None if include_inactive else "active"
     order = "created_at_desc" if sec == Section.JOURNAL else "sort_order_asc"
-    entries = telos_db.list_section(sec, status=status_filter, order_by=order)
+    list_kwargs: dict[str, Any] = {"order_by": order}
+    if include_inactive:
+        list_kwargs["status_in"] = None
+    if metadata_filter:
+        list_kwargs["metadata_filter"] = metadata_filter
+
+    entries = telos_db.list_section(sec, **list_kwargs)
+
+    if fmt == _FORMAT_JSON:
+        payload = {"entries": [_entry_to_json_dict(e) for e in entries]}
+        return mcp_types.TextContent(
+            type="text", text=json.dumps(payload, default=_iso_default)
+        )
 
     header = SECTION_HEADERS.get(sec, sec.value.title())
     if not entries:
@@ -166,22 +292,29 @@ def _render_section(section: str, include_inactive: bool) -> mcp_types.TextConte
     return mcp_types.TextContent(type="text", text="\n".join(lines))
 
 
-def _render_entry(section: str, ref_code: str) -> mcp_types.TextContent:
+def _render_entry(section: str, ref_code: str, fmt: str) -> mcp_types.TextContent:
     from radbot.tools.telos import db as telos_db
     from radbot.tools.telos.models import Section
+
+    if fmt not in _VALID_FORMATS:
+        return _err_text(f"unknown format `{fmt}`. Valid: {', '.join(_VALID_FORMATS)}")
 
     try:
         sec = Section(section.lower())
     except ValueError:
-        return mcp_types.TextContent(
-            type="text", text=f"**Error:** unknown section `{section}`"
-        )
+        return _err_text(f"unknown section `{section}`")
 
     entry = telos_db.get_entry(sec, ref_code)
     if not entry:
         return mcp_types.TextContent(
             type="text",
             text=f"**Not found:** no entry `{ref_code}` in section `{sec.value}`",
+        )
+
+    if fmt == _FORMAT_JSON:
+        payload = {"entry": _entry_to_json_dict(entry)}
+        return mcp_types.TextContent(
+            type="text", text=json.dumps(payload, default=_iso_default)
         )
 
     lines = [

--- a/radbot/tools/telos/db.py
+++ b/radbot/tools/telos/db.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import psycopg2
@@ -16,13 +17,29 @@ import psycopg2.extras
 
 from radbot.db.connection import get_db_connection, get_db_cursor
 
-from .models import REF_PREFIX, STATUS_VALUES, Entry, Section
+from .models import ACTIVE_EQUIVALENT, REF_PREFIX, STATUS_VALUES, Entry, Section
 
 logger = logging.getLogger(__name__)
 
 
+# Sentinel for `list_section` to distinguish "argument omitted" from
+# "explicitly None" (which preserves the legacy "all statuses" semantics).
+_OMITTED: Any = object()
+
+_STATUS_CHECK_NAME = "telos_entries_status_check"
+
+
 def init_telos_schema() -> None:
-    """Create the telos_entries table (idempotent)."""
+    """Create the telos_entries table (idempotent) and apply sibling
+    migrations (GIN index on metadata, status CHECK constraint).
+
+    The two sibling steps run unconditionally on every web startup. They are
+    idempotent: `CREATE INDEX IF NOT EXISTS` is a no-op when the index
+    exists, and `_apply_status_check_constraint` short-circuits when the
+    existing CHECK definition's allowed-status set already matches
+    `STATUS_VALUES` (semantic comparison — Round 3 council blocker fix
+    against `pg_get_constraintdef` byte-string brittleness).
+    """
     from radbot.tools.shared.db_schema import init_table_schema
 
     init_table_schema(
@@ -47,6 +64,110 @@ def init_telos_schema() -> None:
             "CREATE INDEX idx_telos_journal_recent ON telos_entries (created_at DESC) WHERE section = 'journal';",
         ],
     )
+    _apply_metadata_gin_index()
+    _apply_status_check_constraint()
+
+
+def _apply_metadata_gin_index() -> None:
+    """Ensure the GIN index on telos_entries.metadata exists. Idempotent.
+
+    Sibling step inside `init_telos_schema` rather than an entry in
+    `init_table_schema`'s `create_index_sqls` list, because the latter only
+    fires when the table is freshly created — which would silently skip the
+    index on every existing deployment.
+    """
+    with get_db_connection() as conn:
+        with get_db_cursor(conn, commit=True) as cursor:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telos_metadata "
+                "ON telos_entries USING GIN (metadata);"
+            )
+
+
+def _extract_constraint_status_set(constraint_def: str) -> set[str]:
+    """Parse `pg_get_constraintdef` output and return the allowed status set.
+
+    Robust against PG normalization variations:
+      - "CHECK ((status = ANY (ARRAY['active'::text, 'completed'::text, ...])))"
+      - "CHECK (status IN ('active', 'completed', ...))"
+      - "CHECK ((status)::text = ANY ((ARRAY['active'::text, ...])::text[]))"
+    All forms have the allowed values as single-quoted string literals;
+    extract them.
+    """
+    return set(re.findall(r"'([^']+)'", constraint_def))
+
+
+def _add_status_check(cursor, status_values: set[str]) -> None:
+    """Emit `ALTER TABLE ADD CONSTRAINT` with quoted CSV values.
+
+    `STATUS_VALUES` is a closed set defined in `models.py` (never user
+    input), so the f-string interpolation is safe. `ALTER TABLE` does not
+    accept parameterized constraint definitions, so we cannot use %s here.
+    """
+    quoted_csv = ", ".join(f"'{s}'" for s in sorted(status_values))
+    cursor.execute(
+        f"ALTER TABLE telos_entries ADD CONSTRAINT "
+        f"{_STATUS_CHECK_NAME} CHECK (status IN ({quoted_csv}));"
+    )
+
+
+def _apply_status_check_constraint() -> None:
+    """Ensure `telos_entries.status` CHECK constraint matches `STATUS_VALUES`.
+
+    Idempotent + SEMANTICALLY definition-aware: replaces stale constraints
+    whose allowed-status set doesn't match `STATUS_VALUES`. Compare by
+    parsed SET (not by raw string) so PG normalization differences don't
+    trigger spurious DROP+ADD cycles on every startup — `ALTER TABLE`
+    takes an `ACCESS EXCLUSIVE` lock, so unnecessary cycles are wasteful
+    and risky on large tables.
+
+    Preflight: aborts with a clear error if any existing row carries a
+    status outside the new set, so a half-finished rollback can't make the
+    constraint apply silently fail later.
+    """
+    with get_db_connection() as conn:
+        with get_db_cursor(conn, commit=True) as cursor:
+            cursor.execute(
+                "SELECT COUNT(*), COALESCE(string_agg(DISTINCT status, ', '), '') "
+                "FROM telos_entries WHERE status != ALL(%s);",
+                (list(STATUS_VALUES),),
+            )
+            bad_count, bad_values = cursor.fetchone()
+            if bad_count > 0:
+                raise RuntimeError(
+                    f"telos_entries has {bad_count} rows with statuses outside "
+                    f"the new set: {bad_values}. Fix data before applying CHECK."
+                )
+
+            cursor.execute(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = %s AND conrelid = 'telos_entries'::regclass;",
+                (_STATUS_CHECK_NAME,),
+            )
+            row = cursor.fetchone()
+            existing_def = row[0] if row else None
+
+            if existing_def is None:
+                _add_status_check(cursor, STATUS_VALUES)
+                logger.info("Added telos_entries CHECK constraint")
+                return
+
+            existing_set = _extract_constraint_status_set(existing_def)
+            if existing_set == set(STATUS_VALUES):
+                return
+
+            logger.info(
+                "telos_entries CHECK constraint set mismatch; expected %s, got %s — replacing.",
+                sorted(STATUS_VALUES),
+                sorted(existing_set),
+            )
+            cursor.execute(
+                f"ALTER TABLE telos_entries DROP CONSTRAINT {_STATUS_CHECK_NAME};"
+            )
+            _add_status_check(cursor, STATUS_VALUES)
+            logger.info(
+                "Replaced telos_entries CHECK constraint with current STATUS_VALUES"
+            )
 
 
 def _row_to_entry(row: Dict[str, Any]) -> Entry:
@@ -97,7 +218,30 @@ def add_entry(
     sort_order: int = 0,
 ) -> Entry:
     """Insert a new entry. If ref_code is None and the section uses ref_codes,
-    one is auto-assigned."""
+    one is auto-assigned.
+
+    Postmortem invariant (enforced here, the lowest shared write layer, so
+    every writer is covered — MCP `journal_add`, agent-side
+    `telos_add_journal`, and direct `db.add_entry` calls): journal entries
+    flagged as postmortems must include `metadata.processed_at` (initially
+    `null`). Postgres JSONB `@>` matches `{"processed_at": null}` only when
+    the key is explicitly present and serialized as null — a missing key
+    does NOT match, which would silently break the
+    `telos_get_section({metadata_filter: {processed_at: null}})` query that
+    Scout's postmortem-processing pass depends on.
+    """
+    metadata = dict(metadata or {})
+
+    if section == Section.JOURNAL and (
+        metadata.get("type") == "postmortem"
+        or metadata.get("event_type") == "postmortem"
+    ):
+        if "processed_at" not in metadata:
+            raise ValueError(
+                "postmortem journal entries must include metadata.processed_at "
+                "(initially null) — this enables the unprocessed-postmortem query"
+            )
+
     if status not in STATUS_VALUES:
         raise ValueError(f"invalid status {status!r}")
     if ref_code is None and section in REF_PREFIX:
@@ -112,7 +256,7 @@ def add_entry(
         section.value,
         ref_code,
         content,
-        json.dumps(metadata or {}),
+        json.dumps(metadata),
         status,
         sort_order,
     )
@@ -222,21 +366,51 @@ def get_entry(section: Section, ref_code: str) -> Optional[Entry]:
 def list_section(
     section: Section,
     *,
-    status: Optional[str] = "active",
+    status: Any = _OMITTED,
+    status_in: Any = _OMITTED,
     limit: Optional[int] = None,
     order_by: str = "sort_order_asc",
+    metadata_filter: Optional[Dict[str, Any]] = None,
 ) -> List[Entry]:
     """List entries in a section.
 
-    `status=None` returns all statuses. Default "active".
+    Status semantics (sentinel pattern — closes the Round 3 council blocker
+    on default-arg back-compat collision):
+      - Both omitted → `ACTIVE_EQUIVALENT` (active + lifecycle-states).
+      - `status="active"` → legacy single-status filter (back-compat).
+      - `status=None` → all statuses (back-compat for the old `status=None`).
+      - `status_in=None` → all statuses.
+      - `status_in=[...]` → explicit set filter via `status = ANY(%s)`.
+      - Both supplied with non-sentinel values → `ValueError`.
+
+    `metadata_filter`, when non-empty, adds a JSONB `WHERE metadata @> %s`
+    clause — supported by the GIN index on `metadata` (see
+    `_apply_metadata_gin_index`).
+
     `order_by` options: sort_order_asc (default), created_at_desc,
     created_at_asc.
     """
-    where = ["section = %s"]
+    if status is not _OMITTED and status_in is not _OMITTED:
+        raise ValueError("status and status_in are mutually exclusive")
+    if status is _OMITTED and status_in is _OMITTED:
+        status_in = ACTIVE_EQUIVALENT
+
+    where: List[str] = ["section = %s"]
     params: List[Any] = [section.value]
-    if status is not None:
-        where.append("status = %s")
-        params.append(status)
+
+    if status is not _OMITTED:
+        if status is not None:
+            where.append("status = %s")
+            params.append(status)
+    else:
+        if status_in is not None:
+            where.append("status = ANY(%s)")
+            params.append(list(status_in))
+
+    if metadata_filter:
+        where.append("metadata @> %s::jsonb")
+        params.append(json.dumps(metadata_filter))
+
     order_clause = {
         "sort_order_asc": "sort_order ASC, created_at ASC",
         "created_at_desc": "created_at DESC",

--- a/radbot/tools/telos/models.py
+++ b/radbot/tools/telos/models.py
@@ -118,8 +118,30 @@ NEVER_ALWAYS_LOADED: set[Section] = {
     Section.TRAUMAS,
 }
 
-# Valid status values.
-STATUS_VALUES: set[str] = {"active", "completed", "archived", "superseded"}
+# Valid status values. The lifecycle states `proposed/in_review/approved/executing`
+# join the legacy four (`active/completed/archived/superseded`) per Item 1.a of
+# the council-loop-polish EX. The DB CHECK constraint on `telos_entries.status`
+# is regenerated from this set by `_apply_status_check_constraint()` in
+# `radbot/tools/telos/db.py` — keep this set as the single source of truth.
+STATUS_VALUES: set[str] = {
+    "active",
+    "completed",
+    "archived",
+    "superseded",
+    "proposed",
+    "in_review",
+    "approved",
+    "executing",
+}
+
+# Statuses that count as "in flight" — the default filter for `list_section`.
+# Includes legacy `active` plus all the lifecycle states so a freshly-created
+# `proposed` exploration shows up in default listings without callers having
+# to opt in. `completed/archived/superseded` are the inactive set, opt-in via
+# the MCP `include_inactive=True` flag (which translates to `status_in=None`).
+ACTIVE_EQUIVALENT: frozenset[str] = frozenset(
+    {"active", "proposed", "in_review", "approved", "executing"}
+)
 
 # Single identity ref_code (there's only one user).
 IDENTITY_REF = "ME"

--- a/radbot/tools/telos/telos_tools.py
+++ b/radbot/tools/telos/telos_tools.py
@@ -227,6 +227,15 @@ def telos_add_journal(
             metadata["event_type"] = event_type
         if related_refs:
             metadata["related_refs"] = list(related_refs)
+        # Defense-in-depth normalization for postmortem journal entries:
+        # populate the canonical `type` key alongside the legacy
+        # `event_type`, and pre-fill `processed_at: None` so the shared
+        # `db.add_entry` invariant (Item 3) accepts the row. Keeps the
+        # legacy event_type spelling working without making callers know
+        # about the new MCP `journal_add` contract.
+        if event_type == "postmortem":
+            metadata["type"] = "postmortem"
+            metadata.setdefault("processed_at", None)
         row = telos_db.add_entry(Section.JOURNAL, entry, metadata=metadata)
         return {"status": "success", "entry": _serialize_entry(row)}
 

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -13,7 +13,7 @@ Shared pool from `radbot/tools/todo/db/connection.py` (`get_db_pool()`, `get_db_
 | `scheduled_tasks` | `tools/scheduler/db.py` | `task_id` (UUID), `name`, `cron_expression`, `prompt`, `agent_name` (TEXT NOT NULL DEFAULT 'beto' — pins cron to a root agent; engine fires through `scheduler-offline-<agent_name>` session), `enabled`, `metadata` (JSONB) |
 | `scheduler_pending_results` | `tools/scheduler/db.py` | `result_id` (UUID), `task_name`, `prompt`, `response`, `session_id`, `delivered` |
 | `reminders` | `tools/reminders/db.py` | `reminder_id` (UUID), `message`, `remind_at` (TIMESTAMPTZ), `status`, `delivered` |
-| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section` (identity/mission/problems/goals/projects/challenges/wisdom/predictions/journal/…), `ref_code` (e.g. `G1`, `P2`, `ME`), `content`, `metadata` (JSONB — section-specific fields), `status` (active/completed/archived/superseded), `sort_order`, UNIQUE (section, ref_code). **Lifecycle for `project_tasks`:** completion sets `metadata.task_status='done'` + `metadata.completed_at` but leaves `status='active'`; the daily `task_archive` scheduler job (`archive_stale_done_tasks`, `tools/scheduler/defaults.py`) flips done rows older than `config:task_archive.since_days` (default 30) to `status='archived'` with `metadata.archived_reason='auto_stale_done'` so they stop bloating the default `telos_list_tasks` view (EX46 / PT115). |
+| `telos_entries` | `tools/telos/db.py` | `entry_id` (UUID), `section` (identity/mission/problems/goals/projects/challenges/wisdom/predictions/journal/…), `ref_code` (e.g. `G1`, `P2`, `ME`), `content`, `metadata` (JSONB — section-specific fields), `status` (`active`/`completed`/`archived`/`superseded` + lifecycle states `proposed`/`in_review`/`approved`/`executing` — extended set, see `STATUS_VALUES` in `radbot/tools/telos/models.py`), `sort_order`, UNIQUE (section, ref_code). DB-side `CHECK` constraint enforces the same set, regenerated automatically by `_apply_status_check_constraint()` on every web startup if the existing constraint's allowed-status set drifts from `STATUS_VALUES` (semantic comparison via parsed allowed-set, not byte-string equality, so PG normalization differences don't trigger spurious DROP+ADD cycles; preflight aborts if any row violates the new set). **Lifecycle for `project_tasks`:** completion sets `metadata.task_status='done'` + `metadata.completed_at` but leaves `status='active'`; the daily `task_archive` scheduler job (`archive_stale_done_tasks`, `tools/scheduler/defaults.py`) flips done rows older than `config:task_archive.since_days` (default 30) to `status='archived'` with `metadata.archived_reason='auto_stale_done'` so they stop bloating the default `telos_list_tasks` view (EX46 / PT115). **`db.add_entry` postmortem invariant:** journal entries flagged as postmortems (`metadata.type=='postmortem'` OR legacy `metadata.event_type=='postmortem'`) MUST include `metadata.processed_at` (initially `null`) — enforced at the shared write layer so every writer (MCP `journal_add`, agent-side `telos_add_journal`, direct `db.add_entry`) is covered. |
 | `webhook_definitions` | `tools/webhooks/db.py` | `webhook_id` (UUID), `name` (UNIQUE), `path_suffix` (UNIQUE), `prompt_template`, `secret` |
 | `radbot_credentials` | `credentials/store.py` | `name` (PK), `encrypted_value`, `salt`, `credential_type` |
 | `coder_workspaces` | `tools/claude_code/db.py` | `workspace_id` (UUID), `owner`, `repo`, `branch`, `local_path`, `status`, `last_session_id`, `name`, `description` |
@@ -39,7 +39,7 @@ Uses the `radbot_chathistory` database with its own pool in `web/db/connection.p
 |-------|-------|---------|
 | `notifications` | `idx_notifications_type`, `idx_notifications_unread` (partial on `read=FALSE`), `idx_notifications_created (DESC)` | Feed filtering |
 | `llm_usage_log` | `idx_llm_usage_log_created (created_at DESC)`, `idx_llm_usage_log_label` | Rolling cost queries + session filters |
-| `telos_entries` | `idx_telos_section_status`, `idx_telos_active` (partial on `status='active'`), `idx_telos_journal_recent (created_at DESC)` (partial on `section='journal'`) | Loader (always-loaded section queries) + journal recency |
+| `telos_entries` | `idx_telos_section_status`, `idx_telos_active` (partial on `status='active'`), `idx_telos_journal_recent (created_at DESC)` (partial on `section='journal'`), `idx_telos_metadata` (GIN on `metadata`) | Loader (always-loaded section queries) + journal recency. The GIN index backs `db.list_section`'s `metadata_filter` kwarg (JSONB `@>` containment) used by Scout's postmortem-processing dedup queries — sub-second latency at 5000-row scale. Applied via `_apply_metadata_gin_index()` as a sibling step inside `init_telos_schema()` so it lands on existing deployments (not just freshly-created tables). |
 
 ### Schema Init
 
@@ -47,6 +47,21 @@ All schemas idempotent via `init_*_schema()` with `CREATE TABLE IF NOT EXISTS` (
 
 - `tools/schemas.py:init_all_schemas()` — fail-loud central registry, invoked once at FastAPI startup (`web/app.py:initialize_app_startup()`) and once per pytest session (autouse fixture in `tests/conftest.py`).
 - `worker/__main__.py` — worker-side schema init (calls directly during bootstrap).
+
+`init_telos_schema()` runs three steps in order: (1) the `telos_entries` table via `init_table_schema()` (creates table + indexes only on first run); (2) `_apply_metadata_gin_index()` (idempotent `CREATE INDEX IF NOT EXISTS`); (3) `_apply_status_check_constraint()` (definition-aware semantic comparison — drops + re-adds the CHECK constraint only when its parsed allowed-status set drifts from `STATUS_VALUES`, so re-running on an unchanged DB is a cheap two-query no-op). Each sibling step is in the function explicitly because `init_table_schema`'s `create_index_sqls` only fires when the table is freshly created — relying on it for new indexes/constraints would silently skip them on every existing deployment.
+
+### `db.list_section` signature (sentinel pattern)
+
+`radbot/tools/telos/db.py:list_section(section, *, status=_OMITTED, status_in=_OMITTED, limit=None, order_by="sort_order_asc", metadata_filter=None)`. The two sentinels distinguish "argument omitted" from "argument explicitly None":
+
+- Both omitted → `status_in = ACTIVE_EQUIVALENT` (active + lifecycle states).
+- `status="active"` → legacy single-status filter (back-compat for any caller that explicitly wants legacy-active-only).
+- `status=None` → all statuses (back-compat for the old `status=None` "all" semantics).
+- `status_in=[...]` → explicit set filter via `status = ANY(%s)`.
+- Both supplied with non-sentinel values → `ValueError` ("mutually exclusive").
+- `metadata_filter={k: v, ...}` → JSONB `metadata @> %s::jsonb` clause (GIN-indexed).
+
+Code rollback to a pre-extension build is **unsafe** once any row holds a new lifecycle status (`proposed/in_review/approved/executing`) — `db.add_entry` and `db.update_entry` validation will reject writes touching those rows with a cryptic `ValueError`. Recovery: normalize the data first (`UPDATE telos_entries SET status='active' WHERE status IN ('proposed','in_review','approved','executing');`), then drop the CHECK constraint, then deploy the older build.
 
 ## Qdrant
 

--- a/specs/tools.md
+++ b/specs/tools.md
@@ -377,7 +377,7 @@ Exposes **radbot itself** as an MCP server so external clients (primarily Claude
 - **stdio**: `uv run python -m radbot.mcp_server` (local, no auth)
 - **HTTP (streamable, stateless)**: `POST /mcp` mounted on the FastAPI app via `StreamableHTTPSessionManager(stateless=True)` (bearer token). Each request gets a fresh transport — no shared session state means process restarts can never produce 404 "Could not find session" (replaced the legacy `GET /mcp/sse` + `POST /mcp/messages/` SSE transport per PT109).
 
-**Tool surface** (30, all returning markdown `TextContent`):
+**Tool surface** (32):
 
 | Group | Tools |
 |---|---|
@@ -386,12 +386,40 @@ Exposes **radbot itself** as an MCP server so external clients (primarily Claude
 | Projects (read) | `project_match(cwd)`, `project_list`, `project_get_context`, `project_list_children`, `project_set_path_patterns` |
 | Projects (mutate) | `project_create`, `project_update`, `project_archive(cascade_children?)`, `project_merge(from_ref, into_ref)` |
 | Project hierarchy (mutate) | `milestone_add`, `milestone_complete`, `task_add`, `task_update`, `task_complete`, `task_archive`, `exploration_add`, `exploration_update`, `exploration_archive` |
+| Journal (mutate) | `journal_add(entry, metadata?)`, `journal_update(ref_code, metadata_merge?, status?)` — direct wrappers around `telos_db.add_entry/update_entry` for `Section.JOURNAL`. `journal_add` accepts arbitrary `metadata`; postmortem entries (`metadata.type == "postmortem"`) MUST include `metadata.processed_at` (initially `null`). `journal_update`'s `status` enum is restricted to `active/completed/archived/superseded` (lifecycle states are nonsense for journal rows). |
 | Tasks / schedule | `list_tasks` (excludes `done` by default; pass `include_done=true` or `status="done"` to surface completed history — EX46 / PT115), `list_reminders`, `list_scheduled_tasks` |
 | Memory | `search_memory` (Qdrant, default scope=`beto`, pass `agent_scope="all"` to widen) |
 
-Project-hierarchy mutations are a parallel surface to beto's confirm-required `telos_*` tools — they call the same `radbot.tools.telos.db` primitives; user confirmation is expected at the MCP client UI layer (e.g. Claude Code's per-tool approval) rather than enforced server-side. All removal is soft (`status='archived'`, `metadata.archived_reason`) — no hard deletes.
+Project-hierarchy + journal mutations are a parallel surface to beto's confirm-required `telos_*` tools — they call the same `radbot.tools.telos.db` primitives; user confirmation is expected at the MCP client UI layer (e.g. Claude Code's per-tool approval) rather than enforced server-side. All removal is soft (`status='archived'`, `metadata.archived_reason`) — no hard deletes.
 
-**Return convention:** markdown for any structured output, plain single-line text for primitives (`project_match` → name) and action confirmations (`wiki_write` → `Wrote N bytes to <path>`). Never JSON to the LLM — JSON consumers hit the REST API at `/api/*`.
+**Read tools — `format` parameter.** `telos_get_section` and `telos_get_entry` accept `format="markdown"` (default, back-compat) or `format="json"`. JSON returns `TextContent.text = json.dumps(payload)` parseable via `json.loads(response.text)`. Payload shapes:
+
+- `telos_get_entry` → `{"entry": {ref_code, entry_id, section, status, content, metadata, created_at, updated_at}}`
+- `telos_get_section` → `{"entries": [<entry>, ...]}`
+
+Timestamps are ISO 8601 with **literal `Z` suffix** (not `+00:00`); `metadata` is the decoded JSONB dict (not stringified); UUIDs render as strings; `Section` enums render as `.value`. Single source of truth: `_iso_default` + `_entry_to_json_dict` in `radbot/mcp_server/tools/telos.py`.
+
+`telos_get_section` also accepts `metadata_filter: object` (JSONB `@>` filter, GIN-indexed). Default `include_inactive=false` includes the `ACTIVE_EQUIVALENT` set (`active`, `proposed`, `in_review`, `approved`, `executing`); `include_inactive=true` returns all statuses.
+
+**Structured-return contract (creation tools).** The four creation handlers — `task_add`, `exploration_add`, `milestone_add`, `journal_add` — return JSON `TextContent`:
+
+```json
+{"status": "success", "ref_code": "<NEW>", "entry_id": "<uuid>", "section": "<section_name>"}
+```
+
+Errors return JSON too:
+
+```json
+{"status": "error", "message": "<reason>"}
+```
+
+The four `*_update` handlers + `journal_update` use the same JSON `_err` envelope on failure (and `{"status": "success", "ref_code": "<ref>", ...}` on success — entry-status echoes via the `entry_status` key to avoid colliding with the envelope's `status` discriminator). The terminal operations (`task_complete`, `task_archive`, `exploration_archive`, `milestone_complete`) keep their human-readable text returns — callers there already know the ref_code.
+
+Callers branch uniformly on `payload["status"]` after `json.loads(response.text)` — no try/except + heuristic-detection footgun.
+
+**`metadata_merge` on creation + update tools.** `task_add`, `exploration_add`, `milestone_add`, `task_update`, `exploration_update` all accept an optional `metadata_merge: object` for arbitrary metadata attachment. **Whitelist precedence (load-bearing — same rule for all five tools):** the typed schema fields (`title`, `category`, `task_status`, `parent_milestone`, `parent_project`) win silently on collision with `metadata_merge`. Closes the chain-race blocker on Scout's postmortem followups — `source_postmortem` and friends land atomically in the same DB write as the row insert.
+
+**Lifecycle status on `exploration_add` / `exploration_update`.** Both accept an optional `status` validated against the extended `STATUS_VALUES` set (`active`, `completed`, `archived`, `superseded`, `proposed`, `in_review`, `approved`, `executing`). `task_update` and `exploration_update` treat absent `description`/`content` as "leave body unchanged"; whitespace value is rejected with the JSON `_err` envelope.
 
 **Token auth (HTTP):** credential store (`mcp_token` key) wins over `RADBOT_MCP_TOKEN` env var. Rotatable from the "MCP Bridge" admin panel via `POST /api/mcp/token/rotate`. Fails closed (503) when both unset.
 

--- a/tests/unit/test_mcp_server_journal.py
+++ b/tests/unit/test_mcp_server_journal.py
@@ -1,0 +1,151 @@
+"""Unit tests for radbot.mcp_server.tools.journal (Item 0.a).
+
+Covers:
+  * journal_add returns the structured-success contract envelope
+  * journal_add propagates the postmortem invariant ValueError as a JSON
+    error envelope (not a Python crash)
+  * journal_update accepts metadata_merge + status, validates status enum
+  * journal_update returns the JSON _err envelope on missing ref_code
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+from radbot.mcp_server.tools import journal as mcp_journal
+from radbot.tools.telos.models import Entry, Section
+
+
+def _fake_journal_entry(ref_code: str = "JR1") -> Entry:
+    return Entry(
+        entry_id="abcd-uuid",
+        section=Section.JOURNAL,
+        ref_code=ref_code,
+        content="postmortem text",
+        metadata={"type": "postmortem", "processed_at": None},
+        status="active",
+        sort_order=0,
+    )
+
+
+def _call(name: str, arguments: dict):
+    return asyncio.run(mcp_journal.call(name, arguments))
+
+
+class TestJournalAdd:
+    def test_returns_structured_success_envelope(self):
+        with patch.object(
+            mcp_journal,
+            "_do_journal_add",
+            wraps=mcp_journal._do_journal_add,
+        ):
+            with patch(
+                "radbot.tools.telos.db.add_entry",
+                return_value=_fake_journal_entry("JR42"),
+            ):
+                out = _call(
+                    "journal_add",
+                    {
+                        "entry": "postmortem text",
+                        "metadata": {"type": "postmortem", "processed_at": None},
+                    },
+                )
+
+        assert len(out) == 1
+        payload = json.loads(out[0].text)
+        assert payload == {
+            "status": "success",
+            "ref_code": "JR42",
+            "entry_id": "abcd-uuid",
+            "section": "journal",
+        }
+
+    def test_propagates_invariant_violation_as_json_error(self):
+        """db.add_entry's postmortem invariant raises ValueError; the MCP
+        wrapper must convert that to the JSON `_err` envelope, not crash."""
+
+        def _raise(*a, **kw):
+            raise ValueError(
+                "postmortem journal entries must include metadata.processed_at"
+            )
+
+        with patch("radbot.tools.telos.db.add_entry", side_effect=_raise):
+            out = _call(
+                "journal_add",
+                {"entry": "x", "metadata": {"type": "postmortem"}},
+            )
+
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "processed_at" in payload["message"]
+
+    def test_empty_entry_rejected(self):
+        out = _call("journal_add", {"entry": "   "})
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "entry" in payload["message"]
+
+
+class TestJournalUpdate:
+    def test_metadata_merge_and_status_passes_through(self):
+        captured: dict = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            captured["ref_code"] = ref_code
+            return _fake_journal_entry(ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            out = _call(
+                "journal_update",
+                {
+                    "ref_code": "JR1",
+                    "metadata_merge": {
+                        "processed_at": "2026-05-03T12:00:00Z",
+                        "processed_by": "scout",
+                    },
+                    "status": "completed",
+                },
+            )
+
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "success"
+        assert captured["ref_code"] == "JR1"
+        assert captured["status"] == "completed"
+        assert captured["metadata_merge"]["processed_by"] == "scout"
+
+    def test_invalid_status_rejected_against_journal_enum(self):
+        # Lifecycle states are not valid for journal rows
+        out = _call(
+            "journal_update",
+            {"ref_code": "JR1", "status": "in_review"},
+        )
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "in_review" in payload["message"]
+
+    def test_missing_ref_code_returns_json_err(self):
+        with patch("radbot.tools.telos.db.update_entry", return_value=None):
+            out = _call("journal_update", {"ref_code": "JRZ"})
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "JRZ" in payload["message"]
+
+
+class TestSchemaShape:
+    def test_journal_add_schema_requires_entry_only(self):
+        defs = {t.name: t for t in mcp_journal.tools()}
+        schema = defs["journal_add"].inputSchema
+        assert schema["required"] == ["entry"]
+        assert "metadata" in schema["properties"]
+        assert schema["properties"]["metadata"]["type"] == "object"
+
+    def test_journal_update_status_enum_excludes_lifecycle_states(self):
+        defs = {t.name: t for t in mcp_journal.tools()}
+        schema = defs["journal_update"].inputSchema
+        statuses = schema["properties"]["status"]["enum"]
+        assert "active" in statuses
+        for lifecycle in ("proposed", "in_review", "approved", "executing"):
+            assert lifecycle not in statuses

--- a/tests/unit/test_mcp_server_project_tasks_metadata_merge.py
+++ b/tests/unit/test_mcp_server_project_tasks_metadata_merge.py
@@ -1,0 +1,415 @@
+"""Unit tests for radbot.mcp_server.tools.project_tasks (Item 0.b).
+
+Covers:
+  * task_add / exploration_add return the structured-success contract
+    envelope (status/ref_code/entry_id/section)
+  * task_add / exploration_add accept metadata_merge atomically (no
+    chain-race) and whitelist keys silently win on collision
+  * task_update / exploration_update accept metadata_merge with same
+    precedence rule
+  * exploration_update accepts optional `status` (validated against
+    extended STATUS_VALUES)
+  * exploration_add accepts optional `status` and propagates to add_entry
+  * content/description optional + whitespace-rejection trifecta
+  * Error paths return JSON `_err` envelope (not plain prose)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+from radbot.mcp_server.tools import project_tasks as mcp_pt
+from radbot.tools.telos.models import Entry, Section
+
+
+def _fake_row(section: Section, ref_code: str) -> Entry:
+    return Entry(
+        entry_id="abcd-uuid",
+        section=section,
+        ref_code=ref_code,
+        content="x",
+        metadata={},
+        status="active",
+        sort_order=0,
+    )
+
+
+def _call(name: str, arguments: dict):
+    return asyncio.run(mcp_pt.call(name, arguments))
+
+
+def _ok_project():
+    return _fake_row(Section.PROJECTS, "PRJ1"), None
+
+
+# ---------------------------------------------------------------------------
+# *_add return contract
+# ---------------------------------------------------------------------------
+
+
+class TestAddReturnContract:
+    def test_task_add_returns_json_envelope(self):
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch(
+                "radbot.tools.telos.db.add_entry",
+                return_value=_fake_row(Section.PROJECT_TASKS, "PT42"),
+            ):
+                out = _call(
+                    "task_add",
+                    {"parent_project": "PRJ1", "description": "do thing"},
+                )
+
+        payload = json.loads(out[0].text)
+        assert payload == {
+            "status": "success",
+            "ref_code": "PT42",
+            "entry_id": "abcd-uuid",
+            "section": "project_tasks",
+        }
+
+    def test_exploration_add_returns_json_envelope(self):
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch(
+                "radbot.tools.telos.db.add_entry",
+                return_value=_fake_row(Section.EXPLORATIONS, "EX17"),
+            ):
+                out = _call(
+                    "exploration_add",
+                    {"parent_project": "PRJ1", "topic": "research"},
+                )
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "success"
+        assert payload["ref_code"] == "EX17"
+        assert payload["section"] == "explorations"
+
+    def test_milestone_add_returns_json_envelope(self):
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch(
+                "radbot.tools.telos.db.add_entry",
+                return_value=_fake_row(Section.MILESTONES, "MS3"),
+            ):
+                out = _call(
+                    "milestone_add",
+                    {"parent_project": "PRJ1", "title": "ship v1"},
+                )
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "success"
+        assert payload["ref_code"] == "MS3"
+        assert payload["section"] == "milestones"
+
+    def test_error_path_returns_json_err_envelope(self):
+        # Missing project — _require_project returns the JSON err envelope
+        with patch("radbot.tools.telos.db.get_entry", return_value=None):
+            out = _call(
+                "task_add",
+                {"parent_project": "PRJZ", "description": "do thing"},
+            )
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "PRJZ" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# metadata_merge atomic-creation (Item 0.b.ii — closes chain-race blocker)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataMergeOnAdd:
+    def test_task_add_passes_caller_metadata_through(self):
+        captured = {}
+
+        def _stub_add(section, content, *, metadata=None, **kw):
+            captured["metadata"] = metadata
+            return _fake_row(section, "PT1")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                _call(
+                    "task_add",
+                    {
+                        "parent_project": "PRJ1",
+                        "description": "x",
+                        "metadata_merge": {
+                            "source_postmortem": "JR42",
+                            "postmortem_followup_role": "task",
+                            "postmortem_followup_key": "abc123",
+                        },
+                    },
+                )
+
+        assert captured["metadata"]["source_postmortem"] == "JR42"
+        assert captured["metadata"]["postmortem_followup_role"] == "task"
+        assert captured["metadata"]["postmortem_followup_key"] == "abc123"
+        # Whitelist is also present
+        assert captured["metadata"]["parent_project"] == "PRJ1"
+        assert captured["metadata"]["task_status"] == "backlog"
+
+    def test_task_add_whitelist_silently_wins_on_collision(self):
+        """3-of-3 council consensus: silent override, no error raised."""
+        captured = {}
+
+        def _stub_add(section, content, *, metadata=None, **kw):
+            captured["metadata"] = metadata
+            return _fake_row(section, "PT1")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                _call(
+                    "task_add",
+                    {
+                        "parent_project": "PRJ1",
+                        "description": "x",
+                        "task_status": "inprogress",
+                        "metadata_merge": {"task_status": "done"},
+                    },
+                )
+
+        # Whitelist (inprogress) wins silently over caller's "done"
+        assert captured["metadata"]["task_status"] == "inprogress"
+
+    def test_exploration_add_passes_metadata_merge(self):
+        captured = {}
+
+        def _stub_add(section, content, *, metadata=None, **kw):
+            captured["metadata"] = metadata
+            return _fake_row(section, "EX5")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                _call(
+                    "exploration_add",
+                    {
+                        "parent_project": "PRJ1",
+                        "topic": "x",
+                        "metadata_merge": {"source_postmortem": "JR42"},
+                    },
+                )
+        assert captured["metadata"]["source_postmortem"] == "JR42"
+        assert captured["metadata"]["parent_project"] == "PRJ1"
+
+    def test_milestone_add_passes_metadata_merge(self):
+        captured = {}
+
+        def _stub_add(section, content, *, metadata=None, **kw):
+            captured["metadata"] = metadata
+            return _fake_row(section, "MS1")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                _call(
+                    "milestone_add",
+                    {
+                        "parent_project": "PRJ1",
+                        "title": "ship",
+                        "metadata_merge": {"foo": "bar"},
+                    },
+                )
+        assert captured["metadata"]["foo"] == "bar"
+        assert captured["metadata"]["parent_project"] == "PRJ1"
+
+
+# ---------------------------------------------------------------------------
+# Optional status on exploration_add / exploration_update
+# ---------------------------------------------------------------------------
+
+
+class TestExplorationStatus:
+    def test_exploration_add_with_status_proposed(self):
+        captured = {}
+
+        def _stub_add(section, content, *, status="active", metadata=None, **kw):
+            captured["status"] = status
+            return _fake_row(section, "EX99")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                out = _call(
+                    "exploration_add",
+                    {
+                        "parent_project": "PRJ1",
+                        "topic": "x",
+                        "status": "proposed",
+                    },
+                )
+        assert captured["status"] == "proposed"
+        assert json.loads(out[0].text)["status"] == "success"
+
+    def test_exploration_add_default_status_is_active(self):
+        captured = {}
+
+        def _stub_add(section, content, *, status="active", metadata=None, **kw):
+            captured["status"] = status
+            return _fake_row(section, "EX100")
+
+        with patch.object(mcp_pt, "_require_project", return_value=_ok_project()):
+            with patch("radbot.tools.telos.db.add_entry", side_effect=_stub_add):
+                _call(
+                    "exploration_add",
+                    {"parent_project": "PRJ1", "topic": "x"},
+                )
+        assert captured["status"] == "active"
+
+    def test_exploration_update_status_in_review(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            out = _call(
+                "exploration_update",
+                {"ref_code": "EX1", "status": "in_review"},
+            )
+
+        assert captured["status"] == "in_review"
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "success"
+        assert payload["entry_status"] == "in_review"
+
+    def test_exploration_update_invalid_status_returns_json_err(self):
+        out = _call("exploration_update", {"ref_code": "EX1", "status": "bogus"})
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "bogus" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# content/description optional + whitespace-rejection
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateContentOptional:
+    def test_exploration_update_absent_content_leaves_body_unchanged(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            _call("exploration_update", {"ref_code": "EX1"})
+
+        # content kwarg is None when absent
+        assert captured["content"] is None
+
+    def test_exploration_update_non_empty_content_replaces_body(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            _call("exploration_update", {"ref_code": "EX1", "content": "new body"})
+
+        assert captured["content"] == "new body"
+
+    def test_exploration_update_whitespace_content_rejected(self):
+        out = _call("exploration_update", {"ref_code": "EX1", "content": "   "})
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+        assert "whitespace" in payload["message"]
+
+    def test_task_update_absent_description_leaves_body_unchanged(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            _call("task_update", {"ref_code": "PT1"})
+        assert captured["content"] is None
+
+    def test_task_update_whitespace_description_rejected(self):
+        out = _call("task_update", {"ref_code": "PT1", "description": "  "})
+        payload = json.loads(out[0].text)
+        assert payload["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# *_update metadata_merge precedence (matches *_add rule)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMetadataMerge:
+    def test_task_update_metadata_merge_passes_through(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            _call(
+                "task_update",
+                {
+                    "ref_code": "PT1",
+                    "metadata_merge": {"source_postmortem": "JR42"},
+                },
+            )
+
+        assert captured["metadata_merge"]["source_postmortem"] == "JR42"
+
+    def test_task_update_whitelist_silently_wins(self):
+        captured = {}
+
+        def _stub_update(section, ref_code, **kwargs):
+            captured.update(kwargs)
+            return _fake_row(section, ref_code)
+
+        with patch("radbot.tools.telos.db.update_entry", side_effect=_stub_update):
+            _call(
+                "task_update",
+                {
+                    "ref_code": "PT1",
+                    "title": "real title",
+                    "metadata_merge": {"title": "caller title"},
+                },
+            )
+
+        assert captured["metadata_merge"]["title"] == "real title"
+
+
+# ---------------------------------------------------------------------------
+# Schema shape verification
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaShape:
+    def test_task_add_schema_has_metadata_merge(self):
+        defs = {t.name: t for t in mcp_pt.tools()}
+        assert "metadata_merge" in defs["task_add"].inputSchema["properties"]
+
+    def test_exploration_add_schema_has_status_and_metadata_merge(self):
+        defs = {t.name: t for t in mcp_pt.tools()}
+        sch = defs["exploration_add"].inputSchema["properties"]
+        assert "status" in sch
+        assert "metadata_merge" in sch
+
+    def test_exploration_update_content_optional(self):
+        defs = {t.name: t for t in mcp_pt.tools()}
+        assert "content" not in defs["exploration_update"].inputSchema["required"]
+
+    def test_task_update_description_optional(self):
+        defs = {t.name: t for t in mcp_pt.tools()}
+        assert "description" not in defs["task_update"].inputSchema["required"]
+
+    def test_exploration_status_enum_includes_lifecycle(self):
+        defs = {t.name: t for t in mcp_pt.tools()}
+        for tool_name in ("exploration_add", "exploration_update"):
+            statuses = defs[tool_name].inputSchema["properties"]["status"]["enum"]
+            for lifecycle in (
+                "proposed",
+                "in_review",
+                "approved",
+                "executing",
+                "active",
+                "completed",
+                "archived",
+                "superseded",
+            ):
+                assert lifecycle in statuses

--- a/tests/unit/test_mcp_server_telos_json_format.py
+++ b/tests/unit/test_mcp_server_telos_json_format.py
@@ -1,0 +1,223 @@
+"""Unit tests for radbot.mcp_server.tools.telos JSON format (Item 0.c).
+
+Covers:
+  * format='json' returns {entry: {...}} or {entries: [...]} with the
+    pinned _entry_to_json_dict shape
+  * timestamps render as literal Z (not +00:00)
+  * UUIDs render as strings (no json.dumps crash)
+  * Section enum renders as .value
+  * default include_inactive=False translates to status_in=ACTIVE_EQUIVALENT
+    on db.list_section
+  * include_inactive=True translates to status_in=None (all statuses)
+  * metadata_filter passes through to db.list_section
+  * format='markdown' (default) preserves the legacy rendering
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from radbot.mcp_server.tools import telos as mcp_telos
+from radbot.tools.telos.models import Entry, Section
+
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def _entry(
+    section: Section = Section.EXPLORATIONS,
+    ref_code: str = "EX1",
+    metadata: dict | None = None,
+    status: str = "proposed",
+) -> Entry:
+    now = datetime(2026, 5, 3, 12, 0, 0, tzinfo=timezone.utc)
+    return Entry(
+        entry_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        section=section,
+        ref_code=ref_code,
+        content="exploration body",
+        metadata=metadata or {"source_postmortem": "JR42"},
+        status=status,
+        sort_order=0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _call(name: str, arguments: dict):
+    return asyncio.run(mcp_telos.call(name, arguments))
+
+
+# ---------------------------------------------------------------------------
+# JSON format payload shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntryJsonFormat:
+    def test_json_payload_shape_matches_contract(self):
+        with patch("radbot.tools.telos.db.get_entry", return_value=_entry()):
+            out = _call(
+                "telos_get_entry",
+                {"section": "explorations", "ref_code": "EX1", "format": "json"},
+            )
+
+        payload = json.loads(out[0].text)
+        assert "entry" in payload
+        e = payload["entry"]
+        assert e["ref_code"] == "EX1"
+        assert e["entry_id"] == "12345678-1234-5678-1234-567812345678"
+        assert e["section"] == "explorations"
+        assert e["status"] == "proposed"
+        assert e["content"] == "exploration body"
+        assert e["metadata"] == {"source_postmortem": "JR42"}
+
+    def test_timestamps_use_literal_z_suffix(self):
+        with patch("radbot.tools.telos.db.get_entry", return_value=_entry()):
+            out = _call(
+                "telos_get_entry",
+                {"section": "explorations", "ref_code": "EX1", "format": "json"},
+            )
+
+        payload = json.loads(out[0].text)
+        assert _TS_RE.match(payload["entry"]["created_at"])
+        assert _TS_RE.match(payload["entry"]["updated_at"])
+        assert "+00:00" not in out[0].text
+
+    def test_uuid_renders_as_string_no_crash(self):
+        """psycopg2 returns uuid.UUID for UUID columns; json.dumps would
+        crash without explicit handling."""
+        with patch("radbot.tools.telos.db.get_entry", return_value=_entry()):
+            out = _call(
+                "telos_get_entry",
+                {"section": "explorations", "ref_code": "EX1", "format": "json"},
+            )
+        payload = json.loads(out[0].text)
+        assert isinstance(payload["entry"]["entry_id"], str)
+
+    def test_markdown_format_back_compat(self):
+        """Default format=markdown preserves legacy rendering."""
+        with patch("radbot.tools.telos.db.get_entry", return_value=_entry()):
+            out = _call(
+                "telos_get_entry",
+                {"section": "explorations", "ref_code": "EX1"},
+            )
+        # Markdown rendering uses ### headers + **Status:** blocks
+        assert "### explorations: EX1" in out[0].text
+        assert "**Status:**" in out[0].text
+
+
+class TestGetSectionJsonFormat:
+    def test_returns_entries_list(self):
+        rows = [_entry(ref_code="EX1"), _entry(ref_code="EX2")]
+        with patch("radbot.tools.telos.db.list_section", return_value=rows):
+            out = _call(
+                "telos_get_section",
+                {"section": "explorations", "format": "json"},
+            )
+        payload = json.loads(out[0].text)
+        assert "entries" in payload
+        refs = [e["ref_code"] for e in payload["entries"]]
+        assert refs == ["EX1", "EX2"]
+        # Every entry's timestamps match the literal-Z regex
+        for e in payload["entries"]:
+            assert _TS_RE.match(e["created_at"])
+            assert _TS_RE.match(e["updated_at"])
+
+    def test_default_include_inactive_omits_status_in_kwarg(self):
+        """Default behavior: pass nothing → db.list_section uses
+        ACTIVE_EQUIVALENT."""
+        captured = {}
+
+        def _stub(section, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch("radbot.tools.telos.db.list_section", side_effect=_stub):
+            _call("telos_get_section", {"section": "explorations"})
+
+        # MCP layer omits both status and status_in when include_inactive=False
+        # so db.list_section's sentinel default fires (ACTIVE_EQUIVALENT)
+        assert "status" not in captured
+        assert "status_in" not in captured
+
+    def test_include_inactive_true_translates_to_status_in_none(self):
+        captured = {}
+
+        def _stub(section, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch("radbot.tools.telos.db.list_section", side_effect=_stub):
+            _call(
+                "telos_get_section",
+                {"section": "explorations", "include_inactive": True},
+            )
+
+        assert captured.get("status_in") is None
+
+    def test_metadata_filter_passes_through(self):
+        captured = {}
+
+        def _stub(section, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch("radbot.tools.telos.db.list_section", side_effect=_stub):
+            _call(
+                "telos_get_section",
+                {
+                    "section": "journal",
+                    "format": "json",
+                    "metadata_filter": {
+                        "type": "postmortem",
+                        "processed_at": None,
+                    },
+                },
+            )
+
+        assert captured["metadata_filter"] == {
+            "type": "postmortem",
+            "processed_at": None,
+        }
+
+
+class TestSchemaShape:
+    def test_telos_get_section_schema_has_format_and_metadata_filter(self):
+        defs = {t.name: t for t in mcp_telos.tools()}
+        sch = defs["telos_get_section"].inputSchema["properties"]
+        assert "format" in sch
+        assert sch["format"]["enum"] == ["markdown", "json"]
+        assert "metadata_filter" in sch
+
+    def test_telos_get_entry_schema_has_format(self):
+        defs = {t.name: t for t in mcp_telos.tools()}
+        sch = defs["telos_get_entry"].inputSchema["properties"]
+        assert "format" in sch
+        assert sch["format"]["enum"] == ["markdown", "json"]
+
+
+class TestIsoDefault:
+    def test_iso_default_handles_naive_via_aware_promotion(self):
+        # datetime that's already aware in UTC
+        from radbot.mcp_server.tools.telos import _iso_default
+
+        dt = datetime(2026, 5, 3, 12, 0, 0, tzinfo=timezone.utc)
+        assert _iso_default(dt) == "2026-05-03T12:00:00Z"
+
+    def test_iso_default_handles_uuid(self):
+        from radbot.mcp_server.tools.telos import _iso_default
+
+        u = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert _iso_default(u) == "12345678-1234-5678-1234-567812345678"
+
+    def test_iso_default_raises_typeerror_for_unknown(self):
+        import pytest
+
+        from radbot.mcp_server.tools.telos import _iso_default
+
+        with pytest.raises(TypeError):
+            _iso_default({"not": "supported"})

--- a/tests/unit/test_telos_db_invariants.py
+++ b/tests/unit/test_telos_db_invariants.py
@@ -1,0 +1,428 @@
+"""Unit tests for db.py changes from EX_DRAFT_council_loop_polish (Item 0.c +
+Item 1.a + Item 3 invariant).
+
+Covers:
+  * STATUS_VALUES extension + ACTIVE_EQUIVALENT contents
+  * db.add_entry postmortem invariant (raises ValueError when missing
+    `processed_at` on a journal entry flagged as a postmortem)
+  * db.add_entry defensive metadata normalization (None → {} before access)
+  * db.list_section sentinel pattern (mutual-exclusion + back-compat
+    semantics + ACTIVE_EQUIVALENT default)
+  * _extract_constraint_status_set parses all three PG normalization shapes
+  * _apply_status_check_constraint preflight + add + replace flows
+
+The DB-layer tests mock the psycopg2 connection chain rather than hitting
+a real database — matches the pattern used elsewhere in tests/unit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# STATUS_VALUES + ACTIVE_EQUIVALENT
+# ---------------------------------------------------------------------------
+
+
+class TestStatusValues:
+    def test_status_values_contains_legacy_and_lifecycle(self):
+        from radbot.tools.telos.models import STATUS_VALUES
+
+        assert STATUS_VALUES == {
+            "active",
+            "completed",
+            "archived",
+            "superseded",
+            "proposed",
+            "in_review",
+            "approved",
+            "executing",
+        }
+
+    def test_active_equivalent_excludes_terminal_states(self):
+        from radbot.tools.telos.models import ACTIVE_EQUIVALENT
+
+        assert ACTIVE_EQUIVALENT == frozenset(
+            {"active", "proposed", "in_review", "approved", "executing"}
+        )
+        for terminal in ("completed", "archived", "superseded"):
+            assert terminal not in ACTIVE_EQUIVALENT
+
+
+# ---------------------------------------------------------------------------
+# db.add_entry postmortem invariant + defensive normalize
+# ---------------------------------------------------------------------------
+
+
+def _mock_db_chain():
+    """Build a (conn_cm, cursor) pair matching `with get_db_connection() ...`
+    + `with conn.cursor(cursor_factory=...) ...` shape used by db.add_entry."""
+    cursor = MagicMock()
+    cursor.fetchone.return_value = {
+        "entry_id": "fake-uuid",
+        "section": "journal",
+        "ref_code": "JR1",
+        "content": "x",
+        "metadata": {"type": "postmortem", "processed_at": None},
+        "status": "active",
+        "sort_order": 0,
+        "created_at": None,
+        "updated_at": None,
+    }
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_cm
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = conn
+    conn_cm.__exit__.return_value = False
+    return conn_cm, cursor
+
+
+class TestAddEntryPostmortemInvariant:
+    def test_postmortem_journal_without_processed_at_raises(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        with pytest.raises(ValueError, match="processed_at"):
+            telos_db.add_entry(
+                Section.JOURNAL,
+                "x",
+                metadata={"type": "postmortem"},
+            )
+
+    def test_postmortem_via_legacy_event_type_also_raises(self):
+        """Closes the agent-side bypass: telos_add_journal historically used
+        `event_type` (not `type`) for the postmortem flag."""
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        with pytest.raises(ValueError, match="processed_at"):
+            telos_db.add_entry(
+                Section.JOURNAL,
+                "x",
+                metadata={"event_type": "postmortem"},
+            )
+
+    def test_postmortem_with_explicit_null_processed_at_succeeds(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _ = _mock_db_chain()
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "next_ref_code", return_value="JR1"):
+                row = telos_db.add_entry(
+                    Section.JOURNAL,
+                    "x",
+                    metadata={"type": "postmortem", "processed_at": None},
+                )
+        assert row.ref_code == "JR1"
+
+    def test_non_postmortem_journal_with_no_metadata_succeeds(self):
+        """Defensive normalize: metadata=None must not crash on .get()."""
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, cursor = _mock_db_chain()
+        cursor.fetchone.return_value = {
+            "entry_id": "fake-uuid",
+            "section": "journal",
+            "ref_code": "JR2",
+            "content": "x",
+            "metadata": {},
+            "status": "active",
+            "sort_order": 0,
+            "created_at": None,
+            "updated_at": None,
+        }
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "next_ref_code", return_value="JR2"):
+                row = telos_db.add_entry(Section.JOURNAL, "x")
+        assert row.ref_code == "JR2"
+
+    def test_postmortem_invariant_does_not_apply_to_non_journal_sections(self):
+        """Only journal entries get the invariant. A project_tasks row whose
+        metadata happens to contain `type=postmortem` (unlikely but legal)
+        must not trigger the rejection."""
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, cursor = _mock_db_chain()
+        cursor.fetchone.return_value = {
+            "entry_id": "fake-uuid",
+            "section": "project_tasks",
+            "ref_code": "PT1",
+            "content": "x",
+            "metadata": {"type": "postmortem"},
+            "status": "active",
+            "sort_order": 0,
+            "created_at": None,
+            "updated_at": None,
+        }
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "next_ref_code", return_value="PT1"):
+                row = telos_db.add_entry(
+                    Section.PROJECT_TASKS,
+                    "x",
+                    metadata={"type": "postmortem"},
+                )
+        assert row.ref_code == "PT1"
+
+
+# ---------------------------------------------------------------------------
+# telos_add_journal event_type=postmortem normalization (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+class TestTelosAddJournalPostmortemNormalization:
+    def test_event_type_postmortem_writes_canonical_type_and_processed_at(self):
+        from radbot.tools.telos import telos_tools
+
+        captured: dict = {}
+
+        def _stub_add(section, content, *, metadata=None, **kwargs):
+            captured["metadata"] = metadata
+            from radbot.tools.telos.models import Entry
+
+            return Entry(
+                entry_id="x",
+                section=section,
+                ref_code="JR42",
+                content=content,
+                metadata=metadata,
+                status="active",
+            )
+
+        with patch.object(telos_tools.telos_db, "add_entry", side_effect=_stub_add):
+            out = telos_tools.telos_add_journal(
+                entry="postmortem text",
+                event_type="postmortem",
+            )
+
+        assert out["status"] == "success"
+        assert captured["metadata"]["type"] == "postmortem"
+        assert "processed_at" in captured["metadata"]
+        assert captured["metadata"]["processed_at"] is None
+        assert captured["metadata"]["event_type"] == "postmortem"
+
+
+# ---------------------------------------------------------------------------
+# db.list_section sentinel pattern (Item 0.c blocker fix)
+# ---------------------------------------------------------------------------
+
+
+def _patch_list_section_chain(rows: list[dict]):
+    """Return a (conn_cm, cursor, executed) tuple that captures the SQL."""
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows
+    executed: list[tuple] = []
+    cursor.execute.side_effect = lambda sql, params=None: executed.append((sql, params))
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_cm
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = conn
+    conn_cm.__exit__.return_value = False
+    return conn_cm, cursor, executed
+
+
+class TestListSectionSentinel:
+    def test_omitting_both_status_args_uses_active_equivalent(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import ACTIVE_EQUIVALENT, Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(Section.EXPLORATIONS)
+
+        sql, params = executed[0]
+        assert "status = ANY(%s)" in sql
+        assert sorted(params[1]) == sorted(ACTIVE_EQUIVALENT)
+
+    def test_explicit_status_active_keeps_legacy_single_filter(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(Section.EXPLORATIONS, status="active")
+
+        sql, params = executed[0]
+        assert "status = %s" in sql
+        assert params[1] == "active"
+
+    def test_explicit_status_none_returns_all_statuses(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(Section.EXPLORATIONS, status=None)
+
+        sql, params = executed[0]
+        assert "status" not in sql
+        assert tuple(params) == ("explorations",)
+
+    def test_explicit_status_in_none_returns_all_statuses(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(Section.EXPLORATIONS, status_in=None)
+
+        sql, params = executed[0]
+        assert "status" not in sql
+
+    def test_explicit_status_in_set_uses_any(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(
+                Section.EXPLORATIONS, status_in={"proposed", "approved"}
+            )
+
+        sql, params = executed[0]
+        assert "status = ANY(%s)" in sql
+        assert sorted(params[1]) == ["approved", "proposed"]
+
+    def test_status_and_status_in_mutually_exclusive(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import ACTIVE_EQUIVALENT, Section
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            telos_db.list_section(
+                Section.EXPLORATIONS, status="active", status_in=ACTIVE_EQUIVALENT
+            )
+
+    def test_metadata_filter_adds_jsonb_containment(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import Section
+
+        conn_cm, _, executed = _patch_list_section_chain([])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            telos_db.list_section(
+                Section.JOURNAL,
+                metadata_filter={"type": "postmortem", "processed_at": None},
+            )
+
+        sql, params = executed[0]
+        assert "metadata @> %s::jsonb" in sql
+        assert '"type": "postmortem"' in params[-1]
+
+
+# ---------------------------------------------------------------------------
+# _extract_constraint_status_set + _apply_status_check_constraint
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConstraintStatusSet:
+    def test_parses_array_text_form(self):
+        from radbot.tools.telos.db import _extract_constraint_status_set
+
+        result = _extract_constraint_status_set(
+            "CHECK ((status = ANY (ARRAY['active'::text, 'completed'::text])))"
+        )
+        assert result == {"active", "completed"}
+
+    def test_parses_in_clause_form(self):
+        from radbot.tools.telos.db import _extract_constraint_status_set
+
+        result = _extract_constraint_status_set(
+            "CHECK (status IN ('active', 'completed', 'archived'))"
+        )
+        assert result == {"active", "completed", "archived"}
+
+    def test_parses_double_cast_form(self):
+        from radbot.tools.telos.db import _extract_constraint_status_set
+
+        result = _extract_constraint_status_set(
+            "CHECK ((status)::text = ANY ((ARRAY['active'::text, 'archived'::text])::text[]))"
+        )
+        assert result == {"active", "archived"}
+
+
+class TestApplyStatusCheckConstraint:
+    def _patched_chain(self, sequence: list):
+        """Build a cursor whose `fetchone` returns each item in order."""
+        cursor = MagicMock()
+        cursor.fetchone.side_effect = sequence
+        cursor.execute = MagicMock()
+        cursor_cm = MagicMock()
+        cursor_cm.__enter__.return_value = cursor
+        cursor_cm.__exit__.return_value = False
+        conn = MagicMock()
+        conn_cm = MagicMock()
+        conn_cm.__enter__.return_value = conn
+        conn_cm.__exit__.return_value = False
+        return conn_cm, conn, cursor, cursor_cm
+
+    def test_preflight_aborts_when_bad_rows_exist(self):
+        from radbot.tools.telos import db as telos_db
+
+        conn_cm, conn, cursor, cursor_cm = self._patched_chain([(2, "weird, bogus")])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "get_db_cursor", return_value=cursor_cm):
+                with pytest.raises(RuntimeError, match="Fix data before applying"):
+                    telos_db._apply_status_check_constraint()
+
+    def test_no_existing_constraint_then_add(self):
+        from radbot.tools.telos import db as telos_db
+
+        # preflight: 0 bad rows; then None for existing constraint def
+        conn_cm, conn, cursor, cursor_cm = self._patched_chain([(0, ""), None])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "get_db_cursor", return_value=cursor_cm):
+                telos_db._apply_status_check_constraint()
+
+        # Last execute is the ADD CONSTRAINT
+        last_sql = cursor.execute.call_args_list[-1][0][0]
+        assert "ADD CONSTRAINT" in last_sql
+        assert telos_db._STATUS_CHECK_NAME in last_sql
+
+    def test_existing_constraint_with_matching_set_is_noop(self):
+        from radbot.tools.telos import db as telos_db
+        from radbot.tools.telos.models import STATUS_VALUES
+
+        existing_def = (
+            "CHECK (status IN ("
+            + ", ".join(f"'{s}'" for s in sorted(STATUS_VALUES))
+            + "))"
+        )
+        conn_cm, conn, cursor, cursor_cm = self._patched_chain(
+            [(0, ""), (existing_def,)]
+        )
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "get_db_cursor", return_value=cursor_cm):
+                telos_db._apply_status_check_constraint()
+
+        # No DROP/ADD beyond the two SELECTs (preflight + lookup)
+        executed_sql = [c[0][0] for c in cursor.execute.call_args_list]
+        assert not any("DROP CONSTRAINT" in s for s in executed_sql)
+        assert not any("ADD CONSTRAINT" in s for s in executed_sql)
+
+    def test_existing_constraint_with_legacy_set_triggers_replace(self):
+        from radbot.tools.telos import db as telos_db
+
+        legacy_def = (
+            "CHECK (status IN ('active', 'completed', 'archived', 'superseded'))"
+        )
+        conn_cm, conn, cursor, cursor_cm = self._patched_chain([(0, ""), (legacy_def,)])
+        with patch.object(telos_db, "get_db_connection", return_value=conn_cm):
+            with patch.object(telos_db, "get_db_cursor", return_value=cursor_cm):
+                telos_db._apply_status_check_constraint()
+
+        executed_sql = [c[0][0] for c in cursor.execute.call_args_list]
+        assert any("DROP CONSTRAINT" in s for s in executed_sql)
+        assert any("ADD CONSTRAINT" in s for s in executed_sql)
+        # The new ADD should contain all 8 statuses
+        add_sql = next(s for s in executed_sql if "ADD CONSTRAINT" in s)
+        for status in ("proposed", "in_review", "approved", "executing"):
+            assert f"'{status}'" in add_sql


### PR DESCRIPTION
## Summary

Resolves: foundational Item 0 + Item 1.a from `docs/plans/EX_DRAFT_council_loop_polish.md`. This is the gating PR for Items 2-5 of the council-loop polish exploration; no code in this PR introduces user-facing behavior beyond the new MCP tools and the lifecycle status states themselves.

### Item 0.a — `journal_add` / `journal_update` MCP tools (new)
- New file `radbot/mcp_server/tools/journal.py` registered in `_MODULES`.
- Direct wrapper around `telos_db.add_entry/update_entry` for `Section.JOURNAL` (NOT through agent-side `telos_add_journal` whose signature is too narrow).
- Postmortem invariant enforced at `db.add_entry` propagates as JSON `_err` envelope, not a Python crash.

### Item 0.b — project_tasks tool surface
- `task_add`, `exploration_add`, `milestone_add`, `journal_add` return the structured-success envelope per Item 0.b.iv: `{"status": "success", "ref_code": "<NEW>", "entry_id": "<uuid>", "section": "<section>"}`.
- All eight write tools' errors return JSON `{"status": "error", "message": "<reason>"}`.
- `metadata_merge` added to `task_add`, `exploration_add`, `milestone_add`, `task_update`, `exploration_update` — atomic-creation closes the chain-race blocker on Scout's postmortem followups.
- Whitelist precedence (typed schema fields silently win on collision) per Round 3 council 3-of-3 consensus.
- Optional `status` on `exploration_add` + `exploration_update` (validated against the extended `STATUS_VALUES`).
- `content` on `exploration_update` and `description` on `task_update` made optional: absent = leave unchanged; whitespace = JSON `_err`.
- `_text_err` / `_json_err` helper split — terminal `*_complete`/`*_archive` keep human-readable text; the eight chained-by-LLM tools return JSON.

### Item 0.c — telos_get_section / telos_get_entry JSON contract
- New `format` param: `markdown` (default, back-compat) or `json`.
- New `metadata_filter` on `telos_get_section` → JSONB `@>` (GIN-indexed).
- `_iso_default` enforces literal `Z` UTC suffix (closes Round 3 blocker on `+00:00` drift) AND handles `uuid.UUID` (closes the json.dumps crash on entry_id).
- `_entry_to_json_dict` — single helper guarantees identical shape across `telos_get_entry` / `telos_get_section`.
- `ACTIVE_EQUIVALENT` default: `include_inactive=false` translates to `status_in=ACTIVE_EQUIVALENT` so freshly-created `proposed` EXes appear in default listings.
- `_apply_metadata_gin_index()` runs as a sibling step inside `init_telos_schema()` (not via `create_index_sqls`, which would silently skip on existing deployments).

### Item 1.a — STATUS_VALUES extension + DB CHECK constraint
- `STATUS_VALUES` now includes `proposed`, `in_review`, `approved`, `executing` alongside the legacy four.
- `ACTIVE_EQUIVALENT = frozenset({\"active\", \"proposed\", \"in_review\", \"approved\", \"executing\"})`.
- `_apply_status_check_constraint()` — preflight + DEFINITION-aware (semantic set comparison, not byte-string equality) + idempotent. Closes Round 3 blocker against `pg_get_constraintdef` brittleness.
- `db.list_section` refactored to the sentinel pattern (`_OMITTED` private sentinel) — distinguishes \"argument omitted\" from \"argument explicitly None\" so legacy callers (`status=\"active\"` and `status=None`) both keep working while the new no-arg default surfaces lifecycle states. Also adds `metadata_filter` JSONB containment kwarg.

### Item 3 — postmortem invariant (defense-in-depth)
- `db.add_entry` rejects journal entries flagged as postmortems (`metadata.type == \"postmortem\"` OR legacy `metadata.event_type == \"postmortem\"`) without `metadata.processed_at` — single enforcement point, all writers covered.
- `telos_add_journal` normalizes `event_type=\"postmortem\"` → set `metadata.type=\"postmortem\"` AND default `metadata.processed_at=None` before delegating.

## Backward-compat audits

**Item 0.b.iv — return-text consumer audit** (`grep -rn \"Added (task|exploration|milestone|journal)\" tests/ radbot/ ~/.claude/skills ~/.claude/agents ~/.claude/commands ~/.claude/plugins ~/git/perrymanuk/claude-skills/`):

- Zero consumer hits in `tests/` and `radbot/` outside the producer (`project_tasks.py`) itself.
- Zero consumer hits in `~/.claude/skills`, `~/.claude/agents`, `~/.claude/commands`, `~/.claude/plugins`, or `~/git/perrymanuk/claude-skills/`.
- The chat transcript matches in `~/.claude/projects/.../*.jsonl` are JSONL session logs (irrelevant — they don't parse the prose).
- **No migration needed.**

**Item 0.c — db.list_section caller audit** (`grep -nE 'list_section\([^)]*status=' radbot/`):

19 hits, all explicitly passing either `status=\"active\"` or `status=None` — both preserved exactly under the sentinel back-compat semantics. The one intentional behavior change is `radbot/mcp_server/tools/telos.py:_render_section`, migrated to the new ACTIVE_EQUIVALENT default per Item 0.c spec.

| File | Line | Call | Disposition |
|---|---|---|---|
| `radbot/mcp_server/tools/projects.py` | 282 | `status=\"active\"` | back-compat preserved |
| `radbot/mcp_server/tools/projects.py` | 410 | `status=None` (limit=50) | back-compat preserved |
| `radbot/mcp_server/tools/projects.py` | 476 | `status=\"active\"` | back-compat preserved |
| `radbot/mcp_server/tools/tasks.py` | 157 | `status=\"active\"` | back-compat preserved |
| `radbot/mcp_server/tools/tasks.py` | 175 | `status=\"active\"` | back-compat preserved |
| `radbot/mcp_server/tools/telos.py` | (new `_render_section`) | translates `include_inactive` to `status_in=ACTIVE_EQUIVALENT` / `status_in=None` | **migrated** per Item 0.c |
| `radbot/web/api/telos.py` | 153 | `status=None` | back-compat preserved |
| `radbot/web/api/telos.py` | 154-155 | `status=\"active\"` | back-compat preserved |
| `radbot/web/api/telos.py` | 209 | variable `status` (None or \"active\") | back-compat preserved |
| `radbot/web/api/telos.py` | 281 | variable `status` (None or \"active\") | back-compat preserved |
| `radbot/tools/telos/telos_tools.py` | 136 | variable `status` (None or \"active\") | back-compat preserved |
| `radbot/tools/telos/telos_tools.py` | 723, 751, 764, 782, 914, 950 | `status=\"active\"` | back-compat preserved |
| `radbot/tools/telos/db.py` | 477 (`recent_journal`) | `status=\"active\"` | back-compat preserved |
| `radbot/tools/picnic/picnic_tools.py` | 357, 368 | `status=\"active\"` | back-compat preserved |
| `radbot/tools/heartbeat/digest.py` | 37 | `status=\"active\"` | back-compat preserved |

## Specs updated

- `specs/tools.md` — telos MCP tool table updated with new return contract, `format` param, `metadata_filter`, `metadata_merge`, lifecycle status, journal tools.
- `specs/storage.md` — extended `STATUS_VALUES` set, GIN index, JSONB query path, `db.list_section` sentinel signature, code-rollback warning, `db.add_entry` postmortem invariant.
- `CLAUDE.md` — `telos_entries` table row updated; new \"Telos lifecycle status state machine\" + \"MCP write-tool return contract\" subsections added under Common Patterns.

## Round 3 majors punch-list (from spec Status header)

| Major | Disposition |
|---|---|
| Per-tool `metadata_merge` whitelist enumeration | **resolved-in-this-PR** — every schema's `metadata_merge` description names the winning whitelist keys explicitly |
| JSON `_err` envelope global-vs-per-tool decision | **resolved-in-this-PR** — `_text_err` / `_json_err` split helpers in `project_tasks.py`; eight chained tools use JSON, four terminal ones keep text |
| `init_telos_schema()` wrapper refactor + `SCHEMA_INITS` registry update | **resolved-in-this-PR** — `init_telos_schema` is now a real function with sibling steps; `SCHEMA_INITS` already pointed at it (no churn needed) |
| GIN-index definition-aware migration | **resolved-in-this-PR** — `CREATE INDEX IF NOT EXISTS` is idempotent at the metadata-table level; sibling-step pattern in `init_telos_schema` |
| `## Followups` markdown grammar pin + `_None_` sentinel + re-ordinalization footgun | **deferred-to-Item-4** — postmortem markdown contract belongs in `/postmortem-ex` skill |
| Deterministic `parent_project` derivation chain | **deferred-to-Item-3** — Scout instruction edits |
| Pre-strip marker-balance validator | **deferred-to-Items-2-and-4** — `/review-ex` and `/postmortem-ex` skill-side concern |
| `/postmortem-ex` step-7 partial-failure recovery | **deferred-to-Item-4** — out of scope here |
| Per-tool `_err` envelope coverage table | **resolved-in-this-PR** — coverage documented in module docstring + helper-comment in `project_tasks.py` |
| Content optional-vs-empty handler branch | **resolved-in-this-PR** — covered by the trifecta tests in `test_mcp_server_project_tasks_metadata_merge.py` |
| `_iso_default` sub-second precision | **N/A-for-this-scope** — second-precision Z timestamps suffice for postmortem dedup; Item 5 use cases don't need finer |
| Item 6 ordering note rewrite | **deferred-to-Item-6-PR** — Item 6 is its own PR per the spec implementation order |
| Backward-compat audit grep syntax fix | **resolved-in-this-PR** — audit run + documented above |

## Tests

- `tests/unit/test_telos_db_invariants.py` — 22 tests: STATUS_VALUES + ACTIVE_EQUIVALENT contents, postmortem invariant (4 cases incl. legacy event_type), defensive normalize, sentinel pattern (5 cases incl. mutual-exclusion + back-compat), `_extract_constraint_status_set` (3 PG normalization shapes), `_apply_status_check_constraint` (preflight abort, fast-path add, no-op when set matches, replace when set drifts).
- `tests/unit/test_mcp_server_journal.py` — 8 tests: success/error envelopes, invariant propagation as JSON err, journal-status enum exclusion of lifecycle states.
- `tests/unit/test_mcp_server_project_tasks_metadata_merge.py` — 24 tests: structured returns for all four `*_add` tools, `metadata_merge` atomic-attach, whitelist silent-wins on collision, optional `status` on exploration_add/update, content/description optional + whitespace rejection, schema verification.
- `tests/unit/test_mcp_server_telos_json_format.py` — 13 tests: JSON payload shape, literal `Z` timestamp regex, UUID rendering, `include_inactive` translation, `metadata_filter` pass-through, `_iso_default` units.

Total: 67 new tests + 681/681 unit suite passes.

## Release notes

> **Code rollback to a pre-Item-1.a build is unsafe** once any row in `telos_entries.status` holds a new lifecycle status (`proposed`, `in_review`, `approved`, `executing`). Validation in `db.add_entry`/`db.update_entry` will reject writes touching such rows with a cryptic `ValueError`. Recovery procedure (per spec Item 1.a Rollback): (1) `UPDATE telos_entries SET status='active' WHERE status IN ('proposed','in_review','approved','executing');` (loses lifecycle state but preserves rows); (2) `ALTER TABLE telos_entries DROP CONSTRAINT IF EXISTS telos_entries_status_check;`; (3) deploy the older build.

## Test plan

- [x] `uv run pytest tests/unit -q` — 681 passed
- [x] `uv run flake8 radbot tests` — clean
- [x] `uv run mypy radbot tests` — clean (376 source files)
- [x] `uv run black --check radbot tests` — clean
- [x] `uv run isort --check radbot tests` — clean
- [ ] CI quality-pipeline: lint + type-check + unit tests + e2e (with `run-e2e` label) + frontend build
- [ ] Smoke: `init_telos_schema()` runs idempotently on existing DB (CHECK preflight + GIN index migration)
- [ ] Smoke: MCP `journal_add({entry: \"x\", metadata: {type: \"postmortem\", processed_at: null}})` returns `{\"status\": \"success\", \"ref_code\": \"JR<N>\", ...}` and the postmortem invariant rejects the same call without `processed_at`

## Followup PRs (per implementation order)

- Item 1.b + 1.c — pure docs into `specs/agents.md`, `scout.md`, `SKILL.md`, `CLAUDE.md` (the skeleton state-machine note ships here; full transition table + actor pinning ships next).
- Item 3 — Scout instruction edits for postmortem processing (depends on this PR's `metadata_merge` + structured returns + JSON section query).
- Item 6 — remove `inject_telos_context` from beto.
- Item 2 — `/review-ex` skill (in `~/git/perrymanuk/claude-skills`).
- Item 4 — `/postmortem-ex` skill (depends on Item 3).
- Item 5 — followup conventions formalize once Items 3+4 land.