### PR TITLE
[kidsvid-kideo-flow] unbreak picker remount + broaden beto routing + stop _map_status lying

### DIFF
--- a/radbot/config/default_configs/instructions/main_agent.md
+++ b/radbot/config/default_configs/instructions/main_agent.md
@@ -86,10 +86,23 @@ To delegate work, call `transfer_to_agent(agent_name="<name>")` — for example 
 - "Check the Nomad jobs" → call axel
 - "Restart the failing service" → call axel
 - "What's the status of my infrastructure?" → call axel
-- "Find dinosaur videos for Leon" → call kidsvid
+- "Find dinosaur videos for `<child_name>`" → call kidsvid
 - "Search YouTube for learning videos for kids" → call kidsvid
 - "Find something educational for the kids to watch" → call kidsvid
 - "Add those videos to Kideo" → call kidsvid
+- **Contextual kidsvid follow-ups** — when the prior assistant turn in the
+  transcript begins with `[kidsvid] said:` or contains `[kidsvid] called tool`,
+  ANY user message containing add/queue/save/download/put + those/these/them/the
+  videos (with or without the literal word "Kideo") MUST route via
+  `transfer_to_agent(agent_name="kidsvid")`. You do NOT have Kideo tools and
+  cannot legitimately answer these on your own. Examples of follow-ups that
+  must route to kidsvid:
+  - "Can you add those for `<child_name>`?"
+  - "Yeah, queue them all up"
+  - "Save those last two"
+  - "Add the ones you just found"
+  Counter-example: if the prior turn was a different agent (e.g. `[planner] said:`
+  or `[casa] said:`), do NOT assume kidsvid context.
 - "Search the web for Python releases" → use search_agent via transfer_to_agent
 - "Google the latest news" → use search_agent via transfer_to_agent
 - "Hey dude, what's up?" → respond directly as Beto

--- a/radbot/web/api/videos.py
+++ b/radbot/web/api/videos.py
@@ -24,7 +24,12 @@ router = APIRouter(prefix="/api/videos", tags=["videos"])
 
 
 # ── Status mapping ───────────────────────────────────────────────────────
