### PR TITLE
[council-loop] pin Telos exploration lifecycle state machine (Item 1.b + 1.c)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -333,7 +333,16 @@ gh pr view $PR_NUMBER --repo $GITHUB_REPO \
 gh pr merge $PR_NUMBER --repo $GITHUB_REPO --squash --delete-branch
 ```
 
-5. After merge, confirm the deploy fired:
+5. **Flip the linked EX status to `completed`** (single-ownership rule — `/ship` Phase 11 is the sole owner of `executing → completed`; `/postmortem-ex` MUST NOT mutate status). If the branch / PR title / PR body matches `(?i)EX(\d+)\b`, resolve that EX ref and call:
+
+```bash
+mcp__radbot__exploration_update({ref_code: "EX<N>", status: "completed"})
+# content omitted — pure status flip; body unchanged
+```
+
+   No EX link → skip silently (older PRs, hotfixes, anything not driven by an exploration). If multiple sources resolve to different EX numbers, surface the conflict and skip rather than guessing.
+
+6. After merge, confirm the deploy fired:
 
 ```bash
 sleep 10
@@ -342,7 +351,7 @@ gh run list --repo $GITHUB_REPO --workflow "Build and Push Docker Image" --branc
 
    Tell the user the run ID so they can watch it. If no run appears within ~30 s, the user should push an empty commit from their shell to force a fresh `push` event.
 
-6. If `auto-merge-eligible` is missing or `aggregate_conclusion` is not `SUCCESS`, tell the user why and stop — do not attempt the merge.
+7. If `auto-merge-eligible` is missing or `aggregate_conclusion` is not `SUCCESS`, tell the user why and stop — do not attempt the merge.
 
 The skill has NO authority to bypass branch protection or path-guard — it only orchestrates.
 
@@ -393,3 +402,4 @@ Skip 12b entirely on `--manual-merge` or if Phase 11 did not merge (score < thre
 - Bypass `path-guard` for sensitive paths.
 - Run visual regression locally (cost + complexity; CI handles it).
 - Modify spec files for the user (it asks).
+- Write the postmortem. Once /ship returns successfully on an EX-linked PR, suggest the user run `/postmortem-ex <PR#>` next to capture plan-vs-actual, generate followups, and link the journal entry back to the EX body.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,24 @@ FastAPI behind Traefik generates redirect URLs using the internal HTTP scheme un
 
 `ACTIVE_EQUIVALENT = frozenset({"active", "proposed", "in_review", "approved", "executing"})` is the default filter for `db.list_section()` (when called with no `status` / `status_in` kwarg) and for the MCP `telos_get_section({include_inactive: false})` path. Adding a new lifecycle state means: edit `STATUS_VALUES`, update `ACTIVE_EQUIVALENT` if appropriate, restart — the CHECK constraint migration regenerates automatically.
 
+**Transitions — every flip has exactly one owner:**
+
+| From → To | Actor | Trigger |
+|---|---|---|
+| (new) → `proposed` | Scout | `exploration_add(status="proposed")` when persisting a plan post-tier-1-council |
+| `proposed` → `in_review` | `/review-ex` skill | First step before `/mm-council:evaluate` fires |
+| `in_review` → `approved` | Claude Code session | After capturing the council synthesis, on user confirmation |
+| `in_review` → `in_review` (stays) | n/a | Council verdict `revise`/`reject` — EX stays in review until human edits and re-runs `/review-ex`. Does NOT roll back to `proposed` (would hide that review happened) |
+| `approved` → `executing` | `/ship` skill | Phase 1 (pre-flight) when the branch matches the EX-linkage convention |
+| `executing` → `completed` | `/ship` skill | Phase 11 immediately post-merge, before cleanup. **Sole owner of this transition** — `/postmortem-ex` MUST NOT mutate status |
+| `executing` → `approved` | Manual / `/ship --abort` | If the user kills `/ship` before merge — recovery path |
+| `completed` → `archived` | Manual (user via `mcp__radbot__exploration_update`) | When the EX is no longer a useful reference. `completed` is **terminal** otherwise — postmortem step does NOT auto-archive |
+| (any non-terminal) → `superseded` | Manual (user via `mcp__radbot__exploration_update`) | When a newer EX replaces this one before it ever shipped. Set `metadata.superseded_by: "EX<N>"` (string ref code, must point to an existing EX in the same `explorations` section — convention only, no DB-level FK). The new EX MAY symmetrically set `metadata.supersedes: "EX<N>"` pointing back; not required |
+
+**Concurrency invariant:** single user, single active session per EX. No CAS or advisory lock in v1; the invariant is preserved by Scout's user-driven postmortem-processing trigger plus dedup-by-`source_postmortem`.
+
+**Stuck-state recovery:** if an EX sits in `in_review` or `executing` for >24h, manually flip it back via `mcp__radbot__exploration_update({ref_code, status: "<target>"})` (omit `content` to leave the body unchanged).
+
 ### MCP write-tool return contract
 
 The four creation handlers (`task_add`, `exploration_add`, `milestone_add`, `journal_add`) and their `*_update` counterparts return JSON in `TextContent.text`:

--- a/radbot/config/default_configs/instructions/scout.md
+++ b/radbot/config/default_configs/instructions/scout.md
@@ -155,9 +155,14 @@ Once the plan is solid, persist it so Claude Code (or future you) can pick
 it up:
 
 - **Full plan text → exploration.** `telos_add_exploration(project=<ref>,
-  title=<plan title>, content=<full 5-role markdown>)`. Explorations are
-  where long-form proposals live. The `EX<N>` ref_code is how Claude Code
-  will locate it.
+  title=<plan title>, content=<full 5-role markdown>, status="proposed")`.
+  Explorations are where long-form proposals live. The `EX<N>` ref_code is
+  how Claude Code will locate it. **Pass `status="proposed"` explicitly**
+  on every new EX after the tier-1 council clears — that's the entry point
+  for the lifecycle state machine (see `specs/agents.md` § Scout / Telos
+  exploration lifecycle). `/review-ex` flips `proposed → in_review`,
+  `/ship` flips `approved → executing → completed`. Defaulting to `active`
+  hides the EX from the cross-family review loop.
 - **Actionable slice → project_tasks.** For each concrete step the
   executor should do, `telos_add_task(parent_project=<ref>,
   parent_milestone=<ref?>, title=<short imperative>, description=<what +

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -174,6 +174,26 @@ All critics currently run on scout's configured model (Gemini 3.1 Pro). Cross-fa
 
 **Note**: scout does **not** hand plans off to axel inside the agent tree. Axel's role is narrowed to quick-fix alert remediation (see axel section).
 
+### Scout / Telos exploration lifecycle (2026-05-03)
+
+`telos_entries.status` is the state machine for an exploration row from draft → council review → ship → postmortem. `STATUS_VALUES` (in `radbot/tools/telos/models.py`) is the single source of truth for the legal set; the DB CHECK constraint regenerates from it on every startup. See `CLAUDE.md` § Telos lifecycle status state machine for the status-set table.
+
+Every transition has exactly one owner — duplicating the table here so the agent spec stays self-contained:
+
+| From → To | Actor | Trigger |
+|---|---|---|
+| (new) → `proposed` | Scout | `exploration_add(status="proposed")` when persisting a plan post-tier-1-council |
+| `proposed` → `in_review` | `/review-ex` skill | First step before `/mm-council:evaluate` fires |
+| `in_review` → `approved` | Claude Code session | After capturing the council synthesis, on user confirmation |
+| `in_review` → `in_review` (stays) | n/a | Council verdict `revise`/`reject` — EX stays in review until human edits and re-runs `/review-ex`. Does NOT roll back to `proposed` (would hide that review happened) |
+| `approved` → `executing` | `/ship` skill | Phase 1 (pre-flight) when the branch matches the EX-linkage convention |
+| `executing` → `completed` | `/ship` skill | Phase 11 immediately post-merge, before cleanup. **Sole owner of this transition** — `/postmortem-ex` MUST NOT mutate status |
+| `executing` → `approved` | Manual / `/ship --abort` | If the user kills `/ship` before merge — recovery path |
+| `completed` → `archived` | Manual (user via `mcp__radbot__exploration_update`) | When the EX is no longer a useful reference. `completed` is **terminal** otherwise — postmortem step does NOT auto-archive |
+| (any non-terminal) → `superseded` | Manual (user via `mcp__radbot__exploration_update`) | When a newer EX replaces this one before it ever shipped. Set `metadata.superseded_by: "EX<N>"` (string ref code, must point to an existing EX in the same `explorations` section — convention only, no DB-level FK). The new EX MAY symmetrically set `metadata.supersedes: "EX<N>"` pointing back; not required |
+
+**Concurrency invariant.** Single user, single active session per EX. No CAS or advisory lock in v1; the invariant is honestly preserved by Scout's user-driven postmortem-processing trigger plus dedup-by-`source_postmortem` on followup creation. Stuck-state recovery: manually flip via `mcp__radbot__exploration_update({ref_code, status: "<target>"})` with `content` omitted.
+
 ## Session Roots (2026-04-19)
 
 Chat sessions can run with either **beto** or **scout** as the root agent. The choice is stored on `chat_sessions.agent_name` (immutable for a session's lifetime, because the ADK session-service partition is keyed by `app_name`) and selected via a UI toggle at create time.


### PR DESCRIPTION
## Summary

Resolves: Item 1.b + Item 1.c from `docs/plans/EX_DRAFT_council_loop_polish.md` (frozen 2026-05-03). Pure docs follow-up to PR #113 — no code changes.

Pins the From → To / Actor / Trigger transition table from spec Item 1.c verbatim into the four files the spec identifies, and encodes the single-ownership rule (`/ship` Phase 11 is the SOLE owner of `executing → completed`) plus the v1 concurrency invariant (single user, single active session per EX; no CAS/lock).

### What's in the diff

- **`CLAUDE.md`** — extends the existing "Telos lifecycle status state machine" subsection added by PR #113 with the transition table + concurrency invariant + stuck-state-recovery one-liner. `metadata.superseded_by: "EX<N>"` shape pin (string ref code, must point to an existing EX in the same `explorations` section — convention only, no DB-level FK; the new EX MAY symmetrically set `metadata.supersedes` pointing back).
- **`specs/agents.md`** — new "Scout / Telos exploration lifecycle (2026-05-03)" subsection under the Scout block, with the same transition table verbatim so the agent spec stays self-contained.
- **`radbot/config/default_configs/instructions/scout.md`** — tells Scout to pass `status="proposed"` explicitly on every new `telos_add_exploration` after the tier-1 council clears. Defaulting to `active` would hide the EX from the cross-family review loop.
- **`.claude/skills/ship/SKILL.md`** — Phase 11 step 5 flips the linked EX to `completed` via `mcp__radbot__exploration_update({ref_code, status: "completed"})` post-merge (resolved via `(?i)EX(\d+)\b` against branch / PR title / PR body; conflict → skip). End-of-skill pointer suggests `/postmortem-ex <PR#>` as the next step.

## Specs updated

- `specs/agents.md` — new "Scout / Telos exploration lifecycle" subsection (covers the `radbot/config/default_configs/instructions/scout.md` change too).
- `CLAUDE.md` — Telos lifecycle subsection extended with the transition table + concurrency invariant per the Spec Maintenance rule.

No other specs needed — this PR is pure documentation; nothing in `radbot/tools/**`, `radbot/web/**`, SQL schema, or `radbot/agent/**` source code changed.

## Dependency

Depends on **#113** (already merged, commit `f0e6e37`) for the `STATUS_VALUES` extension (`proposed`/`in_review`/`approved`/`executing`) and the structured-return contract on the MCP write surface that this docs PR references. PR #113's CLAUDE.md added the lifecycle subsection that this PR extends.

## Quality pipeline

The diff is docs-only (paths: `CLAUDE.md`, `specs/**`, `radbot/config/default_configs/instructions/**`, `.claude/skills/**`). The `quality-pipeline.yml` `paths:` filter excludes all four — the workflow will not trigger and there will be no automated quality signal. Per `/ship` Phase 8, this PR routes to manual user merge.

## Verification

- [x] Diff is scoped to the four files identified by spec Item 1.b
- [x] Transition table copied verbatim from spec Item 1.c (CLAUDE.md + specs/agents.md)
- [x] Single-ownership rule encoded (`/ship` Phase 11 is the sole owner of `executing → completed`; `/postmortem-ex` MUST NOT mutate status)
- [x] Concurrency invariant + stuck-state recovery one-liners present
- [x] `metadata.superseded_by` shape pin present
- [x] Scout instruction passes `status="proposed"` explicitly
- [ ] Manual user merge (path-filter excludes — no auto-merge)

## Next in implementation order

**Item 3** — Scout instruction edits for postmortem processing. Depends on this PR's documented state machine (Scout's "Postmortem processing" section needs to reference the lifecycle states + the `## Followups` markdown contract that `/postmortem-ex` writes).