-# Kideo's per-video status strings → the four UI states VideoCard renders.
+# Kideo's per-video status strings → the UI states VideoCard renders.
+# Default for unmapped values is "unknown" — explicitly NOT "in_library",
+# which would silently mask actual upstream failures or pre-completion states
+# as a successful library entry.
+DEFAULT_UNKNOWN_STATUS = "unknown"
+
 _KIDEO_STATUS_MAP = {
     "ready": "in_library",
     "available": "in_library",
@@ -35,11 +40,19 @@ _KIDEO_STATUS_MAP = {
     "transcoding": "processing",
     "error": "error",
     "failed": "error",
+    "rejected": "error",
+    "cancelled": "error",
+    "expired": "error",
 }
 
 
-def _map_status(raw: Optional[str]) -> str:
-    return _KIDEO_STATUS_MAP.get((raw or "").lower(), "in_library")
+def _map_status(raw: Optional[str], default: str = DEFAULT_UNKNOWN_STATUS) -> str:
+    key = (raw or "").lower()
+    if key in _KIDEO_STATUS_MAP:
+        return _KIDEO_STATUS_MAP[key]
+    if raw:
+        logger.warning("Unmapped Kideo status %r; falling back to %r", raw, default)
+    return default
 
 
 # ── Routes ───────────────────────────────────────────────────────────────
@@ -69,10 +82,12 @@ async def get_kideo_status(url: str = Query(..., min_length=1)) -> Dict[str, Any
         logger.error("Kideo find_video_by_url failed: %s", e)
         raise HTTPException(502, f"Kideo unreachable: {e}")
     if not match:
-        return {"status": "not_added", "kideo_video_id": None}
+        return {"status": "not_added", "kideo_video_id": None, "raw_status": None}
+    raw_status = match.get("status")
     return {
-        "status": _map_status(match.get("status")),
+        "status": _map_status(raw_status),
         "kideo_video_id": match.get("id"),
+        "raw_status": raw_status,
     }
 
 
@@ -140,12 +155,19 @@ async def add_to_kideo(body: AddToKideoBody) -> Dict[str, Any]:
     if body.generate_tags and kideo_video_id:
         tags = _maybe_generate_tags(body.url, kideo_video_id)
 
+    raw_status = result.get("status")
+    # On a fresh add, treat missing/unknown status as "queued" rather than
+    # "unknown" — Kideo accepted the POST and the typical pipeline is
+    # accept → queue → download → transcode → ready, so a silent provider
+    # response almost always means queued. Known terminal failures still
+    # map via _KIDEO_STATUS_MAP.
     return {
-        "status": _map_status(result.get("status")),
+        "status": _map_status(raw_status, default="queued"),
         "kideo_video_id": kideo_video_id,
         "title": result.get("title"),
         "collection_id": body.collection_id,
         "tags": tags,
+        "raw_status": raw_status,
     }
 
 

--- a/radbot/web/frontend/src/components/chat/AgentCards.tsx
+++ b/radbot/web/frontend/src/components/chat/AgentCards.tsx
@@ -756,7 +756,8 @@ export type VideoStatus =
   | "queued"
   | "processing"
   | "error"
-  | "not_added";
+  | "not_added"
+  | "unknown";
 
 export interface VideoCardData {
   title: string;
@@ -827,6 +828,10 @@ function VideoStatusPill({ status }: { status: VideoStatus }) {
     },
     not_added: {
       label: "NOT IN KIDEO",
+      color: "text-txt-secondary border-border bg-bg-tertiary",
+    },
+    unknown: {
+      label: "STATUS UNKNOWN",
       color: "text-txt-secondary border-border bg-bg-tertiary",
     },
   };

--- a/radbot/web/frontend/src/components/chat/ChatMessage.tsx
+++ b/radbot/web/frontend/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Message } from "@/types";
 import { cn } from "@/lib/utils";
@@ -21,6 +22,105 @@ import InboxSummary, {
 } from "@/components/chat/InboxSummary";
 import { agentFor, type AgentIdentity } from "@/components/chat/agent-registry";
 import { useAppStore } from "@/stores/app-store";
+
+// MUST stay at module scope. ReactMarkdown remounts the entire markdown
+// subtree whenever `components` is a new reference, which destroys local
+// useState in any rendered card (e.g. VideoCard's collection picker).
+// All renderers below must remain pure functions of their args — no
+// closure over component-scope props or state.
+const MARKDOWN_COMPONENTS: Components = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  code: ({ className, children, ...props }) => {
+    const isBlock = className?.includes("language-");
+    if (isBlock) {
+      const codeText = String(children).replace(/\n$/, "");
+
+      // Agent-card render protocol: ```radbot:<kind>\n{json}\n```
+      const radbotKind = className?.match(/language-radbot:(\S+)/)?.[1];
+      if (radbotKind) {
+        try {
+          const data = JSON.parse(codeText);
+          switch (radbotKind) {
+            case "media":
+              return <MediaCard m={data as MediaCardData} />;
+            case "seasons":
+              return <SeasonBreakdownCard data={data as SeasonBreakdownData} />;
+            case "ha-device":
+              return <HaDeviceCard d={data as HaDevice} />;
+            case "video":
+              return <VideoCard v={data as VideoCardData} />;
+            case "handoff":
+              return <HandoffLine handoff={data as HandoffInfo} />;
+            case "inbox":
+              return <InboxSummary s={data as InboxSummaryData} />;
+            default:
+              // fall through to default code rendering
+          }
+        } catch {
+          // Invalid JSON — fall through to show raw block.
+        }
+      }
+
+      return (
+        <pre className="bg-black/70 p-3 my-3 border border-border overflow-x-auto relative group/code">
+          <span className="absolute top-0 right-0 text-terminal-amber text-[0.7rem] bg-black/70 px-1.5 py-0.5 tracking-wider">
+            {className?.replace("language-", "").toUpperCase() ?? "OUTPUT"}
+          </span>
+          <CopyButton text={codeText} />
+          <code
+            className={cn(
+              "bg-transparent p-0 border-none text-txt-primary text-[0.85rem] block leading-relaxed",
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </code>
+        </pre>
+      );
+    }
+    return (
+      <code
+        className="font-mono bg-black/30 px-1 py-0.5 text-[0.85em] text-accent-blue border-l border-accent-blue"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => <>{children}</>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-accent-blue underline hover:text-accent-blue/80 focus:outline-none focus:ring-1 focus:ring-accent-blue"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => <ul className="list-disc list-inside ml-3 my-2 space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="list-decimal list-inside ml-3 my-2 space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-accent-blue pl-3 my-2 text-txt-secondary italic">
+      {children}
+    </blockquote>
+  ),
+  h1: ({ children }) => <span className="text-lg font-bold text-accent-blue block mt-3 mb-1.5">{children}</span>,
+  h2: ({ children }) => <span className="text-base font-bold text-accent-blue block mt-3 mb-1.5">{children}</span>,
+  h3: ({ children }) => <span className="text-sm font-bold text-accent-blue block mt-2 mb-1">{children}</span>,
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-2">
+      <table className="border-collapse border border-border text-sm w-full">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border border-border bg-bg-tertiary px-2 py-1.5 text-left text-accent-blue">{children}</th>
+  ),
+  td: ({ children }) => <td className="border border-border px-2 py-1.5">{children}</td>,
+  strong: ({ children }) => <strong className="font-bold text-terminal-amber">{children}</strong>,
+};
 
 interface Props {
   message: Message;
@@ -238,102 +338,7 @@ export default function ChatMessage({ message }: Props) {
       <div className="font-sans text-txt-primary text-[0.8125rem] sm:text-[0.875rem] leading-[1.55] [overflow-wrap:anywhere]">
         {thoughts && <ThoughtCard text={thoughts} />}
         <CollapsibleContent lineCount={lineCount}>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-              code: ({ className, children, ...props }) => {
-                const isBlock = className?.includes("language-");
-                if (isBlock) {
-                  const codeText = String(children).replace(/\n$/, "");
-
-                  // Agent-card render protocol: ```radbot:<kind>\n{json}\n```
-                  const radbotKind = className?.match(/language-radbot:(\S+)/)?.[1];
-                  if (radbotKind) {
-                    try {
-                      const data = JSON.parse(codeText);
-                      switch (radbotKind) {
-                        case "media":
-                          return <MediaCard m={data as MediaCardData} />;
-                        case "seasons":
-                          return <SeasonBreakdownCard data={data as SeasonBreakdownData} />;
-                        case "ha-device":
-                          return <HaDeviceCard d={data as HaDevice} />;
-                        case "video":
-                          return <VideoCard v={data as VideoCardData} />;
-                        case "handoff":
-                          return <HandoffLine handoff={data as HandoffInfo} />;
-                        case "inbox":
-                          return <InboxSummary s={data as InboxSummaryData} />;
-                        default:
-                          // fall through to default code rendering
-                      }
-                    } catch {
-                      // Invalid JSON — fall through to show raw block.
-                    }
-                  }
-
-                  return (
-                    <pre className="bg-black/70 p-3 my-3 border border-border overflow-x-auto relative group/code">
-                      <span className="absolute top-0 right-0 text-terminal-amber text-[0.7rem] bg-black/70 px-1.5 py-0.5 tracking-wider">
-                        {className?.replace("language-", "").toUpperCase() ?? "OUTPUT"}
-                      </span>
-                      <CopyButton text={codeText} />
-                      <code
-                        className={cn(
-                          "bg-transparent p-0 border-none text-txt-primary text-[0.85rem] block leading-relaxed",
-                          className,
-                        )}
-                        {...props}
-                      >
-                        {children}
-                      </code>
-                    </pre>
-                  );
-                }
-                return (
-                  <code
-                    className="font-mono bg-black/30 px-1 py-0.5 text-[0.85em] text-accent-blue border-l border-accent-blue"
-                    {...props}
-                  >
-                    {children}
-                  </code>
-                );
-              },
-              pre: ({ children }) => <>{children}</>,
-              a: ({ href, children }) => (
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-accent-blue underline hover:text-accent-blue/80 focus:outline-none focus:ring-1 focus:ring-accent-blue"
-                >
-                  {children}
-                </a>
-              ),
-              ul: ({ children }) => <ul className="list-disc list-inside ml-3 my-2 space-y-1">{children}</ul>,
-              ol: ({ children }) => <ol className="list-decimal list-inside ml-3 my-2 space-y-1">{children}</ol>,
-              li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-              blockquote: ({ children }) => (
-                <blockquote className="border-l-2 border-accent-blue pl-3 my-2 text-txt-secondary italic">
-                  {children}
-                </blockquote>
-              ),
-              h1: ({ children }) => <span className="text-lg font-bold text-accent-blue block mt-3 mb-1.5">{children}</span>,
-              h2: ({ children }) => <span className="text-base font-bold text-accent-blue block mt-3 mb-1.5">{children}</span>,
-              h3: ({ children }) => <span className="text-sm font-bold text-accent-blue block mt-2 mb-1">{children}</span>,
-              table: ({ children }) => (
-                <div className="overflow-x-auto my-2">
-                  <table className="border-collapse border border-border text-sm w-full">{children}</table>
-                </div>
-              ),
-              th: ({ children }) => (
-                <th className="border border-border bg-bg-tertiary px-2 py-1.5 text-left text-accent-blue">{children}</th>
-              ),
-              td: ({ children }) => <td className="border border-border px-2 py-1.5">{children}</td>,
-              strong: ({ children }) => <strong className="font-bold text-terminal-amber">{children}</strong>,
-            }}
-          >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>
             {bodyContent}
           </ReactMarkdown>
         </CollapsibleContent>

--- a/specs/web.md
+++ b/specs/web.md
@@ -151,8 +151,8 @@ Powers the ADD TO KIDEO button + library-status pill on kidsvid's `<VideoCard />
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/api/videos/collections` | Kideo collections for the picker dropdown |
-| `GET` | `/api/videos/kideo-status?url=X` | Library status for a video URL (`in_library` / `queued` / `processing` / `not_added`) |
-| `POST` | `/api/videos/add-to-kideo` | `{url, collection_id?, generate_tags?}` — adds + (best-effort) AI-tags YouTube videos |
+| `GET` | `/api/videos/kideo-status?url=X` | Library status for a video URL (`in_library` / `queued` / `processing` / `error` / `not_added` / `unknown`). Response also echoes `raw_status` from Kideo so future drift is visible. Unmapped raw values fall through to `unknown` (NOT `in_library`) and log a WARNING. |
+| `POST` | `/api/videos/add-to-kideo` | `{url, collection_id?, generate_tags?}` — adds + (best-effort) AI-tags YouTube videos. Response echoes `raw_status`; missing/unmapped raw status defaults to `queued` on this path (a successful POST means Kideo accepted the add) while still logging a WARNING for unmapped values. |
 
 ## Per-Session Token Stats (2026-04-18)
 

--- a/tests/unit/test_videos_status_mapping.py
+++ b/tests/unit/test_videos_status_mapping.py
@@ -1,0 +1,80 @@
+"""Tests for the Kideo status mapping in radbot.web.api.videos."""
+
+import logging
+
+import pytest
+
+from radbot.web.api.videos import (
+    _KIDEO_STATUS_MAP,
+    DEFAULT_UNKNOWN_STATUS,
+    _map_status,
+)
+
+
+class TestMapStatus:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("ready", "in_library"),
+            ("available", "in_library"),
+            ("downloaded", "in_library"),
+            ("queued", "queued"),
+            ("pending", "queued"),
+            ("downloading", "processing"),
+            ("transcoding", "processing"),
+            ("error", "error"),
+            ("failed", "error"),
+            ("rejected", "error"),
+            ("cancelled", "error"),
+            ("expired", "error"),
+        ],
+    )
+    def test_known_status_maps_correctly(self, raw, expected):
+        assert _map_status(raw) == expected
+
+    def test_uppercase_status_normalized(self):
+        assert _map_status("QUEUED") == "queued"
+        assert _map_status("Failed") == "error"
+
+    def test_unknown_status_falls_back_to_default(self):
+        assert _map_status("weird-new-state") == DEFAULT_UNKNOWN_STATUS
+
+    def test_unknown_status_respects_explicit_default(self):
+        assert _map_status("weird-new-state", default="queued") == "queued"
+
+    def test_none_status_returns_default(self):
+        assert _map_status(None) == DEFAULT_UNKNOWN_STATUS
+
+    def test_empty_status_returns_default(self):
+        assert _map_status("") == DEFAULT_UNKNOWN_STATUS
+
+    def test_explicit_default_used_for_none(self):
+        assert _map_status(None, default="queued") == "queued"
+
+    def test_unmapped_status_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="radbot.web.api.videos"):
+            _map_status("weird-new-state")
+        assert any(
+            "Unmapped Kideo status" in r.message and "weird-new-state" in r.message
+            for r in caplog.records
+        )
+
+    def test_known_status_does_not_log_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="radbot.web.api.videos"):
+            _map_status("queued")
+        assert not [r for r in caplog.records if "Unmapped Kideo status" in r.message]
+
+    def test_none_does_not_log_warning(self, caplog):
+        # A missing status from the provider isn't worth a WARNING for every poll.
+        with caplog.at_level(logging.WARNING, logger="radbot.web.api.videos"):
+            _map_status(None)
+        assert not [r for r in caplog.records if "Unmapped Kideo status" in r.message]
+
+    def test_default_unknown_status_is_unknown(self):
+        # Guard against silent regression to "in_library" — the bug we're fixing.
+        assert DEFAULT_UNKNOWN_STATUS == "unknown"
+
+    def test_terminal_failure_states_are_mapped_explicitly(self):
+        # All these should map to "error", not silently fall through to default.
+        for failure_state in ("rejected", "cancelled", "expired", "failed", "error"):
+            assert _KIDEO_STATUS_MAP.get(failure_state) == "error"


### PR DESCRIPTION
## Summary

Three related bugs in the kidsvid → Kideo flow:

- **Bug B (primary):** ADD TO KIDEO collection picker dismounts after ~500 ms because `ChatMessage.tsx` passed an inline-literal `components` prop to `<ReactMarkdown>` — every parent render gave it a fresh reference, ReactMarkdown unmounted/remounted the whole markdown subtree, and `<VideoActions>` lost its `useState`. Hoisted to a module-scope `MARKDOWN_COMPONENTS` constant.
- **Bug A:** beto answered "can you add those for leon?" directly with "I don't recall fetching any videos" instead of routing to kidsvid. Verified via `google/adk-python` source (`flows/llm_flows/contents.py:606-671`) that beto's LLM context contains kidsvid's prior tool calls + responses, rewritten as `role='user'` text with `[kidsvid]` author prefixes. New routing rule keys off that concrete signal. Uses `<child_name>` placeholder instead of hard-coding "leon".
- **Bug C (drive-by):** `_map_status` defaulted unmapped raw values to `"in_library"` — a successful add with an unrecognized status would silently lie to the UI. Replaced with `DEFAULT_UNKNOWN_STATUS = "unknown"` + an explicit `default=` parameter (`add_to_kideo` opts into `"queued"`). Added `rejected`/`cancelled`/`expired` to the explicit error-state map. Both endpoints now echo `raw_status` so future Kideo drift surfaces without a code change.

Plan was reviewed by a 3-model council (`/mm-council:evaluate`); council verdict was `revise` on the prior draft. The four blockers it raised drove this revision (module-scope > useMemo, `DEFAULT_UNKNOWN_STATUS` over silent fallback, routing grounded in `[kidsvid]` prefix, PII placeholder).

## Specs updated

- `specs/web.md` — added new status values + `raw_status` response field for `/api/videos/kideo-status` and `/api/videos/add-to-kideo`.
- `specs/agents.md` — no change needed; routing structure unchanged, only an additional rule appended to the existing main_agent.md routing example list.

## Quality pipeline

Score: _pending_ — awaiting workflow run.

## Verification

- [x] `make lint` (flake8 + mypy + black + isort) — green
- [x] `make test-unit` (707 tests, including 23 new in `tests/unit/test_videos_status_mapping.py`) — green
- [x] Frontend `tsc --noEmit` + `vite build` — green
- [ ] Playwright local — skipped, needs running radbot stack (CI's bootstrap-radbot-stack composite action handles this)
- [ ] Quality pipeline (CI)
- [ ] Auto-merge at score ≥ 90 (user pre-authorized merge at score = 100)